### PR TITLE
[codex] Organize CLI surface and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Visual Regression Testing toolkit — pixel diff, computed style diff, a11y tree diff, and AI-powered CSS fix generation.
 
+The public surface is organized into three layers:
+
+- `vrt <command>` for one-shot analysis and comparison commands
+- `vrt workflow <command>` for baseline/snapshot verification loops
+- `vrt api <command>` for serving and probing the HTTP API
+
 ## Features
 
 - **Pixel diff** — pixelmatch v7 + heatmap generation
@@ -16,10 +22,12 @@ Visual Regression Testing toolkit — pixel diff, computed style diff, a11y tree
 
 ## Quick Start
 
+The examples below assume the `vrt` command is already installed and available on your PATH.
+
 ```bash
 pnpm install
 
-# Run tests (341 tests)
+# Run tests
 pnpm test
 
 # Compare two HTML files
@@ -31,6 +39,11 @@ vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/
 # Snapshot URLs (creates baseline on first run, diffs on subsequent runs)
 vrt snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
 
+# Workflow verification loop
+vrt workflow init
+vrt workflow capture
+vrt workflow verify
+
 # Mask dynamic content
 vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
 
@@ -41,17 +54,89 @@ just css-bench --fixture page --trials 30
 just fix-loop --fixture page --seed 42
 ```
 
-## CLI
+## CLI Surface
+
+### Core Commands
 
 ```bash
-vrt compare <before.html> <after.html>     # Migration VRT (file or URL)
-vrt snapshot <url1> [url2] ...             # Multi-viewport snapshot + diff
+vrt compare <before.html> <after.html>      # Migration VRT for files or URLs
+vrt snapshot <url1> [url2] ...              # Multi-viewport snapshot + diff
+vrt elements [options]                      # Element-level diff with shift isolation
+vrt smoke <file-or-url>                     # A11y-driven random interaction test
+vrt discover <html-file>                    # Breakpoint discovery from HTML/CSS
 vrt bench [options]                         # CSS challenge benchmark
-vrt report                                 # Detection pattern report
-vrt smoke <file-or-url>                    # A11y-driven random interaction test
-vrt serve [--port 3456]                    # API server
-vrt status [--url http://localhost:3456]   # Server health check
+vrt report                                  # Detection pattern report
 ```
+
+### Workflow Commands
+
+These commands manage state under `baselines/`, `snapshots/`, `output/`, `vrt-report.json`, `expectation.json`, and `spec.json`.
+
+Before running them, start the target app and point `VRT_BASE_URL` at it when needed.
+The built-in capture workflow defaults to `http://127.0.0.1:4174`.
+
+```bash
+vrt workflow init
+vrt workflow capture
+vrt workflow verify
+vrt workflow approve
+vrt workflow report
+vrt workflow graph
+vrt workflow affected
+vrt workflow introspect
+vrt workflow spec-verify
+vrt workflow expect
+```
+
+Workflow aliases are kept for ergonomics where they do not collide:
+
+- `vrt init`, `vrt capture`, `vrt verify`, `vrt approve`
+- `vrt graph`, `vrt affected`, `vrt introspect`, `vrt spec-verify`, `vrt expect`
+
+`vrt report` remains the detection pattern report, so verification output lives under `vrt workflow report`.
+
+### API Commands
+
+```bash
+vrt api serve [--port 3456]                # Start HTTP API server
+vrt api status [--url http://localhost:3456]
+```
+
+Compatibility aliases:
+
+- `vrt serve` -> `vrt api serve`
+- `vrt status` -> `vrt api status`
+
+## HTTP API
+
+Start the server:
+
+```bash
+vrt api serve --port 3456
+```
+
+Available endpoints:
+
+- `GET /api/status` — server version, backends, and capabilities
+- `POST /api/compare` — compare baseline/current HTML or URLs across viewports
+- `POST /api/compare-renderers` — compare Chromium vs Crater rendering
+- `POST /api/reason` — VLM/LLM reasoning pipeline for diff analysis and fixes
+- `POST /api/smoke-test` — random or reasoning-guided a11y smoke test
+
+TypeScript client:
+
+```ts
+import { VrtClient } from "./src/vrt-client.ts";
+
+const client = new VrtClient("http://localhost:3456");
+const status = await client.status();
+const result = await client.compareHtml(
+  "<main><button>Before</button></main>",
+  "<main><button class='primary'>After</button></main>",
+);
+```
+
+`compareUrls(...)` is intended for public HTTP(S) targets. The API server rejects localhost and private-network URLs.
 
 ## Architecture
 
@@ -90,7 +175,10 @@ HTML (file or URL)
 
 ```
 src/
-  vrt.ts                    # CLI entry point
+  vrt.ts                    # Unified public CLI entry point
+  vrt-command-router.ts     # Root command routing + usage text
+  vrt-cli.ts                # Stateful workflow CLI
+  vrt-client.ts             # TypeScript client for the HTTP API
   snapshot.ts               # URL snapshot + baseline diff
   migration-compare.ts      # HTML/URL comparison across viewports
   css-challenge-bench.ts    # CSS deletion/recovery benchmark

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vrt",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/src/a11y-semantic.ts
+++ b/src/a11y-semantic.ts
@@ -1,7 +1,6 @@
 import type {
   A11yNode,
   A11yChange,
-  A11yChangeType,
   A11yDiff,
   A11ySnapshot,
 } from "./types.ts";

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -10,10 +10,9 @@
 import crypto from "node:crypto";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { readFile } from "node:fs/promises";
 import type {
-  CompareRequest, CompareResponse, CompareOptions,
-  SmokeTestRequest, SmokeTestResponse,
+  CompareRequest, CompareResponse,
+  SmokeTestRequest,
   StatusResponse,
   ViewportResult, PixelDiffResult,
   HtmlSource,
@@ -24,7 +23,7 @@ import { isCraterAvailable, CraterClient } from "./crater-client.ts";
 // ---- Config ----
 
 const args = process.argv.slice(2);
-const PORT = parseInt(args.find((a, i) => args[i - 1] === "--port") ?? "3456", 10);
+const PORT = parseInt(args.find((_a, i) => args[i - 1] === "--port") ?? "3456", 10);
 
 // ---- App ----
 
@@ -46,7 +45,7 @@ app.use("*", async (c, next) => {
 app.get("/api/status", async (c) => {
   const craterAvailable = await isCraterAvailable();
   const status: StatusResponse = {
-    version: "0.2.0",
+    version: "0.3.0",
     capabilities: ["compare", "compare-renderers", "smoke-test", "reason", "report"],
     backends: [
       { name: "chromium", available: true },
@@ -208,8 +207,6 @@ app.post("/api/compare-renderers", async (c) => {
   const { discoverViewports } = await import("./viewport-discovery.ts");
   const { mkdir, rm } = await import("node:fs/promises");
   const { join } = await import("node:path");
-  const { PNG } = await import("pngjs");
-
   const tmpDir = join(process.cwd(), "test-results", "api", `renderers-${Date.now()}`);
   await mkdir(tmpDir, { recursive: true });
 
@@ -251,7 +248,6 @@ app.post("/api/compare-renderers", async (c) => {
       // Paint tree for detailed diff
       let paintTreeChanges = 0;
       try {
-        const { diffPaintTrees } = await import("./crater-client.ts");
         // Capture paint tree for both renders
         // (crater only — chromium doesn't have paint tree)
         paintTreeChanges = 0; // placeholder — would need baseline vs current

--- a/src/bench-pixelmatch.ts
+++ b/src/bench-pixelmatch.ts
@@ -6,8 +6,7 @@
  * 同一の画像データで比較する。
  */
 import { performance } from "node:perf_hooks";
-import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { DIM, RESET, GREEN, YELLOW, CYAN, BOLD } from "./terminal-colors.ts";
 
@@ -105,7 +104,7 @@ async function main() {
       // 同等サイズのベンチ結果を moon bench から取得済みのデータで比較する
       console.log(`  ${DIM}MoonBit JS: using moon bench data (100x100 = 1.18ms)${RESET}`);
       // 100x100 → 1.18ms = 10,000px → extrapolate
-      for (const { w, h, label } of sizes) {
+  for (const { w, h, label } of sizes) {
         const pixels = w * h;
         const ratio = pixels / 10000;
         const estMs = 1.18 * ratio;
@@ -147,7 +146,7 @@ async function main() {
   console.log(`  ${"Implementation".padEnd(25)} ${"Size".padEnd(12)} ${"avg".padStart(10)} ${"ops/s".padStart(8)} ${DIM}diff${RESET}`);
   console.log(`  ${"─".repeat(25)} ${"─".repeat(12)} ${"─".repeat(10)} ${"─".repeat(8)}`);
 
-  for (const { w, h, label } of sizes) {
+  for (const { label } of sizes) {
     const group = results.filter((r) => r.size === label);
     for (const r of group) {
       const avgStr = r.avgMs < 1 ? `${(r.avgMs * 1000).toFixed(0)}µs` : `${r.avgMs.toFixed(1)}ms`;

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -10,7 +10,7 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { PNG } from "pngjs";
-import { DIM, RESET, GREEN, CYAN, BOLD } from "./terminal-colors.ts";
+import { DIM, RESET, CYAN, BOLD } from "./terminal-colors.ts";
 import type { DetectionRecord } from "./detection-db.ts";
 
 const TMP = join(import.meta.dirname!, "..", "test-results", "benchmark");
@@ -230,7 +230,6 @@ async function main() {
   // ---- Property classify ----
   {
     const { categorizeProperty } = await import("./css-challenge-core.ts");
-    const { classifySelectorType } = await import("./detection-classify.ts");
 
     const r = await bench("categorizeProperty x100", () => {
       for (const p of ["display", "padding", "width", "color", "font-size", "animation", "transform",
@@ -335,7 +334,7 @@ async function main() {
   // ---- Full migration-compare pipeline (no browser) ----
   {
     const { extractBreakpoints } = await import("./viewport-discovery.ts");
-    const { parseCssDeclarations, extractCss, diffComputedStyles } = await import("./css-challenge-core.ts");
+    const { parseCssDeclarations, extractCss } = await import("./css-challenge-core.ts");
     const html1 = await readFile(join(import.meta.dirname!, "..", "fixtures", "css-challenge", "page.html"), "utf-8");
     const html2 = await readFile(join(import.meta.dirname!, "..", "fixtures", "css-challenge", "dashboard.html"), "utf-8");
 

--- a/src/crater-client.ts
+++ b/src/crater-client.ts
@@ -114,7 +114,7 @@ export class CraterClient {
     if (this.contextId) {
       try {
         await this.sendBidi("browsingContext.close", { context: this.contextId });
-      } catch { /* best-effort */ }
+      } catch (e) { console.warn("[crater] close context failed:", e instanceof Error ? e.message : e); }
     }
     this.contextId = null;
     this.ws?.close();
@@ -288,14 +288,19 @@ export class CraterClient {
   }
 
   private handleMessage(data: string): void {
+    let msg: BidiResponse;
     try {
-      const msg = JSON.parse(data) as BidiResponse;
-      const pending = this.pendingCommands.get(msg.id);
-      if (pending) {
-        this.pendingCommands.delete(msg.id);
-        pending.resolve(msg);
-      }
-    } catch { /* ignore parse errors */ }
+      msg = JSON.parse(data) as BidiResponse;
+    } catch {
+      console.warn("[crater] invalid JSON from BiDi:", data.slice(0, 200));
+      return;
+    }
+    if (typeof msg.id !== "number") return;
+    const pending = this.pendingCommands.get(msg.id);
+    if (pending) {
+      this.pendingCommands.delete(msg.id);
+      pending.resolve(msg);
+    }
   }
 
   private sendBidi(method: string, params: Record<string, unknown>, timeoutMs = 10_000): Promise<BidiResponse> {

--- a/src/css-challenge-bench.ts
+++ b/src/css-challenge-bench.ts
@@ -67,7 +67,7 @@ import {
   type PrescannerTrialResolution,
 } from "./prescanner.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "./terminal-colors.ts";
-import { args, getArg, getArgValues, hasFlag } from "./cli-args.ts";
+import { args } from "./cli-args.ts";
 
 // ---- Config ----
 
@@ -619,12 +619,12 @@ async function runFixtureBenchmark(fixture: string) {
     await rm(trialDir, { recursive: true, force: true }).catch(() => {});
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- TS narrows to never but craterClient may be set at runtime
-  if ((craterClient as CraterClient | null) != null) {
-    await (craterClient as unknown as CraterClient).close();
+  // Cleanup resources
+  if (craterClient != null) {
+    await (craterClient as CraterClient).close();
   }
-  if ((browser as Browser | null) != null) {
-    await (browser as unknown as Browser).close();
+  if (browser != null) {
+    await (browser as Browser).close();
   }
   const elapsedMs = Date.now() - startTime;
   const elapsed = (elapsedMs / 1000).toFixed(1);
@@ -673,7 +673,6 @@ async function runFixtureBenchmark(fixture: string) {
   // Scoped rate (excluding animation)
   const scoped = dbRecords.filter((r) => !isOutOfScope(r.property));
   const scopedDetected = scoped.filter((r) => r.detected).length;
-  const scopedUndetected = scoped.filter((r) => !r.detected).length;
   if (scoped.length < dbRecords.length) {
     const outOfScope = dbRecords.length - scoped.length;
     console.log(`    ${DIM}(excl. animation: ${fmtRate(scopedDetected, scoped.length)} | ${outOfScope} animation skipped)${RESET}`);

--- a/src/css-challenge-core.ts
+++ b/src/css-challenge-core.ts
@@ -4,7 +4,7 @@
  *
  * Shared foundation for css-challenge.ts and css-challenge-bench.ts
  */
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Browser, Page } from "playwright";
 import { chromium } from "playwright";
@@ -30,9 +30,7 @@ import {
   buildInteractionTargetPlans,
   captureEmulatedInteractionStyleSnapshotInDom,
   captureComputedStyleSnapshotForTargetSelectorsInDom,
-  buildComputedStyleCaptureExpression,
   buildComputedStyleCaptureJsonExpression,
-  captureComputedStyleSnapshotInDom,
   ESBUILD_NAME_POLYFILL,
   type ComputedStyleSnapshot,
   collectInteractionTargetPlansInDom,

--- a/src/css-challenge.ts
+++ b/src/css-challenge.ts
@@ -10,14 +10,14 @@
  *
  * Usage: npx tsx src/css-challenge.ts [--fixture <name>] [--seed <number>] [--max-attempts <number>] [--approval <path>] [--strict]
  */
-import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { readFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { chromium } from "playwright";
 import { formatPlaywrightLaunchError, isPlaywrightSandboxRestrictionError } from "./playwright-launch-error.ts";
 import { applyApprovalToVrtDiff, collectApprovalWarnings, inferApprovalChangeType, loadApprovalManifest } from "./approval.ts";
 import { getCssChallengeFixturePath } from "./css-challenge-fixtures.ts";
 import { categorizeProperty, escapeRegex } from "./css-challenge-core.ts";
-import { compareScreenshots, encodePng } from "./heatmap.ts";
+import { compareScreenshots } from "./heatmap.ts";
 import { classifyVisualDiff } from "./visual-semantic.ts";
 import { diffA11yTrees, checkA11yTree, parsePlaywrightA11ySnapshot } from "./a11y-semantic.ts";
 import { createLLMProvider } from "./llm-client.ts";
@@ -37,7 +37,6 @@ const APPROVAL_PATH = getArg("approval", "");
 const STRICT = hasFlag("strict");
 const VIEWPORT = { width: 1280, height: 900 };
 
-const BG_RED = "\x1b[41m";
 const BG_GREEN = "\x1b[42m";
 function banner(text: string) { console.log(`\n${BOLD}${CYAN}▸ ${text}${RESET}\n`); }
 
@@ -207,7 +206,7 @@ function cdpNodesToTree(nodes: Array<{
 // ---- LLM fix ----
 
 function buildFixPrompt(
-  removedFrom: { selector: string; property: string },
+  _removedFrom: { selector: string; property: string },
   vrtReport: string,
   fullCss: string,
 ): string {
@@ -486,7 +485,7 @@ async function main() {
     const fixedCss = applyCssFix(currentCss, fix);
     const fixedHtml = htmlRaw.replace(originalCss, fixedCss);
     const fixedPath = join(TMP, `fixed-${attempt}.png`);
-    const fixedState = await capturePageState(fixedHtml, fixedPath);
+    await capturePageState(fixedHtml, fixedPath);
 
     // Compare fixed vs baseline
     const fixedSnap: VrtSnapshot = {

--- a/src/demo-fix-loop.ts
+++ b/src/demo-fix-loop.ts
@@ -9,17 +9,15 @@
  *
  * Usage: npx tsx vrt/src/demo-fix-loop.ts
  */
-import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { readFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { diffA11yTrees, parsePlaywrightA11ySnapshot, checkA11yTree } from "./a11y-semantic.ts";
 import { reasonAboutChanges, type ReasoningChain } from "./reasoning.ts";
-import { matchA11yExpectation } from "./expectation.ts";
-import { introspectToSpec, verifySpec, type SpecVerifyResult } from "./introspect.ts";
-import { compareScreenshots, encodePng } from "./heatmap.ts";
+import { introspectToSpec, verifySpec } from "./introspect.ts";
+import { compareScreenshots } from "./heatmap.ts";
+import { encodePng } from "./png-utils.ts";
 import { classifyVisualDiff } from "./visual-semantic.ts";
-import { runGoal, formatGoalReport, type Goal } from "./goal-runner.ts";
 import { createLLMProvider } from "./llm-client.ts";
-import type { LLMProvider } from "./intent.ts";
 import type { A11yNode, PageExpectation, ChangeIntent, VrtSnapshot } from "./types.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr as _hr } from "./terminal-colors.ts";
 

--- a/src/demo-multistep.ts
+++ b/src/demo-multistep.ts
@@ -12,8 +12,7 @@ import { readFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { diffA11yTrees, parsePlaywrightA11ySnapshot, checkA11yTree } from "./a11y-semantic.ts";
 import { reasonAboutChanges, type ReasoningChain } from "./reasoning.ts";
-import { introspectToSpec, verifySpec } from "./introspect.ts";
-import { encodePng } from "./heatmap.ts";
+import { encodePng } from "./png-utils.ts";
 import { createLLMProvider } from "./llm-client.ts";
 import type { LLMProvider } from "./intent.ts";
 import type { A11yNode, PageExpectation, ChangeIntent } from "./types.ts";
@@ -337,8 +336,6 @@ In 3-4 sentences: explain what went wrong and give the specific fix.`,
   console.log(`  ${D}Pattern: implement → verify → ${failCount > 0 ? "AI diagnose → fix → re-verify → " : ""}complete${R}`);
 
   // Final spec check
-  const LANDMARK = new Set(["banner","main","navigation","contentinfo","form","region","search","tablist","tabpanel"]);
-  const INTERACTIVE = new Set(["button","link","textbox","checkbox","radio","searchbox","switch","tab","columnheader"]);
   const finalTree = await loadTree("dashboard-step5-complete.a11y.json");
   const finalIssues = checkA11yTree(finalTree);
   console.log(`\n  ${B}Final a11y:${R} ${finalIssues.length === 0 ? `${BG_G}${B} CLEAN ${R}` : `${RE}${finalIssues.length} issues${R}`}`);

--- a/src/demo-scenarios.ts
+++ b/src/demo-scenarios.ts
@@ -13,12 +13,11 @@ import { readFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { diffA11yTrees, parsePlaywrightA11ySnapshot, checkA11yTree } from "./a11y-semantic.ts";
 import { reasonAboutChanges, type ReasoningChain } from "./reasoning.ts";
-import { introspectToSpec, verifySpec, type SpecVerifyResult } from "./introspect.ts";
-import { compareScreenshots, encodePng } from "./heatmap.ts";
-import { classifyVisualDiff } from "./visual-semantic.ts";
+import { introspectToSpec, verifySpec } from "./introspect.ts";
+import { encodePng } from "./png-utils.ts";
 import { createLLMProvider } from "./llm-client.ts";
 import type { LLMProvider } from "./intent.ts";
-import type { A11yNode, PageExpectation, ChangeIntent, VrtSnapshot, UiSpec } from "./types.ts";
+import type { A11yNode, UiSpec } from "./types.ts";
 
 const FIXTURES = join(import.meta.dirname!, "..", "fixtures", "react-sample");
 const TMP = join(import.meta.dirname!, "..", "test-results", "demo-multi");
@@ -166,7 +165,7 @@ async function scenarioA(llm: LLMProvider | null, baseline: A11yNode) {
   console.log(`\n${B}${C}═══ Scenario A: Refactor → Labels Broken → Fix ═══${R}\n`);
 
   const spec = quickSpec(baseline);
-  const basePath = await makePng("a-base.png", [...HDR, ...HEAD, ...FORM({r:35,g:134,b:54})]);
+  await makePng("a-base.png", [...HDR, ...HEAD, ...FORM({r:35,g:134,b:54})]);
 
   // Break
   phase(1, 3, "Regression: labels removed by refactor");

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -7,15 +7,15 @@
  *
  * Usage: npx tsx vrt/src/demo.ts
  */
-import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { readFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { diffA11yTrees, parsePlaywrightA11ySnapshot } from "./a11y-semantic.ts";
 import { reasonAboutChanges } from "./reasoning.ts";
 import { matchA11yExpectation } from "./expectation.ts";
-import { introspectToSpec, verifySpec } from "./introspect.ts";
-import { compareScreenshots, encodePng } from "./heatmap.ts";
+import { compareScreenshots } from "./heatmap.ts";
+import { encodePng } from "./png-utils.ts";
 import { classifyVisualDiff } from "./visual-semantic.ts";
-import type { A11yNode, PageExpectation, ChangeIntent, VrtSnapshot } from "./types.ts";
+import type { PageExpectation, ChangeIntent, VrtSnapshot } from "./types.ts";
 
 const FIXTURES = join(import.meta.dirname!, "..", "fixtures", "react-sample");
 const TMP = join(import.meta.dirname!, "..", "test-results", "demo");

--- a/src/dep-graph.test.ts
+++ b/src/dep-graph.test.ts
@@ -1,7 +1,9 @@
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { findAffectedComponents, graphStats } from "./dep-graph.ts";
-import type { DepGraph, DepNode, DepEdge } from "./types.ts";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { findAffectedComponents, graphStats, buildDepGraph } from "./dep-graph.ts";
+import type { DepGraph, DepNode } from "./types.ts";
 
 function makeNode(id: string, opts: Partial<DepNode> = {}): DepNode {
   return {
@@ -125,5 +127,235 @@ describe("graphStats", () => {
     assert.equal(stats.totalEdges, 1);
     assert.equal(stats.components, 1);
     assert.deepEqual(stats.byLanguage, { typescript: 2, moonbit: 1 });
+  });
+
+  it("should handle empty graph", () => {
+    const graph = makeGraph([], []);
+    const stats = graphStats(graph);
+    assert.equal(stats.totalFiles, 0);
+    assert.equal(stats.totalEdges, 0);
+    assert.equal(stats.components, 0);
+    assert.deepEqual(stats.byLanguage, {});
+  });
+});
+
+describe("findAffectedComponents edge cases", () => {
+  it("should include changed file itself if it is a component", () => {
+    const graph = makeGraph(
+      [makeNode("App.tsx", { isComponent: true })],
+      []
+    );
+    const affected = findAffectedComponents(graph, ["App.tsx"]);
+    assert.equal(affected.length, 1);
+    assert.equal(affected[0].node.id, "App.tsx");
+    assert.equal(affected[0].depth, 0);
+    assert.deepEqual(affected[0].changedDependencies, ["App.tsx"]);
+  });
+
+  it("should track multiple changed dependencies via BFS merge", () => {
+    const graph = makeGraph(
+      [
+        makeNode("a.ts"),
+        makeNode("c.ts"),
+        makeNode("Shared.tsx", { isComponent: true }),
+        makeNode("d.tsx", { isComponent: true }),
+      ],
+      [
+        ["Shared.tsx", "a.ts", []],
+        ["d.tsx", "c.ts", []],
+        ["d.tsx", "Shared.tsx", []],
+      ]
+    );
+    // a.ts changed -> Shared.tsx affected (depth 1) -> d.tsx affected (depth 2)
+    // c.ts changed -> d.tsx affected (depth 1)
+    // d.tsx should be visited from both paths
+    const affected = findAffectedComponents(graph, ["a.ts", "c.ts"]);
+    const dEntry = affected.find((a) => a.node.id === "d.tsx");
+    assert.ok(dEntry, "d.tsx should be affected");
+    assert.ok(dEntry.changedDependencies.includes("c.ts"));
+  });
+
+  it("should use default maxDepth of 10", () => {
+    // Build a chain of 12 nodes: n0 -> n1 -> ... -> n11
+    const nodes: DepNode[] = [];
+    const edges: Array<[string, string, string[]]> = [];
+    for (let i = 0; i <= 11; i++) {
+      nodes.push(makeNode(`n${i}.tsx`, { isComponent: true }));
+      if (i > 0) edges.push([`n${i}.tsx`, `n${i - 1}.tsx`, []]);
+    }
+    const graph = makeGraph(nodes, edges);
+    const affected = findAffectedComponents(graph, ["n0.tsx"]);
+    // n0 at depth 0, n1 at depth 1, ... n10 at depth 10
+    // n11 at depth 11 is beyond default maxDepth
+    assert.equal(affected.length, 11);
+    assert.equal(affected[affected.length - 1].depth, 10);
+  });
+});
+
+describe("buildDepGraph", () => {
+  const TMP = join(import.meta.dirname!, "..", "test-results", "dep-graph-test");
+
+  before(async () => {
+    await mkdir(TMP, { recursive: true });
+    // Create a small project structure
+    await mkdir(join(TMP, "src"), { recursive: true });
+    await writeFile(join(TMP, "src", "utils.ts"), `
+export function cn(...args: string[]) { return args.join(" "); }
+export function format(x: number) { return x.toFixed(2); }
+`);
+    await writeFile(join(TMP, "src", "Button.tsx"), `
+import { cn } from "./utils.ts";
+export function Button() { return <button className={cn("btn")}>OK</button>; }
+`);
+    await writeFile(join(TMP, "src", "App.tsx"), `
+import { Button } from "./Button.tsx";
+import { format } from "./utils.ts";
+export default function App() { return <div><Button /></div>; }
+`);
+    await writeFile(join(TMP, "src", "standalone.ts"), `
+const x = 42;
+export default x;
+`);
+  });
+
+  after(async () => {
+    await rm(TMP, { recursive: true, force: true });
+  });
+
+  it("should build graph from real files", async () => {
+    const graph = await buildDepGraph(TMP, { languages: ["typescript"] });
+
+    // Should have 4 nodes
+    assert.ok(graph.nodes.size >= 4);
+
+    // Check that edges are created
+    const buttonNode = [...graph.nodes.values()].find((n) => n.id.endsWith("Button.tsx"));
+    assert.ok(buttonNode, "Button.tsx should be in graph");
+
+    // Button.tsx imports from utils.ts, so there should be an edge
+    const buttonEdges = graph.edges.filter((e) => e.from.endsWith("Button.tsx"));
+    assert.ok(buttonEdges.length > 0, "Button.tsx should have import edges");
+    assert.ok(buttonEdges.some((e) => e.to.includes("utils")));
+  });
+
+  it("should detect exports", async () => {
+    const graph = await buildDepGraph(TMP, { languages: ["typescript"] });
+
+    const utilsNode = [...graph.nodes.values()].find((n) => n.id.endsWith("utils.ts"));
+    assert.ok(utilsNode);
+    assert.ok(utilsNode.exports.includes("cn"), "should export cn");
+    assert.ok(utilsNode.exports.includes("format"), "should export format");
+  });
+
+  it("should detect .tsx files as components", async () => {
+    const graph = await buildDepGraph(TMP, { languages: ["typescript"] });
+
+    const buttonNode = [...graph.nodes.values()].find((n) => n.id.endsWith("Button.tsx"));
+    assert.ok(buttonNode);
+    assert.equal(buttonNode.isComponent, true);
+
+    const standaloneNode = [...graph.nodes.values()].find((n) => n.id.endsWith("standalone.ts"));
+    assert.ok(standaloneNode);
+    assert.equal(standaloneNode.isComponent, false);
+  });
+
+  it("should ignore specified directories", async () => {
+    await mkdir(join(TMP, "node_modules", "fake"), { recursive: true });
+    await writeFile(join(TMP, "node_modules", "fake", "index.ts"), "export default 1;");
+
+    const graph = await buildDepGraph(TMP, { languages: ["typescript"] });
+
+    // node_modules should be ignored
+    const fakeNode = [...graph.nodes.values()].find((n) => n.filePath.includes("node_modules"));
+    assert.equal(fakeNode, undefined);
+  });
+
+  it("should handle empty directory", async () => {
+    const emptyDir = join(TMP, "empty");
+    await mkdir(emptyDir, { recursive: true });
+
+    const graph = await buildDepGraph(emptyDir, { languages: ["typescript"] });
+    assert.equal(graph.nodes.size, 0);
+    assert.equal(graph.edges.length, 0);
+  });
+
+  it("should parse TypeScript default imports and require()", async () => {
+    const tsDir = join(TMP, "ts-imports");
+    await mkdir(tsDir, { recursive: true });
+    await writeFile(join(tsDir, "lib.ts"), `export const value = 1;`);
+    await writeFile(join(tsDir, "main.ts"), `
+import lib from "./lib.ts";
+const x = require("./lib.ts");
+export { lib, x };
+`);
+    const graph = await buildDepGraph(tsDir, { languages: ["typescript"] });
+
+    const mainNode = [...graph.nodes.values()].find((n) => n.id === "main.ts");
+    assert.ok(mainNode);
+    // Should have edges from both import and require
+    const mainEdges = graph.edges.filter((e) => e.from === "main.ts");
+    assert.ok(mainEdges.length >= 2, "should have edges from import + require");
+    // Default import should add specifier
+    const importEdge = mainEdges.find((e) => e.specifiers.includes("lib"));
+    assert.ok(importEdge, "default import specifier should be captured");
+  });
+
+  it("should parse MoonBit @pkg.func imports", async () => {
+    const mbtDir = join(TMP, "mbt-imports");
+    await mkdir(mbtDir, { recursive: true });
+    await writeFile(join(mbtDir, "main.mbt"), `
+fn main {
+  let x = @pkg1.helper()
+  let y = @pkg2/sub.deep()
+  let z = @pkg1.helper() // duplicate, should be deduped
+}
+`);
+    const graph = await buildDepGraph(mbtDir, { languages: ["moonbit"] });
+
+    assert.ok(graph.nodes.size >= 1);
+    const mainEdges = graph.edges.filter((e) => e.from === "main.mbt");
+    // Should have 2 edges (pkg1 and pkg2/sub), deduped
+    assert.equal(mainEdges.length, 2);
+    const sources = mainEdges.map((e) => e.to).sort();
+    assert.deepEqual(sources, ["@pkg1", "@pkg2/sub"]);
+  });
+
+  it("should parse Rust use and mod declarations", async () => {
+    const rsDir = join(TMP, "rs-imports");
+    await mkdir(rsDir, { recursive: true });
+    await writeFile(join(rsDir, "lib.rs"), `pub fn helper() {}`);
+    await writeFile(join(rsDir, "main.rs"), `
+use crate::lib::helper;
+use std::collections::{HashMap, HashSet};
+mod parser;
+`);
+    const graph = await buildDepGraph(rsDir, { languages: ["rust"] });
+
+    // Node should be created even though most Rust imports are external
+    const mainNode = [...graph.nodes.values()].find((n) => n.id === "main.rs");
+    assert.ok(mainNode, "main.rs should be in graph");
+    assert.equal(mainNode.language, "rust");
+
+    // crate::lib::helper and parser don't start with . or @ so resolveImport skips them
+    // But the parser itself works — we verify by checking no crash and node was created
+    const mainEdges = graph.edges.filter((e) => e.from === "main.rs");
+    // All Rust imports are external (no relative ./ paths), so no edges
+    assert.equal(mainEdges.length, 0);
+  });
+
+  it("should skip external TypeScript packages (not relative or @)", async () => {
+    const extDir = join(TMP, "ext-pkg");
+    await mkdir(extDir, { recursive: true });
+    await writeFile(join(extDir, "main.ts"), `
+import { readFile } from "node:fs/promises";
+import lodash from "lodash";
+import { foo } from "./local.ts";
+`);
+    const graph = await buildDepGraph(extDir, { languages: ["typescript"] });
+
+    const mainEdges = graph.edges.filter((e) => e.from === "main.ts");
+    // Only "./local.ts" should create an edge; "node:fs/promises" and "lodash" are external
+    assert.equal(mainEdges.length, 1);
+    assert.ok(mainEdges[0].to.includes("local"));
   });
 });

--- a/src/dep-graph.ts
+++ b/src/dep-graph.ts
@@ -3,7 +3,6 @@ import { join, relative, resolve, dirname, extname } from "node:path";
 import type {
   DepGraph,
   DepNode,
-  DepEdge,
   Language,
   AffectedComponent,
 } from "./types.ts";

--- a/src/detection-classify.ts
+++ b/src/detection-classify.ts
@@ -4,8 +4,6 @@
  * Pre-classification: selector type, interactive state
  * Post-classification: undetected reason estimation
  */
-import type { PropertyCategory } from "./css-challenge-core.ts";
-
 // ---- Types ----
 
 export type SelectorType = "element" | "class" | "pseudo-class" | "pseudo-element" | "compound";

--- a/src/detection-report.ts
+++ b/src/detection-report.ts
@@ -6,7 +6,7 @@
  *
  * Usage: npx tsx src/detection-report.ts
  */
-import { readAllRecords, getDbStats, type DetectionRecord } from "./detection-db.ts";
+import { readAllRecords, getDbStats } from "./detection-db.ts";
 import { isOutOfScope } from "./detection-classify.ts";
 import { getBenchHistoryStats, readBenchHistory } from "./bench-history.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr as _hr } from "./terminal-colors.ts";

--- a/src/element-compare.ts
+++ b/src/element-compare.ts
@@ -13,7 +13,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { chromium, type Page } from "playwright";
-import { compareScreenshots, encodePng, decodePng } from "./heatmap.ts";
+import { compareScreenshots } from "./heatmap.ts";
 import { applyMask, parseMaskSelectors } from "./mask.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "./terminal-colors.ts";
 import type { VrtSnapshot } from "./types.ts";
@@ -232,8 +232,7 @@ function parseArgs(args: string[]): ElementCompareOptions {
 
   const selectorsRaw = getArg("selectors");
   if (!selectorsRaw) {
-    console.error("Error: --selectors is required (comma-separated CSS selectors)");
-    process.exit(1);
+    throw new Error("--selectors is required (comma-separated CSS selectors)");
   }
   const selectors = selectorsRaw.split(",").map((s) => s.trim()).filter(Boolean);
 

--- a/src/expectation.test.ts
+++ b/src/expectation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { matchA11yExpectation, crossValidateWithExpectation, scoreLoop } from "./expectation.ts";
-import type { PageExpectation, A11yDiff, ChangeIntent, UnifiedAgentContext, VrtExpectation } from "./types.ts";
+import type { PageExpectation, A11yDiff, ChangeIntent, UnifiedAgentContext } from "./types.ts";
 
 const navRemovalDiff: A11yDiff = {
   testId: "home",

--- a/src/expectation.ts
+++ b/src/expectation.ts
@@ -241,7 +241,7 @@ export function crossValidateWithExpectation(
   pageExp: PageExpectation | undefined,
   visualDiff: VisualSemanticDiff | undefined,
   a11yDiff: A11yDiff | undefined,
-  intent: ChangeIntent
+  _intent: ChangeIntent
 ): CrossValidationResult {
   if (!pageExp) {
     // No expectation defined -- fall back to normal cross-validation
@@ -319,13 +319,13 @@ export function scoreLoop(
   const practicalityScore = scorePracticality(ctx, expectations, details);
 
   // 3. Fix steps
-  const stepsScore = scoreFixSteps(meta.fixSteps, details);
+  scoreFixSteps(meta.fixSteps, details);
 
   // 4. Final quality
   const qualityScore = scoreFinalQuality(ctx, details);
 
   // 5. Token usage
-  const tokenScore = scoreTokenUsage(meta.tokenUsage, details);
+  scoreTokenUsage(meta.tokenUsage, details);
 
   return {
     usability: usabilityScore,

--- a/src/fix-loop.ts
+++ b/src/fix-loop.ts
@@ -9,16 +9,16 @@
  *   node --experimental-strip-types src/fix-loop.ts --fixture page --seed 42
  *   node --experimental-strip-types src/fix-loop.ts --fixture dashboard --max-rounds 5
  */
-import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { readFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { chromium } from "playwright";
 import { compareScreenshots, generateDiffReport } from "./heatmap.ts";
 import {
   parseCssDeclarations, removeCssProperty, extractCss, replaceCss,
   seededRandom, groupBySelector, removeSelectorBlock, escapeRegex,
-  type CssDeclaration, type CssSelectorBlock,
+  type CssDeclaration,
 } from "./css-challenge-core.ts";
-import { createReasoningPipeline, type StructuredDiffReport, type FixSuggestion } from "./vrt-reasoning-pipeline.ts";
+import { createReasoningPipeline } from "./vrt-reasoning-pipeline.ts";
 import { resolveResolutionForViewport } from "./image-resize.ts";
 import { getCssChallengeFixturePath } from "./css-challenge-fixtures.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "./terminal-colors.ts";

--- a/src/flaker-vrt-results.ts
+++ b/src/flaker-vrt-results.ts
@@ -1,4 +1,4 @@
-import { relative, resolve, sep } from "node:path";
+import { relative, resolve } from "node:path";
 import type { FlakerVrtMigrationScenario } from "./flaker-vrt-config.ts";
 import type { MigrationCompareReport, MigrationCompareResult } from "./migration-compare.ts";
 import type { FlakerTestCaseResult, FlakerTestId } from "./flaker-vrt-runner.ts";

--- a/src/flaker-vrt-runner.ts
+++ b/src/flaker-vrt-runner.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { mkdir, readFile } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
 import { loadFlakerVrtConfig, toViewportSpec, type FlakerVrtConfig, type FlakerVrtMigrationScenario } from "./flaker-vrt-config.ts";
 import {
   runMigrationCompare,

--- a/src/goal-runner.test.ts
+++ b/src/goal-runner.test.ts
@@ -15,8 +15,8 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { runGoal, formatGoalReport } from "./goal-runner.ts";
-import type { Goal, GoalStep } from "./goal-runner.ts";
-import type { A11yNode, PageExpectation } from "./types.ts";
+import type { Goal } from "./goal-runner.ts";
+import type { A11yNode } from "./types.ts";
 
 const FIXTURES = join(import.meta.dirname!, "..", "fixtures", "react-sample");
 

--- a/src/goal-runner.ts
+++ b/src/goal-runner.ts
@@ -1,13 +1,9 @@
 import type {
-  A11yDiff,
   ChangeIntent,
   PageExpectation,
-  LoopScore,
-  UnifiedAgentContext,
-  VrtExpectation,
 } from "./types.ts";
 import { diffA11yTrees, parsePlaywrightA11ySnapshot } from "./a11y-semantic.ts";
-import { matchA11yExpectation, crossValidateWithExpectation, scoreLoop } from "./expectation.ts";
+import { matchA11yExpectation } from "./expectation.ts";
 import { reasonAboutChanges, type ReasoningChain } from "./reasoning.ts";
 import { introspectToSpec, verifySpec, type SpecVerifyResult } from "./introspect.ts";
 import type { A11yNode } from "./types.ts";

--- a/src/harness.test.ts
+++ b/src/harness.test.ts
@@ -12,10 +12,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { diffA11yTrees, parsePlaywrightA11ySnapshot, checkA11yTree } from "./a11y-semantic.ts";
-import { matchA11yExpectation, crossValidateWithExpectation } from "./expectation.ts";
+import { diffA11yTrees, parsePlaywrightA11ySnapshot } from "./a11y-semantic.ts";
+import { crossValidateWithExpectation } from "./expectation.ts";
 import { reasonAboutChanges } from "./reasoning.ts";
-import { crossValidate } from "./cross-validation.ts";
 import { introspectToSpec, verifySpec } from "./introspect.ts";
 import type { A11yNode, PageExpectation, ChangeIntent, A11yDiff } from "./types.ts";
 
@@ -177,7 +176,6 @@ describe("Harness: full pipeline quality", () => {
           "home", sc.correctExpectation, undefined, d.changes.length > 0 ? d : undefined, sc.intent
         );
 
-        const approved = cv.recommendation === "approve";
         // style-only と regression cases: correct exp は no-change なので approve
         // 期待が変更ありの場合: 変更検出 + マッチ → approve
         if (sc.snapshot === "snapshot-style-only.a11y.json") {

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -1,72 +1,29 @@
-import { readFile, writeFile } from "node:fs/promises";
 import type { VrtDiff, VrtSnapshot, DiffRegion, DiffRegionType, DiffReport, ShiftRegion } from "./types.ts";
+import { type PngData, cropImage, decodePng, encodePng } from "./png-utils.ts";
 
-// PNG decoding/encoding and pixel comparison
-// Uses pngjs + pixelmatch — both are devDependencies
+// ---- Shared diff pipeline ----
 
-interface PngData {
+interface PixelDiffResult {
+  diffOutput: Uint8Array;
   width: number;
   height: number;
-  data: Uint8Array;
+  diffPixels: number;
+  totalPixels: number;
+  threshold: number;
+  resizedBaseline: PngData;
+  resizedCurrent: PngData;
 }
 
-function cropImage(img: PngData, w: number, h: number): PngData {
-  if (img.width === w && img.height === h) return img;
-  const data = new Uint8Array(w * h * 4);
-  for (let y = 0; y < h; y++) {
-    const srcOffset = y * img.width * 4;
-    const dstOffset = y * w * 4;
-    data.set(img.data.subarray(srcOffset, srcOffset + w * 4), dstOffset);
-  }
-  return { width: w, height: h, data };
-}
-
-/**
- * Read a PNG file and return RGBA pixel data.
- */
-export async function decodePng(path: string): Promise<PngData> {
-  const { PNG } = await import("pngjs");
-  const buffer = await readFile(path);
-  const png = PNG.sync.read(buffer);
-  return {
-    width: png.width,
-    height: png.height,
-    data: new Uint8Array(png.data.buffer, png.data.byteOffset, png.data.byteLength),
-  };
-}
-
-/**
- * Write RGBA pixel data to a PNG file.
- */
-export async function encodePng(
-  path: string,
-  data: PngData
-): Promise<void> {
-  const { PNG } = await import("pngjs");
-  const png = new PNG({ width: data.width, height: data.height });
-  Buffer.from(data.data.buffer, data.data.byteOffset, data.data.byteLength).copy(png.data);
-  const buffer = PNG.sync.write(png);
-  await writeFile(path, buffer);
-}
-
-/**
- * Compare two screenshots pixel-by-pixel and generate a diff heatmap.
- */
-export async function compareScreenshots(
-  snapshot: VrtSnapshot,
-  opts: {
-    threshold?: number; // pixelmatch threshold (0-1), default 0.1
-    outputDir?: string;
-    skipHeatmap?: boolean; // skip PNG heatmap generation for speed
-  } = {}
-): Promise<VrtDiff | null> {
-  if (!snapshot.baselinePath) return null;
-
+async function runPixelDiff(
+  baselinePath: string,
+  screenshotPath: string,
+  testId: string,
+  opts: { threshold?: number; outputDir?: string; skipHeatmap?: boolean },
+): Promise<PixelDiffResult & { heatmapPath?: string }> {
   const pixelmatch = (await import("pixelmatch")).default;
-  const baseline = await decodePng(snapshot.baselinePath);
-  const current = await decodePng(snapshot.screenshotPath);
+  const baseline = await decodePng(baselinePath);
+  const current = await decodePng(screenshotPath);
 
-  // Different sizes: compare common region + count overflow as diff
   let resizedBaseline = baseline;
   let resizedCurrent = current;
   let overflowPixels = 0;
@@ -74,11 +31,9 @@ export async function compareScreenshots(
   if (baseline.width !== current.width || baseline.height !== current.height) {
     const commonW = Math.min(baseline.width, current.width);
     const commonH = Math.min(baseline.height, current.height);
-    const maxW = Math.max(baseline.width, current.width);
-    const maxH = Math.max(baseline.height, current.height);
-    overflowPixels = maxW * maxH - commonW * commonH;
-
-    // Crop both images to common region
+    overflowPixels =
+      Math.max(baseline.width, current.width) * Math.max(baseline.height, current.height)
+      - commonW * commonH;
     resizedBaseline = cropImage(baseline, commonW, commonH);
     resizedCurrent = cropImage(current, commonW, commonH);
   }
@@ -90,31 +45,43 @@ export async function compareScreenshots(
   const threshold = opts.threshold ?? 0.1;
 
   const diffPixels = overflowPixels + pixelmatch(
-    resizedBaseline.data,
-    resizedCurrent.data,
-    diffOutput,
-    width,
-    height,
-    { threshold }
+    resizedBaseline.data, resizedCurrent.data, diffOutput, width, height, { threshold },
   );
 
-  // Heatmap output (skip PNG encode if skipHeatmap is set)
   let heatmapPath: string | undefined;
   if (opts.outputDir && diffPixels > 0 && !opts.skipHeatmap) {
-    const safeName = snapshot.testId.replace(/[/\\:]/g, "_");
+    const safeName = testId.replace(/[/\\:]/g, "_");
     heatmapPath = `${opts.outputDir}/${safeName}_heatmap.png`;
     await encodePng(heatmapPath, { width, height, data: diffOutput });
   }
 
-  // Detect diff regions (simplified connected-component analysis: grid-based)
-  const regions = detectDiffRegions(diffOutput, width, height);
+  return { diffOutput, width, height, diffPixels, totalPixels, threshold, resizedBaseline, resizedCurrent, heatmapPath };
+}
+
+// ---- Public API ----
+
+/**
+ * Compare two screenshots pixel-by-pixel and generate a diff heatmap.
+ */
+export async function compareScreenshots(
+  snapshot: VrtSnapshot,
+  opts: {
+    threshold?: number;
+    outputDir?: string;
+    skipHeatmap?: boolean;
+  } = {}
+): Promise<VrtDiff | null> {
+  if (!snapshot.baselinePath) return null;
+
+  const r = await runPixelDiff(snapshot.baselinePath, snapshot.screenshotPath, snapshot.testId, opts);
+  const regions = detectDiffRegions(r.diffOutput, r.width, r.height);
 
   return {
     snapshot,
-    diffPixels,
-    totalPixels,
-    diffRatio: diffPixels / totalPixels,
-    heatmapPath,
+    diffPixels: r.diffPixels,
+    totalPixels: r.totalPixels,
+    diffRatio: r.diffPixels / r.totalPixels,
+    heatmapPath: r.heatmapPath,
     regions,
   };
 }
@@ -362,78 +329,33 @@ export async function generateDiffReport(
 ): Promise<DiffReport | null> {
   if (!snapshot.baselinePath) return null;
 
-  const pixelmatch = (await import("pixelmatch")).default;
-  const baseline = await decodePng(snapshot.baselinePath);
-  const current = await decodePng(snapshot.screenshotPath);
-
-  let resizedBaseline = baseline;
-  let resizedCurrent = current;
-  let overflowPixels = 0;
-
-  if (baseline.width !== current.width || baseline.height !== current.height) {
-    const commonW = Math.min(baseline.width, current.width);
-    const commonH = Math.min(baseline.height, current.height);
-    const maxW = Math.max(baseline.width, current.width);
-    const maxH = Math.max(baseline.height, current.height);
-    overflowPixels = maxW * maxH - commonW * commonH;
-    resizedBaseline = cropImage(baseline, commonW, commonH);
-    resizedCurrent = cropImage(current, commonW, commonH);
-  }
-
-  const width = resizedBaseline.width;
-  const height = resizedBaseline.height;
-  const totalPixels = width * height + overflowPixels;
-  const diffOutput = new Uint8Array(width * height * 4);
-  const threshold = opts.threshold ?? 0.1;
-
-  const diffPixels = overflowPixels + pixelmatch(
-    resizedBaseline.data,
-    resizedCurrent.data,
-    diffOutput,
-    width,
-    height,
-    { threshold },
-  );
-
-  // Heatmap
-  let heatmapPath: string | undefined;
-  if (opts.outputDir && diffPixels > 0 && !opts.skipHeatmap) {
-    const safeName = snapshot.testId.replace(/[/\\:]/g, "_");
-    heatmapPath = `${opts.outputDir}/${safeName}_heatmap.png`;
-    await encodePng(heatmapPath, { width, height, data: diffOutput });
-  }
-
-  // Regions with classification
-  const regions = detectDiffRegions(diffOutput, width, height);
+  const r = await runPixelDiff(snapshot.baselinePath, snapshot.screenshotPath, snapshot.testId, opts);
+  const regions = detectDiffRegions(r.diffOutput, r.width, r.height);
 
   // Shift detection
   let globalShift = 0;
   let shiftRegions: ShiftRegion[] = [];
-  let compensated = diffPixels;
+  let compensated = r.diffPixels;
 
-  if (opts.detectShift !== false && height > 4) {
-    globalShift = detectGlobalShift(resizedBaseline, resizedCurrent);
+  if (opts.detectShift !== false && r.height > 4) {
+    globalShift = detectGlobalShift(r.resizedBaseline, r.resizedCurrent);
     if (globalShift !== 0) {
       compensated = compensatedDiffCount(
-        resizedBaseline.data,
-        resizedCurrent.data,
-        width,
-        height,
-        globalShift,
-        threshold,
+        r.resizedBaseline.data, r.resizedCurrent.data,
+        r.width, r.height, globalShift, r.threshold,
       );
-      shiftRegions = [{ yStart: 0, yEnd: height, shift: globalShift }];
+      shiftRegions = [{ yStart: 0, yEnd: r.height, shift: globalShift }];
     }
   }
 
-  const shiftOnly = regions.length > 0 && regions.every((r) => r.regionType === "shift" || r.regionType === "edge");
-  const contentChangeCount = regions.filter((r) => r.regionType === "content").length;
-  const compact = generateCompact(diffOutput, width, height, diffPixels, totalPixels, regions);
+  const shiftOnly = regions.length > 0 && regions.every((rg) => rg.regionType === "shift" || rg.regionType === "edge");
+  const contentChangeCount = regions.filter((rg) => rg.regionType === "content").length;
+  const compact = generateCompact(r.diffOutput, r.width, r.height, r.diffPixels, r.totalPixels, regions);
 
   return {
-    diffPixels,
-    totalPixels,
-    diffRatio: diffPixels / totalPixels,
+    diffPixels: r.diffPixels,
+    totalPixels: r.totalPixels,
+    diffRatio: r.diffPixels / r.totalPixels,
     regions,
     shiftOnly,
     contentChangeCount,

--- a/src/intent.ts
+++ b/src/intent.ts
@@ -144,7 +144,7 @@ function isComponentFile(path: string): boolean {
  */
 function inferVisualExpectations(
   files: FileChange[],
-  commitMessage: string,
+  _commitMessage: string,
   changeType: ChangeIntent["changeType"]
 ): VisualExpectation[] {
   const expectations: VisualExpectation[] = [];

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -103,10 +103,10 @@ function generateDescription(
 }
 
 function generateInvariants(
-  testId: string,
+  _testId: string,
   landmarks: { role: string; name: string }[],
   interactive: { role: string; name: string; hasLabel: boolean }[],
-  headingLevels: number[],
+  _headingLevels: number[],
   unlabeledCount: number
 ): SpecInvariant[] {
   const invariants: SpecInvariant[] = [];

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -73,19 +73,20 @@ function createAnthropicClient(apiKey: string, model?: string): UnifiedLLMClient
   async function call(content: MessageContent, maxTokens: number): Promise<LLMResponse> {
     const start = Date.now();
 
-    // Build messages
-    let messageContent: any;
-    if (typeof content === "string") {
-      messageContent = content;
-    } else {
-      messageContent = content.map((c) => {
-        if (c.type === "text") return { type: "text", text: c.text };
-        return {
-          type: "image",
-          source: { type: "base64", media_type: c.mimeType ?? "image/png", data: c.base64 },
-        };
-      });
-    }
+    type AnthropicBlock =
+      | { type: "text"; text: string }
+      | { type: "image"; source: { type: "base64"; media_type: string; data: string } };
+
+    const messageContent: string | AnthropicBlock[] =
+      typeof content === "string"
+        ? content
+        : content.map((c): AnthropicBlock => {
+          if (c.type === "text") return { type: "text", text: c.text };
+          return {
+            type: "image",
+            source: { type: "base64", media_type: c.mimeType ?? "image/png", data: c.base64 },
+          };
+        });
 
     const res = await fetch("https://api.anthropic.com/v1/messages", {
       method: "POST",
@@ -147,15 +148,17 @@ function createGeminiLLMClient(apiKey: string, model?: string): UnifiedLLMClient
     const genModel = genAI.getGenerativeModel({ model: modelId });
     const start = Date.now();
 
-    let parts: any[];
-    if (typeof content === "string") {
-      parts = [{ text: content }];
-    } else {
-      parts = content.map((c) => {
-        if (c.type === "text") return { text: c.text };
-        return { inlineData: { mimeType: c.mimeType ?? "image/png", data: c.base64 } };
-      });
-    }
+    type GeminiPart =
+      | { text: string }
+      | { inlineData: { mimeType: string; data: string } };
+
+    const parts: GeminiPart[] =
+      typeof content === "string"
+        ? [{ text: content }]
+        : content.map((c): GeminiPart => {
+          if (c.type === "text") return { text: c.text };
+          return { inlineData: { mimeType: c.mimeType ?? "image/png", data: c.base64 } };
+        });
 
     const result = await genModel.generateContent({
       contents: [{ role: "user", parts }],
@@ -194,15 +197,17 @@ function createOpenRouterLLMClient(apiKey: string, model?: string): UnifiedLLMCl
   async function call(content: MessageContent, maxTokens: number): Promise<LLMResponse> {
     const start = Date.now();
 
-    let messageContent: any;
-    if (typeof content === "string") {
-      messageContent = content;
-    } else {
-      messageContent = content.map((c) => {
-        if (c.type === "text") return { type: "text", text: c.text };
-        return { type: "image_url", image_url: { url: `data:${c.mimeType ?? "image/png"};base64,${c.base64}` } };
-      });
-    }
+    type OpenRouterBlock =
+      | { type: "text"; text: string }
+      | { type: "image_url"; image_url: { url: string } };
+
+    const messageContent: string | OpenRouterBlock[] =
+      typeof content === "string"
+        ? content
+        : content.map((c): OpenRouterBlock => {
+          if (c.type === "text") return { type: "text", text: c.text };
+          return { type: "image_url", image_url: { url: `data:${c.mimeType ?? "image/png"};base64,${c.base64}` } };
+        });
 
     const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
       method: "POST",

--- a/src/mask.ts
+++ b/src/mask.ts
@@ -6,8 +6,6 @@
  */
 import type { Page } from "playwright";
 
-const MASK_STYLE_ID = "__vrt-mask-style__";
-
 /**
  * Inject mask styles into the page.
  * Sets visibility: hidden on target selectors including descendants.

--- a/src/playwright-helper.test.ts
+++ b/src/playwright-helper.test.ts
@@ -53,7 +53,7 @@ const sampleA11y = `
 
 describe("heuristicCheck", () => {
   it("should pass when keywords match", () => {
-    const result = heuristicCheck(sampleA11y, "ナビゲーションにリンクがある");
+    heuristicCheck(sampleA11y, "ナビゲーションにリンクがある");
     // "ナビゲーション" doesn't match because a11y is in English
     // But let's test with English
     const r2 = heuristicCheck(sampleA11y, "navigation has links");
@@ -66,7 +66,7 @@ describe("heuristicCheck", () => {
   });
 
   it("should check numeric assertions", () => {
-    const r1 = heuristicCheck(sampleA11y, "リンクが3つ以上ある");
+    heuristicCheck(sampleA11y, "リンクが3つ以上ある");
     // a11y has "- " markers — count them
     const count = (sampleA11y.match(/- /g) || []).length;
     assert.ok(count >= 3, `Element count: ${count}`);

--- a/src/playwright-helper.ts
+++ b/src/playwright-helper.ts
@@ -10,7 +10,6 @@
  * - cache -> don't re-run the same assertion
  */
 import type { Page } from "@playwright/test";
-import type { NlAssertion } from "./types.ts";
 import type { LLMProvider } from "./intent.ts";
 
 export interface NlAssertOptions {
@@ -58,7 +57,7 @@ export async function nlAssert(
   assertion: string,
   opts: NlAssertOptions = {}
 ): Promise<NlAssertResult> {
-  const { onlyOnFailure = true, dependsOn, llm, cache = true } = opts;
+  const { onlyOnFailure = true, llm, cache = true } = opts;
 
   // Cache check
   const cacheKey = `${page.url()}:${assertion}`;
@@ -143,8 +142,7 @@ async function llmAssert(
   llm: LLMProvider
 ): Promise<NlAssertResult> {
   // Capture screenshot
-  const screenshot = await page.screenshot({ type: "png" });
-  const base64 = screenshot.toString("base64");
+  await page.screenshot({ type: "png" });
 
   // Get a11y tree
   let a11yYaml = "";

--- a/src/png-utils.ts
+++ b/src/png-utils.ts
@@ -1,0 +1,56 @@
+/**
+ * PNG I/O utilities
+ *
+ * Low-level PNG decode/encode using pngjs.
+ * Used by heatmap.ts and other modules that need raw pixel data.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+
+export interface PngData {
+  width: number;
+  height: number;
+  data: Uint8Array;
+}
+
+/**
+ * Crop or pad an image to the target dimensions.
+ * Only handles the common region; overflow is zero-filled.
+ */
+export function cropImage(img: PngData, w: number, h: number): PngData {
+  if (img.width === w && img.height === h) return img;
+  const data = new Uint8Array(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    const srcOffset = y * img.width * 4;
+    const dstOffset = y * w * 4;
+    data.set(img.data.subarray(srcOffset, srcOffset + w * 4), dstOffset);
+  }
+  return { width: w, height: h, data };
+}
+
+/**
+ * Read a PNG file and return RGBA pixel data.
+ */
+export async function decodePng(path: string): Promise<PngData> {
+  const { PNG } = await import("pngjs");
+  const buffer = await readFile(path);
+  const png = PNG.sync.read(buffer);
+  return {
+    width: png.width,
+    height: png.height,
+    data: new Uint8Array(png.data.buffer, png.data.byteOffset, png.data.byteLength),
+  };
+}
+
+/**
+ * Write RGBA pixel data to a PNG file.
+ */
+export async function encodePng(
+  path: string,
+  data: PngData
+): Promise<void> {
+  const { PNG } = await import("pngjs");
+  const png = new PNG({ width: data.width, height: data.height });
+  Buffer.from(data.data.buffer, data.data.byteOffset, data.data.byteLength).copy(png.data);
+  const buffer = PNG.sync.write(png);
+  await writeFile(path, buffer);
+}

--- a/src/quality.ts
+++ b/src/quality.ts
@@ -1,12 +1,12 @@
 import type {
   QualityCheckResult,
-  QualityCheckType,
   VrtSnapshot,
   VrtDiff,
   DepGraph,
   AffectedComponent,
 } from "./types.ts";
-import { decodePng, detectWhiteout, detectEmptyContent } from "./heatmap.ts";
+import { detectWhiteout, detectEmptyContent } from "./heatmap.ts";
+import { decodePng } from "./png-utils.ts";
 
 /**
  * Run all quality checks.

--- a/src/scenario.test.ts
+++ b/src/scenario.test.ts
@@ -23,7 +23,6 @@ import type {
   ChangeIntent,
   UnifiedAgentContext,
   VrtExpectation,
-  IntrospectResult,
   PageIntrospection,
 } from "./types.ts";
 

--- a/src/smoke-runner.ts
+++ b/src/smoke-runner.ts
@@ -14,10 +14,10 @@ import { readFile } from "node:fs/promises";
 import { chromium, type Page, type Browser } from "playwright";
 import type {
   SmokeTestRequest, SmokeTestResponse, SmokeAction, SmokeError,
-  A11ySnapshot, A11yNodeCompact, SmokeTestMeta,
+  A11ySnapshot, A11yNodeCompact,
 } from "./api-types.ts";
 
-import { getArg, hasFlag, args } from "./cli-args.ts";
+import { getArg, args } from "./cli-args.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD } from "./terminal-colors.ts";
 
 // ---- Config ----
@@ -90,8 +90,6 @@ async function discoverActions(page: Page): Promise<ActionCandidate[]> {
   // Get a11y snapshot
   const snapshot = await page.locator(":root").ariaSnapshot().then((yaml: string) => parseAriaYaml(yaml)).catch(() => null);
   if (!snapshot) return candidates;
-
-  const origin = new URL(page.url()).origin;
 
   function walk(node: any, path: string) {
     const role = node.role ?? "";

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -6,12 +6,12 @@
  *   vrt snapshot http://localhost:4156/todomvc --output snapshots/luna/
  *   vrt snapshot http://localhost:3000/ http://localhost:3000/luna/ --output snapshots/sol/
  */
-import { mkdir, readFile, writeFile, access } from "node:fs/promises";
+import { mkdir, writeFile, access } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { chromium } from "playwright";
 import { compareScreenshots, generateDiffReport } from "./heatmap.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "./terminal-colors.ts";
-import { getArg, hasFlag, getPositionalArgs, args } from "./cli-args.ts";
+import { getArg, getPositionalArgs, args } from "./cli-args.ts";
 import { applyMask, parseMaskSelectors } from "./mask.ts";
 import type { VrtSnapshot } from "./types.ts";
 

--- a/src/visual-pipeline.test.ts
+++ b/src/visual-pipeline.test.ts
@@ -8,9 +8,10 @@
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { writeFile, mkdir, rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { compareScreenshots, decodePng, detectWhiteout, detectEmptyContent } from "./heatmap.ts";
+import { compareScreenshots, detectWhiteout } from "./heatmap.ts";
+import { decodePng } from "./png-utils.ts";
 import { classifyVisualDiff } from "./visual-semantic.ts";
 import type { VrtSnapshot } from "./types.ts";
 
@@ -44,7 +45,7 @@ function createTestPng(width: number, height: number, regions: Array<{
 }
 
 async function savePng(path: string, png: { width: number; height: number; data: Uint8Array }) {
-  const { encodePng } = await import("./heatmap.ts");
+  const { encodePng } = await import("./png-utils.ts");
   await encodePng(path, png);
 }
 

--- a/src/vrt-cli.ts
+++ b/src/vrt-cli.ts
@@ -29,6 +29,7 @@ import { buildDepGraph, findAffectedComponents, graphStats } from "./dep-graph.t
 import { extractDiffSemantics } from "./intent.ts";
 import { diffA11yTrees, parsePlaywrightA11ySnapshot } from "./a11y-semantic.ts";
 import { introspect, introspectToSpec, verifySpec } from "./introspect.ts";
+import { formatWorkflowUsage } from "./vrt-command-router.ts";
 import { runVerifyPipeline, type VerifyPaths } from "./vrt-verify.ts";
 import type { UnifiedAgentContext, UiSpec, A11yNode } from "./types.ts";
 
@@ -132,19 +133,19 @@ async function verify() {
   const result = await runVerifyPipeline(paths);
 
   if (!result.passed) {
-    console.log("\nFAILED — Fix the issues and run `vrt capture && vrt verify` again.");
+    console.log("\nFAILED — Fix the issues and run `vrt workflow capture && vrt workflow verify` again.");
     console.log("Details: " + REPORT_PATH);
     process.exit(1);
   } else if (result.needsReview) {
-    console.log("\nWARNING — Some changes need review. Run `vrt report` for details.");
-    console.log("If changes are intentional, run `vrt approve` to update baselines.");
+    console.log("\nWARNING — Some changes need review. Run `vrt workflow report` for details.");
+    console.log("If changes are intentional, run `vrt workflow approve` to update baselines.");
     process.exit(0);
   } else if (result.vrtDiffs.length === 0 && result.a11yDiffs.length === 0) {
     console.log("\nPASS — No visual or semantic changes detected.");
     process.exit(0);
   } else {
     console.log("\nPASS — All changes approved.");
-    console.log("Run `vrt approve` to update baselines.");
+    console.log("Run `vrt workflow approve` to update baselines.");
     process.exit(0);
   }
 }
@@ -153,7 +154,7 @@ async function approve() {
   console.log("=== VRT Approve: Updating baselines ===\n");
 
   if (!existsSync(SNAPSHOTS_DIR)) {
-    console.error("No snapshots found. Run `vrt capture` first.");
+    console.error("No snapshots found. Run `vrt workflow capture` first.");
     process.exit(1);
   }
 
@@ -170,7 +171,7 @@ async function approve() {
 
 async function report() {
   if (!existsSync(REPORT_PATH)) {
-    console.error("No report found. Run `vrt verify` first.");
+    console.error("No report found. Run `vrt workflow verify` first.");
     process.exit(1);
   }
 
@@ -263,7 +264,7 @@ async function affectedCmd() {
 async function introspectCmd() {
   const dir = existsSync(SNAPSHOTS_DIR) ? SNAPSHOTS_DIR : BASELINES_DIR;
   if (!existsSync(dir)) {
-    console.error("No snapshots or baselines found. Run `vrt init` or `vrt capture` first.");
+    console.error("No snapshots or baselines found. Run `vrt workflow init` or `vrt workflow capture` first.");
     process.exit(1);
   }
 
@@ -288,7 +289,7 @@ async function introspectCmd() {
 
 async function specVerifyCmd() {
   if (!existsSync(SPEC_PATH)) {
-    console.error("No spec.json found. Run `vrt introspect` first.");
+    console.error("No spec.json found. Run `vrt workflow introspect` first.");
     process.exit(1);
   }
 
@@ -361,11 +362,11 @@ async function expectCmd() {
   console.log("=== Generate expectation.json from current state ===\n");
 
   if (!existsSync(BASELINES_DIR)) {
-    console.error("No baselines found. Run `vrt init` first.");
+    console.error("No baselines found. Run `vrt workflow init` first.");
     process.exit(1);
   }
   if (!existsSync(SNAPSHOTS_DIR)) {
-    console.error("No snapshots found. Run `vrt capture` first.");
+    console.error("No snapshots found. Run `vrt workflow capture` first.");
     process.exit(1);
   }
 
@@ -449,7 +450,7 @@ async function expectCmd() {
     const icon = !p.hasA11yDiff ? "  " : p.hasRegression ? "!!" : "~~";
     console.log(`  [${icon}] ${p.testId}: ${p.changes.length} change(s)`);
   }
-  console.log(`\nReview and edit as needed, then run: vrt verify`);
+  console.log(`\nReview and edit as needed, then run: vrt workflow verify`);
 }
 
 // ---- Helpers ----
@@ -465,8 +466,6 @@ async function listFiles(dir: string, suffix: string): Promise<string[]> {
 
 // ---- Main ----
 
-const command = process.argv[2];
-
 const commands: Record<string, () => Promise<void>> = {
   init,
   capture,
@@ -480,35 +479,26 @@ const commands: Record<string, () => Promise<void>> = {
   expect: expectCmd,
 };
 
-const handler = commands[command];
-if (handler) {
-  handler().catch((err) => {
+export async function runWorkflowCli(argv = process.argv.slice(2)) {
+  const command = argv[0];
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    console.log(formatWorkflowUsage());
+    return;
+  }
+
+  const handler = commands[command];
+  if (!handler) {
+    console.error(`Unknown workflow command: ${command}\n`);
+    console.error(formatWorkflowUsage());
+    process.exit(1);
+  }
+
+  await handler();
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  runWorkflowCli().catch((err) => {
     console.error(err);
     process.exit(1);
   });
-} else {
-  console.log(`vrt — Visual Regression + Semantic Testing CLI
-
-Usage: tsx vrt/src/vrt-cli.ts <command>
-
-Commands:
-  init       Create baseline screenshots + a11y trees (requires running server)
-  capture    Take current snapshots (requires running server)
-  verify     Compare snapshots against baselines, run verification pipeline
-  approve    Promote current snapshots to new baselines
-  report     Show last verification report
-  graph      Display dependency graph
-  affected   Show components affected by current changes
-  introspect Generate spec.json from current a11y snapshots
-  spec-verify Verify spec.json invariants against current state
-  expect     Auto-generate expectation.json from baseline vs snapshot diff
-
-Workflow for coding agents:
-  1. vrt init            — One-time baseline setup
-  2. (make code changes)
-  3. vrt capture         — Snapshot current state
-  4. vrt verify          — Check for regressions
-  5. (fix if needed, repeat 3-4)
-  6. vrt approve         — Accept changes as new baseline
-`);
 }

--- a/src/vrt-cli.ts
+++ b/src/vrt-cli.ts
@@ -23,21 +23,14 @@ import {
   mkdir,
   cp,
   rm,
-  stat,
 } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { buildDepGraph, findAffectedComponents, graphStats } from "./dep-graph.ts";
-import { extractDiffSemantics, parseDiff, buildIntent } from "./intent.ts";
-import { collectScreenshots } from "./playwright-analyzer.ts";
-import { compareScreenshots } from "./heatmap.ts";
-import { classifyVisualDiff } from "./visual-semantic.ts";
-import { diffA11yTrees, parsePlaywrightA11ySnapshot, checkA11yTree } from "./a11y-semantic.ts";
-import { crossValidate, crossValidationToQualityChecks } from "./cross-validation.ts";
-import { loadExpectation, crossValidateWithExpectation, scoreLoop } from "./expectation.ts";
-import { runQualityChecks } from "./quality.ts";
-import { runVerificationLoop, generateReport as generateAgentReport } from "./agent.ts";
+import { extractDiffSemantics } from "./intent.ts";
+import { diffA11yTrees, parsePlaywrightA11ySnapshot } from "./a11y-semantic.ts";
 import { introspect, introspectToSpec, verifySpec } from "./introspect.ts";
-import type { VrtDiff, A11yDiff, VisualSemanticDiff, UnifiedAgentContext, VrtExpectation, PageExpectation, UiSpec, A11yNode } from "./types.ts";
+import { runVerifyPipeline, type VerifyPaths } from "./vrt-verify.ts";
+import type { UnifiedAgentContext, UiSpec, A11yNode } from "./types.ts";
 
 // ---- Paths ----
 // baselines/ and snapshots/ are placed outside test-results/ (Playwright clears test-results)
@@ -127,254 +120,26 @@ async function capture() {
 async function verify() {
   console.log("=== VRT Verify: Running verification pipeline ===\n");
 
-  if (!existsSync(BASELINES_DIR)) {
-    console.error("No baselines found. Run `vrt init` first.");
-    process.exit(1);
-  }
-  if (!existsSync(SNAPSHOTS_DIR)) {
-    console.error("No snapshots found. Run `vrt capture` first.");
-    process.exit(1);
-  }
-
-  await mkdir(OUTPUT_DIR, { recursive: true });
-
-  // ---- Track 1: Intent ----
-  console.log("[Track 1] Extracting change intent...");
-  let intent;
-  try {
-    const semantics = await extractDiffSemantics(PROJECT_ROOT);
-    intent = semantics.intent;
-    console.log(`  Intent: ${intent.summary} (${intent.changeType})`);
-  } catch {
-    console.log("  (no git diff available, using unknown intent)");
-    intent = {
-      summary: "unknown change",
-      changeType: "unknown" as const,
-      expectedVisualChanges: [],
-      expectedA11yChanges: [],
-      affectedComponents: [],
-    };
-  }
-
-  // ---- Track 1: Dep graph ----
-  console.log("[Track 1] Building dependency graph...");
-  let affected;
-  try {
-    const graph = await buildDepGraph(PROJECT_ROOT, { languages: ["typescript", "moonbit"] });
-    const stats = graphStats(graph);
-    console.log(`  ${stats.totalFiles} files, ${stats.components} components`);
-    const changed = intent.affectedComponents;
-    affected = findAffectedComponents(graph, changed);
-    console.log(`  ${affected.length} components affected`);
-  } catch {
-    console.log("  (dep graph skipped)");
-    affected = [];
-  }
-
-  // ---- Track 2: Visual diff ----
-  console.log("[Track 2] Comparing screenshots...");
-  const baselineFiles = await listFiles(BASELINES_DIR, ".png");
-  const vrtDiffs: VrtDiff[] = [];
-
-  for (const baseFile of baselineFiles) {
-    const name = baseFile.replace(/\.png$/, "");
-    const snapFile = join(SNAPSHOTS_DIR, `${name}.png`);
-    if (!existsSync(snapFile)) {
-      console.log(`  MISSING: ${name} (no snapshot)`);
-      continue;
-    }
-
-    const snapshot = {
-      testId: name,
-      testTitle: name,
-      projectName: "vrt",
-      screenshotPath: snapFile,
-      baselinePath: join(BASELINES_DIR, baseFile),
-      status: "changed" as const,
-    };
-
-    const diff = await compareScreenshots(snapshot, { outputDir: OUTPUT_DIR });
-    if (diff && diff.diffPixels > 0) {
-      vrtDiffs.push(diff);
-      console.log(
-        `  CHANGED: ${name} — ${(diff.diffRatio * 100).toFixed(2)}% (${diff.regions.length} region(s))`
-      );
-    } else {
-      console.log(`  OK: ${name}`);
-    }
-  }
-
-  // ---- Track 3: A11y diff ----
-  console.log("[Track 3] Comparing a11y trees...");
-  const a11yDiffs: A11yDiff[] = [];
-  const baseA11yFiles = await listFiles(BASELINES_DIR, ".a11y.json");
-
-  for (const baseFile of baseA11yFiles) {
-    const name = baseFile.replace(/\.a11y\.json$/, "");
-    const snapA11yFile = join(SNAPSHOTS_DIR, `${name}.a11y.json`);
-    if (!existsSync(snapA11yFile)) continue;
-
-    try {
-      const baseRaw = JSON.parse(await readFile(join(BASELINES_DIR, baseFile), "utf-8"));
-      const snapRaw = JSON.parse(await readFile(snapA11yFile, "utf-8"));
-
-      if (!baseRaw || !snapRaw) continue;
-
-      const baseSnap = parsePlaywrightA11ySnapshot(name, name, baseRaw);
-      const snapSnap = parsePlaywrightA11ySnapshot(name, name, snapRaw);
-      const diff = diffA11yTrees(baseSnap, snapSnap);
-
-      if (diff.changes.length > 0) {
-        a11yDiffs.push(diff);
-        const emoji = diff.hasRegression ? "NG" : "~~";
-        console.log(
-          `  [${emoji}] ${name}: +${diff.stats.added}/-${diff.stats.removed}/~${diff.stats.modified}`
-        );
-      } else {
-        console.log(`  OK: ${name}`);
-      }
-
-      // A11y quality check on current snapshot
-      const issues = checkA11yTree(snapSnap.tree);
-      if (issues.length > 0) {
-        console.log(`  A11Y ISSUES in ${name}:`);
-        for (const issue of issues) {
-          console.log(`    [${issue.severity}] ${issue.rule}: ${issue.message}`);
-        }
-      }
-    } catch (err) {
-      console.log(`  SKIP: ${name} (parse error)`);
-    }
-  }
-
-  // ---- Load Expectations (if available) ----
-  let expectations: VrtExpectation | undefined;
-  if (existsSync(EXPECTATION_PATH)) {
-    expectations = await loadExpectation(EXPECTATION_PATH);
-    console.log(`\n[Expectations] Loaded: "${expectations.description}"`);
-    console.log(`  ${expectations.pages.length} page(s) with expectations`);
-    if (expectations.intent) {
-      // Merge partial intent (includes description -> summary fallback)
-      intent = {
-        ...intent,
-        ...expectations.intent,
-        summary: expectations.intent.summary ?? expectations.description,
-        expectedA11yChanges: expectations.intent.expectedA11yChanges ?? intent.expectedA11yChanges,
-        expectedVisualChanges: expectations.intent.expectedVisualChanges ?? intent.expectedVisualChanges,
-        affectedComponents: expectations.intent.affectedComponents ?? intent.affectedComponents,
-        changeType: expectations.intent.changeType ?? intent.changeType,
-      };
-      console.log(`  Intent: ${intent.summary} (${intent.changeType})`);
-    }
-  }
-
-  // ---- Cross-Validation ----
-  console.log("\n[Cross-Validation] Visual x A11y x Intent...");
-  const visualSemanticDiffs: VisualSemanticDiff[] = vrtDiffs.map(classifyVisualDiff);
-
-  // Collect all testIds (from diffs + expectations)
-  const allTestIds = new Set([
-    ...vrtDiffs.map((d) => d.snapshot.testId),
-    ...a11yDiffs.map((d) => d.testId),
-    ...(expectations?.pages.map((p) => p.testId) ?? []),
-  ]);
-
-  const crossValidations = [...allTestIds].map((testId) => {
-    const visDiff = visualSemanticDiffs.find((d) => d.testId === testId);
-    const a11yDiff = a11yDiffs.find((d) => d.testId === testId);
-    const pageExp = expectations?.pages.find((p) => p.testId === testId);
-
-    if (pageExp) {
-      return crossValidateWithExpectation(testId, pageExp, visDiff, a11yDiff, intent);
-    }
-    return crossValidate(testId, visDiff, a11yDiff, intent);
-  });
-
-  for (const cv of crossValidations) {
-    const icon = cv.recommendation === "approve" ? "OK"
-      : cv.recommendation === "reject" ? "NG" : "??";
-    console.log(`  [${icon}] ${cv.testId}: ${cv.reasoning}`);
-  }
-
-  // ---- Quality + Verdicts ----
-  console.log("\n[Verdict] Final verification...");
-  const snapshots = vrtDiffs.map((d) => d.snapshot);
-
-  // Exclude approved regressions from quality errors
-  const approvedTestIds = new Set(
-    crossValidations.filter((cv) => cv.recommendation === "approve").map((cv) => cv.testId)
-  );
-  const filteredCrossValidations = crossValidations.map((cv) => {
-    if (approvedTestIds.has(cv.testId) && cv.a11yDiff?.hasRegression) {
-      // Expected regression approved -> disable hasRegression for checks
-      return { ...cv, a11yDiff: { ...cv.a11yDiff, hasRegression: false } };
-    }
-    return cv;
-  });
-
-  const unresolvedSnapshots = snapshots.filter((s) => !approvedTestIds.has(s.testId));
-  const unresolvedDiffs = vrtDiffs.filter((d) => !approvedTestIds.has(d.snapshot.testId));
-  const qualityChecks = [
-    ...(await runQualityChecks(unresolvedSnapshots, unresolvedDiffs)),
-    ...crossValidationToQualityChecks(filteredCrossValidations),
-  ];
-
-  // Exclude approved diffs from agent loop
-  const unresolved = vrtDiffs.filter((d) => !approvedTestIds.has(d.snapshot.testId));
-  const agentResult = await runVerificationLoop(unresolved, intent, qualityChecks);
-
-  const ctx: UnifiedAgentContext = {
-    intent,
-    vrtDiffs,
-    a11yDiffs,
-    visualSemanticDiffs,
-    crossValidations,
-    verdicts: agentResult.verdicts,
-    qualityChecks,
+  const paths: VerifyPaths = {
+    projectRoot: PROJECT_ROOT,
+    baselinesDir: BASELINES_DIR,
+    snapshotsDir: SNAPSHOTS_DIR,
+    outputDir: OUTPUT_DIR,
+    reportPath: REPORT_PATH,
+    expectationPath: EXPECTATION_PATH,
   };
 
-  // Save report
-  await writeFile(REPORT_PATH, JSON.stringify(ctx, null, 2));
+  const result = await runVerifyPipeline(paths);
 
-  // Print summary
-  const approved = agentResult.verdicts.filter((v) => v.decision === "approve").length;
-  const rejected = agentResult.verdicts.filter((v) => v.decision === "reject").length;
-  const escalated = agentResult.verdicts.filter((v) => v.decision === "escalate").length;
-  const failedQuality = qualityChecks.filter((c) => !c.passed && c.severity === "error").length;
-
-  // Score
-  const score = scoreLoop(ctx, expectations, {
-    fixSteps: 1, // will be tracked across iterations
-    tokenUsage: 0, // placeholder — real value from agent metadata
-    startTime: 0,
-    endTime: Date.now(),
-  });
-
-  console.log("\n========================================");
-  console.log("  VRT + Semantic Verification Summary");
-  console.log("========================================");
-  console.log(`  Visual diffs:    ${vrtDiffs.length}`);
-  console.log(`  A11y diffs:      ${a11yDiffs.length}`);
-  console.log(`  Approved:        ${approved}`);
-  console.log(`  Rejected:        ${rejected}`);
-  console.log(`  Escalated:       ${escalated}`);
-  console.log(`  Quality errors:  ${failedQuality}`);
-  console.log("----------------------------------------");
-  console.log("  Scores:");
-  for (const d of score.details) {
-    console.log(`    ${d.category.padEnd(14)} ${d.score}/${d.maxScore}  ${d.reasoning}`);
-  }
-  console.log("========================================");
-
-  if (rejected > 0 || failedQuality > 0) {
+  if (!result.passed) {
     console.log("\nFAILED — Fix the issues and run `vrt capture && vrt verify` again.");
     console.log("Details: " + REPORT_PATH);
     process.exit(1);
-  } else if (escalated > 0) {
+  } else if (result.needsReview) {
     console.log("\nWARNING — Some changes need review. Run `vrt report` for details.");
     console.log("If changes are intentional, run `vrt approve` to update baselines.");
     process.exit(0);
-  } else if (vrtDiffs.length === 0 && a11yDiffs.length === 0) {
+  } else if (result.vrtDiffs.length === 0 && result.a11yDiffs.length === 0) {
     console.log("\nPASS — No visual or semantic changes detected.");
     process.exit(0);
   } else {

--- a/src/vrt-command-router.test.ts
+++ b/src/vrt-command-router.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatRootUsage, resolveRootCommand } from "./vrt-command-router.ts";
+
+describe("resolveRootCommand", () => {
+  it("routes workflow commands under an explicit namespace", () => {
+    const route = resolveRootCommand(["workflow", "verify"]);
+    assert.equal(route.kind, "workflow");
+    assert.deepEqual(route.argv, ["verify"]);
+  });
+
+  it("supports short aliases for workflow commands that do not collide", () => {
+    const route = resolveRootCommand(["verify"]);
+    assert.equal(route.kind, "workflow");
+    assert.deepEqual(route.argv, ["verify"]);
+  });
+
+  it("keeps detection report and workflow report distinct", () => {
+    const detection = resolveRootCommand(["report"]);
+    const workflow = resolveRootCommand(["workflow", "report"]);
+
+    assert.equal(detection.kind, "module");
+    assert.equal(detection.modulePath, "./detection-report.ts");
+    assert.equal(workflow.kind, "workflow");
+    assert.deepEqual(workflow.argv, ["report"]);
+  });
+
+  it("routes api commands under the api namespace", () => {
+    const route = resolveRootCommand(["api", "serve", "--port", "4567"]);
+    assert.equal(route.kind, "module");
+    assert.equal(route.modulePath, "./api-server.ts");
+    assert.deepEqual(route.argv, ["--port", "4567"]);
+  });
+
+  it("keeps serve and status aliases for backward compatibility", () => {
+    const serve = resolveRootCommand(["serve", "--port", "4567"]);
+    const status = resolveRootCommand(["status", "--url", "http://localhost:4567"]);
+
+    assert.equal(serve.kind, "module");
+    assert.equal(serve.modulePath, "./api-server.ts");
+    assert.deepEqual(serve.argv, ["--port", "4567"]);
+
+    assert.equal(status.kind, "status");
+    assert.deepEqual(status.argv, ["--url", "http://localhost:4567"]);
+  });
+
+  it("returns usage when workflow namespace is missing a subcommand", () => {
+    const route = resolveRootCommand(["workflow"]);
+    assert.equal(route.kind, "usage");
+    assert.equal(route.exitCode, 1);
+    assert.match(route.message, /workflow <command>/);
+  });
+});
+
+describe("formatRootUsage", () => {
+  it("documents grouped command categories", () => {
+    const usage = formatRootUsage();
+    assert.match(usage, /Workflow Commands:/);
+    assert.match(usage, /API Commands:/);
+    assert.match(usage, /workflow verify/);
+    assert.match(usage, /api serve/);
+  });
+});

--- a/src/vrt-command-router.ts
+++ b/src/vrt-command-router.ts
@@ -1,0 +1,193 @@
+export const WORKFLOW_COMMANDS = [
+  "init",
+  "capture",
+  "verify",
+  "approve",
+  "report",
+  "graph",
+  "affected",
+  "introspect",
+  "spec-verify",
+  "expect",
+] as const;
+
+export type WorkflowCommand = typeof WORKFLOW_COMMANDS[number];
+
+type ModuleRoute = {
+  kind: "module";
+  modulePath: string;
+  argv: string[];
+};
+
+type WorkflowRoute = {
+  kind: "workflow";
+  argv: string[];
+};
+
+type StatusRoute = {
+  kind: "status";
+  argv: string[];
+};
+
+type DiscoverRoute = {
+  kind: "discover";
+  argv: string[];
+};
+
+type UsageRoute = {
+  kind: "usage";
+  message: string;
+  exitCode: number;
+};
+
+export type RootCommandRoute =
+  | ModuleRoute
+  | WorkflowRoute
+  | StatusRoute
+  | DiscoverRoute
+  | UsageRoute;
+
+const ROOT_MODULE_COMMANDS: Record<string, string> = {
+  compare: "./migration-compare.ts",
+  bench: "./css-challenge-bench.ts",
+  report: "./detection-report.ts",
+  snapshot: "./snapshot.ts",
+  elements: "./element-compare.ts",
+  smoke: "./smoke-runner.ts",
+};
+
+const WORKFLOW_ALIAS_COMMANDS = new Set<WorkflowCommand>([
+  "init",
+  "capture",
+  "verify",
+  "approve",
+  "graph",
+  "affected",
+  "introspect",
+  "spec-verify",
+  "expect",
+]);
+
+export function formatWorkflowUsage(): string {
+  return `vrt workflow <command>
+
+Commands:
+  init         Create baseline screenshots + a11y trees
+  capture      Take current snapshots
+  verify       Compare snapshots against baselines
+  approve      Promote current snapshots to new baselines
+  report       Show the latest verification report
+  graph        Display dependency graph
+  affected     Show components affected by current changes
+  introspect   Generate spec.json from current a11y snapshots
+  spec-verify  Verify spec.json invariants against current state
+  expect       Auto-generate expectation.json from baseline vs snapshot diff`;
+}
+
+export function formatRootUsage(): string {
+  return `vrt — Visual Regression Testing Harness
+
+Core Commands:
+  compare <before> <after>    Compare HTML files or URLs across viewports
+  snapshot <url...>           Capture multi-viewport snapshots with baseline diff
+  elements [options]          Element-level comparison with shift isolation
+  smoke <file-or-url>         A11y-driven smoke test
+  discover <file>             Discover responsive breakpoints from HTML/CSS
+  bench [options]             CSS challenge benchmark
+  report                      Detection pattern report
+
+Workflow Commands:
+  workflow <command>          Stateful baseline/snapshot verification workflow
+  workflow verify             Compare current snapshots against baselines
+  workflow report             Show the latest verification report
+
+API Commands:
+  api serve [--port N]        Start the HTTP API server
+  api status [--url URL]      Check HTTP API server status
+
+Compatibility Aliases:
+  serve                       Alias for \`vrt api serve\`
+  status                      Alias for \`vrt api status\`
+  init|capture|verify|approve
+  graph|affected|introspect|spec-verify|expect
+                              Alias for \`vrt workflow <command>\`
+
+Examples:
+  vrt compare before.html after.html
+  vrt snapshot http://localhost:3000/ --output snapshots/
+  vrt workflow verify
+  vrt workflow report
+  vrt api serve --port 3456`;
+}
+
+export function resolveRootCommand(args: string[]): RootCommandRoute {
+  const [command, ...rest] = args;
+
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    return { kind: "usage", message: formatRootUsage(), exitCode: 0 };
+  }
+
+  if (command in ROOT_MODULE_COMMANDS) {
+    return {
+      kind: "module",
+      modulePath: ROOT_MODULE_COMMANDS[command]!,
+      argv: rest,
+    };
+  }
+
+  if (command === "discover") {
+    return { kind: "discover", argv: rest };
+  }
+
+  if (command === "workflow") {
+    if (!rest[0] || rest[0] === "help" || rest[0] === "--help" || rest[0] === "-h") {
+      return {
+        kind: "usage",
+        message: formatWorkflowUsage(),
+        exitCode: rest[0] ? 0 : 1,
+      };
+    }
+    return { kind: "workflow", argv: rest };
+  }
+
+  if (command === "api") {
+    const [apiCommand, ...apiRest] = rest;
+    if (!apiCommand || apiCommand === "help" || apiCommand === "--help" || apiCommand === "-h") {
+      return {
+        kind: "usage",
+        message: `vrt api <command>\n\nCommands:\n  serve [--port N]\n  status [--url URL]`,
+        exitCode: apiCommand ? 0 : 1,
+      };
+    }
+
+    if (apiCommand === "serve") {
+      return { kind: "module", modulePath: "./api-server.ts", argv: apiRest };
+    }
+    if (apiCommand === "status") {
+      return { kind: "status", argv: apiRest };
+    }
+
+    return {
+      kind: "usage",
+      message: `Unknown api command: ${apiCommand}\n\n${formatRootUsage()}`,
+      exitCode: 1,
+    };
+  }
+
+  if (command === "serve") {
+    return { kind: "module", modulePath: "./api-server.ts", argv: rest };
+  }
+  if (command === "status") {
+    return { kind: "status", argv: rest };
+  }
+
+  if (WORKFLOW_ALIAS_COMMANDS.has(command as WorkflowCommand)) {
+    return { kind: "workflow", argv: [command, ...rest] };
+  }
+
+  return {
+    kind: "usage",
+    message: `Unknown command: ${command}\n\n${formatRootUsage()}`,
+    exitCode: 1,
+  };
+}

--- a/src/vrt-reasoning-pipeline.ts
+++ b/src/vrt-reasoning-pipeline.ts
@@ -9,9 +9,9 @@
  *   const analysis = await pipeline.analyze(heatmapBase64, textReport);
  *   const fix = await pipeline.suggestFix(analysis, cssSource);
  */
-import { createUnifiedLLMClient, type UnifiedLLMClient, type LLMResponse } from "./llm-client.ts";
-import { createVlmClient, resolveModel, type VlmClient, type VlmResponse } from "./vlm-client.ts";
-import { resizeBase64Png, type ResolutionPreset, RESOLUTION_PRESETS } from "./image-resize.ts";
+import { createUnifiedLLMClient } from "./llm-client.ts";
+import { createVlmClient, resolveModel, type VlmClient } from "./vlm-client.ts";
+import { resizeBase64Png, type ResolutionPreset } from "./image-resize.ts";
 
 // ---- Types ----
 

--- a/src/vrt-verify.ts
+++ b/src/vrt-verify.ts
@@ -1,0 +1,294 @@
+/**
+ * VRT Verify Pipeline
+ *
+ * 3-track parallel verification:
+ *   Track 1: Intent extraction + dependency graph
+ *   Track 2: Visual pixel diff
+ *   Track 3: A11y tree diff
+ * Then: Cross-validation, quality checks, verdicts, scoring.
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { buildDepGraph, findAffectedComponents, graphStats } from "./dep-graph.ts";
+import { extractDiffSemantics } from "./intent.ts";
+import { compareScreenshots } from "./heatmap.ts";
+import { classifyVisualDiff } from "./visual-semantic.ts";
+import { diffA11yTrees, parsePlaywrightA11ySnapshot, checkA11yTree } from "./a11y-semantic.ts";
+import { crossValidate, crossValidationToQualityChecks } from "./cross-validation.ts";
+import { loadExpectation, crossValidateWithExpectation, scoreLoop } from "./expectation.ts";
+import { runQualityChecks } from "./quality.ts";
+import { runVerificationLoop } from "./agent.ts";
+import type { VrtDiff, A11yDiff, VisualSemanticDiff, UnifiedAgentContext, VrtExpectation, ChangeIntent } from "./types.ts";
+
+export interface VerifyPaths {
+  projectRoot: string;
+  baselinesDir: string;
+  snapshotsDir: string;
+  outputDir: string;
+  reportPath: string;
+  expectationPath: string;
+}
+
+export interface VerifyResult {
+  context: UnifiedAgentContext;
+  vrtDiffs: VrtDiff[];
+  a11yDiffs: A11yDiff[];
+  passed: boolean;
+  needsReview: boolean;
+}
+
+export async function runVerifyPipeline(paths: VerifyPaths): Promise<VerifyResult> {
+  const { projectRoot, baselinesDir, snapshotsDir, outputDir, reportPath, expectationPath } = paths;
+
+  if (!existsSync(baselinesDir)) {
+    throw new Error("No baselines found. Run `vrt init` first.");
+  }
+  if (!existsSync(snapshotsDir)) {
+    throw new Error("No snapshots found. Run `vrt capture` first.");
+  }
+
+  await mkdir(outputDir, { recursive: true });
+
+  // ---- Track 1: Intent ----
+  console.log("[Track 1] Extracting change intent...");
+  let intent: ChangeIntent;
+  try {
+    const semantics = await extractDiffSemantics(projectRoot);
+    intent = semantics.intent;
+    console.log(`  Intent: ${intent.summary} (${intent.changeType})`);
+  } catch {
+    console.log("  (no git diff available, using unknown intent)");
+    intent = {
+      summary: "unknown change",
+      changeType: "unknown" as const,
+      expectedVisualChanges: [],
+      expectedA11yChanges: [],
+      affectedComponents: [],
+    };
+  }
+
+  // ---- Track 1: Dep graph ----
+  console.log("[Track 1] Building dependency graph...");
+  let affected;
+  try {
+    const graph = await buildDepGraph(projectRoot, { languages: ["typescript", "moonbit"] });
+    const stats = graphStats(graph);
+    console.log(`  ${stats.totalFiles} files, ${stats.components} components`);
+    const changed = intent.affectedComponents;
+    affected = findAffectedComponents(graph, changed);
+    console.log(`  ${affected.length} components affected`);
+  } catch {
+    console.log("  (dep graph skipped)");
+    affected = [];
+  }
+
+  // ---- Track 2: Visual diff ----
+  console.log("[Track 2] Comparing screenshots...");
+  const baselineFiles = await listFiles(baselinesDir, ".png");
+  const vrtDiffs: VrtDiff[] = [];
+
+  for (const baseFile of baselineFiles) {
+    const name = baseFile.replace(/\.png$/, "");
+    const snapFile = join(snapshotsDir, `${name}.png`);
+    if (!existsSync(snapFile)) {
+      console.log(`  MISSING: ${name} (no snapshot)`);
+      continue;
+    }
+
+    const snapshot = {
+      testId: name,
+      testTitle: name,
+      projectName: "vrt",
+      screenshotPath: snapFile,
+      baselinePath: join(baselinesDir, baseFile),
+      status: "changed" as const,
+    };
+
+    const diff = await compareScreenshots(snapshot, { outputDir });
+    if (diff && diff.diffPixels > 0) {
+      vrtDiffs.push(diff);
+      console.log(
+        `  CHANGED: ${name} — ${(diff.diffRatio * 100).toFixed(2)}% (${diff.regions.length} region(s))`
+      );
+    } else {
+      console.log(`  OK: ${name}`);
+    }
+  }
+
+  // ---- Track 3: A11y diff ----
+  console.log("[Track 3] Comparing a11y trees...");
+  const a11yDiffs: A11yDiff[] = [];
+  const baseA11yFiles = await listFiles(baselinesDir, ".a11y.json");
+
+  for (const baseFile of baseA11yFiles) {
+    const name = baseFile.replace(/\.a11y\.json$/, "");
+    const snapA11yFile = join(snapshotsDir, `${name}.a11y.json`);
+    if (!existsSync(snapA11yFile)) continue;
+
+    try {
+      const baseRaw = JSON.parse(await readFile(join(baselinesDir, baseFile), "utf-8"));
+      const snapRaw = JSON.parse(await readFile(snapA11yFile, "utf-8"));
+
+      if (!baseRaw || !snapRaw) continue;
+
+      const baseSnap = parsePlaywrightA11ySnapshot(name, name, baseRaw);
+      const snapSnap = parsePlaywrightA11ySnapshot(name, name, snapRaw);
+      const diff = diffA11yTrees(baseSnap, snapSnap);
+
+      if (diff.changes.length > 0) {
+        a11yDiffs.push(diff);
+        const emoji = diff.hasRegression ? "NG" : "~~";
+        console.log(
+          `  [${emoji}] ${name}: +${diff.stats.added}/-${diff.stats.removed}/~${diff.stats.modified}`
+        );
+      } else {
+        console.log(`  OK: ${name}`);
+      }
+
+      // A11y quality check on current snapshot
+      const issues = checkA11yTree(snapSnap.tree);
+      if (issues.length > 0) {
+        console.log(`  A11Y ISSUES in ${name}:`);
+        for (const issue of issues) {
+          console.log(`    [${issue.severity}] ${issue.rule}: ${issue.message}`);
+        }
+      }
+    } catch (err) {
+      console.log(`  SKIP: ${name} (parse error)`);
+    }
+  }
+
+  // ---- Load Expectations (if available) ----
+  let expectations: VrtExpectation | undefined;
+  if (existsSync(expectationPath)) {
+    expectations = await loadExpectation(expectationPath);
+    console.log(`\n[Expectations] Loaded: "${expectations.description}"`);
+    console.log(`  ${expectations.pages.length} page(s) with expectations`);
+    if (expectations.intent) {
+      intent = {
+        ...intent,
+        ...expectations.intent,
+        summary: expectations.intent.summary ?? expectations.description,
+        expectedA11yChanges: expectations.intent.expectedA11yChanges ?? intent.expectedA11yChanges,
+        expectedVisualChanges: expectations.intent.expectedVisualChanges ?? intent.expectedVisualChanges,
+        affectedComponents: expectations.intent.affectedComponents ?? intent.affectedComponents,
+        changeType: expectations.intent.changeType ?? intent.changeType,
+      };
+      console.log(`  Intent: ${intent.summary} (${intent.changeType})`);
+    }
+  }
+
+  // ---- Cross-Validation ----
+  console.log("\n[Cross-Validation] Visual x A11y x Intent...");
+  const visualSemanticDiffs: VisualSemanticDiff[] = vrtDiffs.map(classifyVisualDiff);
+
+  const allTestIds = new Set([
+    ...vrtDiffs.map((d) => d.snapshot.testId),
+    ...a11yDiffs.map((d) => d.testId),
+    ...(expectations?.pages.map((p) => p.testId) ?? []),
+  ]);
+
+  const crossValidations = [...allTestIds].map((testId) => {
+    const visDiff = visualSemanticDiffs.find((d) => d.testId === testId);
+    const a11yDiff = a11yDiffs.find((d) => d.testId === testId);
+    const pageExp = expectations?.pages.find((p) => p.testId === testId);
+
+    if (pageExp) {
+      return crossValidateWithExpectation(testId, pageExp, visDiff, a11yDiff, intent);
+    }
+    return crossValidate(testId, visDiff, a11yDiff, intent);
+  });
+
+  for (const cv of crossValidations) {
+    const icon = cv.recommendation === "approve" ? "OK"
+      : cv.recommendation === "reject" ? "NG" : "??";
+    console.log(`  [${icon}] ${cv.testId}: ${cv.reasoning}`);
+  }
+
+  // ---- Quality + Verdicts ----
+  console.log("\n[Verdict] Final verification...");
+  const snapshots = vrtDiffs.map((d) => d.snapshot);
+
+  const approvedTestIds = new Set(
+    crossValidations.filter((cv) => cv.recommendation === "approve").map((cv) => cv.testId)
+  );
+  const filteredCrossValidations = crossValidations.map((cv) => {
+    if (approvedTestIds.has(cv.testId) && cv.a11yDiff?.hasRegression) {
+      return { ...cv, a11yDiff: { ...cv.a11yDiff, hasRegression: false } };
+    }
+    return cv;
+  });
+
+  const unresolvedSnapshots = snapshots.filter((s) => !approvedTestIds.has(s.testId));
+  const unresolvedDiffs = vrtDiffs.filter((d) => !approvedTestIds.has(d.snapshot.testId));
+  const qualityChecks = [
+    ...(await runQualityChecks(unresolvedSnapshots, unresolvedDiffs)),
+    ...crossValidationToQualityChecks(filteredCrossValidations),
+  ];
+
+  const unresolved = vrtDiffs.filter((d) => !approvedTestIds.has(d.snapshot.testId));
+  const agentResult = await runVerificationLoop(unresolved, intent, qualityChecks);
+
+  const ctx: UnifiedAgentContext = {
+    intent,
+    vrtDiffs,
+    a11yDiffs,
+    visualSemanticDiffs,
+    crossValidations,
+    verdicts: agentResult.verdicts,
+    qualityChecks,
+  };
+
+  // Save report
+  await writeFile(reportPath, JSON.stringify(ctx, null, 2));
+
+  // Score
+  const score = scoreLoop(ctx, expectations, {
+    fixSteps: 1,
+    tokenUsage: 0,
+    startTime: 0,
+    endTime: Date.now(),
+  });
+
+  // Print summary
+  const approved = agentResult.verdicts.filter((v) => v.decision === "approve").length;
+  const rejected = agentResult.verdicts.filter((v) => v.decision === "reject").length;
+  const escalated = agentResult.verdicts.filter((v) => v.decision === "escalate").length;
+  const failedQuality = qualityChecks.filter((c) => !c.passed && c.severity === "error").length;
+
+  console.log("\n========================================");
+  console.log("  VRT + Semantic Verification Summary");
+  console.log("========================================");
+  console.log(`  Visual diffs:    ${vrtDiffs.length}`);
+  console.log(`  A11y diffs:      ${a11yDiffs.length}`);
+  console.log(`  Approved:        ${approved}`);
+  console.log(`  Rejected:        ${rejected}`);
+  console.log(`  Escalated:       ${escalated}`);
+  console.log(`  Quality errors:  ${failedQuality}`);
+  console.log("----------------------------------------");
+  console.log("  Scores:");
+  for (const d of score.details) {
+    console.log(`    ${d.category.padEnd(14)} ${d.score}/${d.maxScore}  ${d.reasoning}`);
+  }
+  console.log("========================================");
+
+  return {
+    context: ctx,
+    vrtDiffs,
+    a11yDiffs,
+    passed: rejected === 0 && failedQuality === 0,
+    needsReview: escalated > 0,
+  };
+}
+
+import { readdir } from "node:fs/promises";
+
+async function listFiles(dir: string, suffix: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir);
+    return entries.filter((e) => e.endsWith(suffix));
+  } catch {
+    return [];
+  }
+}

--- a/src/vrt.ts
+++ b/src/vrt.ts
@@ -1,66 +1,43 @@
 #!/usr/bin/env node
 /**
  * vrt -- unified CLI entry point
- *
- * Usage:
- *   vrt compare <before> <after> [options]
- *   vrt bench [options]
- *   vrt report
- *   vrt discover <file>
- *   vrt smoke <file-or-url> [options]
- *   vrt serve [--port 3456]
- *   vrt status [--url http://localhost:3456]
  */
-
-const args = process.argv.slice(2);
-const command = args[0];
-const rest = args.slice(1);
+import { resolveRootCommand } from "./vrt-command-router.ts";
 
 async function main() {
-  switch (command) {
-    case "compare":
-      process.argv = [process.argv[0], "migration-compare", ...rest];
-      await import("./migration-compare.ts");
-      break;
-    case "bench":
-      process.argv = [process.argv[0], "css-challenge-bench", ...rest];
-      await import("./css-challenge-bench.ts");
-      break;
-    case "report":
-      await import("./detection-report.ts");
-      break;
+  const route = resolveRootCommand(process.argv.slice(2));
+
+  switch (route.kind) {
+    case "module":
+      await runModuleCommand(route.modulePath, route.argv);
+      return;
     case "discover":
-      await runDiscover(rest);
-      break;
-    case "snapshot":
-      process.argv = [process.argv[0], "snapshot", ...rest];
-      await import("./snapshot.ts");
-      break;
-    case "elements":
-      process.argv = [process.argv[0], "element-compare", ...rest];
-      await import("./element-compare.ts");
-      break;
-    case "smoke":
-      process.argv = [process.argv[0], "smoke-runner", ...rest];
-      await import("./smoke-runner.ts");
-      break;
-    case "serve":
-      process.argv = [process.argv[0], "api-server", ...rest];
-      await import("./api-server.ts");
-      break;
+      await runDiscover(route.argv);
+      return;
     case "status":
-      await runStatus(rest);
-      break;
-    case "help":
-    case "--help":
-    case "-h":
-      printUsage();
-      break;
+      await runStatus(route.argv);
+      return;
+    case "workflow": {
+      const { runWorkflowCli } = await import("./vrt-cli.ts");
+      await runWorkflowCli(route.argv);
+      return;
+    }
+    case "usage":
+      if (route.exitCode === 0) {
+        console.log(route.message);
+      } else {
+        console.error(route.message);
+        process.exit(route.exitCode);
+      }
+      return;
     default:
-      if (command) console.error(`Unknown command: ${command}\n`);
-      printUsage();
-      process.exit(command ? 1 : 0);
+      route satisfies never;
   }
+}
+
+async function runModuleCommand(modulePath: string, argv: string[]) {
+  process.argv = [process.argv[0], modulePath, ...argv];
+  await import(modulePath);
 }
 
 async function runDiscover(args: string[]) {
@@ -95,32 +72,6 @@ async function runStatus(args: string[]) {
     console.error(`Server not available at ${url}`);
     process.exit(1);
   }
-}
-
-function printUsage() {
-  console.log(`
-\x1b[1mvrt\x1b[0m — Visual Regression Testing Harness
-
-\x1b[1mCommands:\x1b[0m
-  compare <before> <after>    Compare HTML files across viewports
-  elements [options]          Element-level comparison (avoids cascade shifts)
-  bench [options]             CSS challenge benchmark
-  report                      Detection pattern report
-  discover <file>             Discover breakpoints from HTML/CSS
-  smoke <file-or-url>         A11y-driven smoke test
-  serve [--port N]            Start API server
-  status [--url URL]          Check API server status
-
-\x1b[1mExamples:\x1b[0m
-  vrt compare before.html after.html
-  vrt compare --dir fixtures/migration/reset-css --baseline normalize.html --variants modern.html destyle.html
-  vrt bench --fixture page --trials 30
-  vrt bench --mode selector --backend crater
-  vrt discover page.html
-  vrt smoke page.html --max-actions 20 --seed 42
-  vrt smoke --url https://example.com --mode reasoning
-  vrt serve --port 3456
-`);
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- organize the public `vrt` CLI surface into `core`, `workflow`, and `api` groups
- add a dedicated command router with tests for routing and help output
- clarify README usage, workflow prerequisites, and HTTP API examples

## Validation
- `pnpm test`
