### PR TITLE
[codex] Improve snapshot workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/
 # Snapshot URLs (creates baseline on first run, diffs on subsequent runs)
 vrt snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
 
+# Use explicit labels when URL-derived names are not ideal
+vrt snapshot http://localhost:3000/issues?severity=critical --label critical-issues
+
+# Fail CI when diffs or new baselines are detected
+vrt snapshot http://localhost:3000/ --fail-on-diff --fail-on-new-baseline --max-diff-ratio 0.01
+
+# Promote accepted snapshot diffs to the new baseline
+vrt snapshot approve --output snapshots/
+
+# Load snapshot targets from vrt.config.json
+vrt snapshot
+
 # Workflow verification loop
 vrt workflow init
 vrt workflow capture
@@ -67,12 +79,35 @@ just fix-loop --fixture page --seed 42
 vrt compare <before.html> <after.html>      # Migration VRT for files or URLs
 vrt png-diff <baseline.png> <current.png>   # Direct PNG pixel diff + heatmap
 vrt snapshot <url1> [url2] ...              # Multi-viewport snapshot + diff
+vrt snapshot approve                        # Promote *-current.png to *-baseline.png
 vrt elements [options]                      # Element-level diff with shift isolation
 vrt smoke <file-or-url>                     # A11y-driven random interaction test
 vrt discover <html-file>                    # Breakpoint discovery from HTML/CSS
 vrt bench [options]                         # CSS challenge benchmark
 vrt report                                  # Detection pattern report
 ```
+
+Snapshot labels are query-aware by default, so `/issues` and `/issues?severity=critical` no longer share the same baseline name.
+Use repeated `--label` flags to override labels explicitly when needed.
+The same `--label` flag can be used with `vrt snapshot approve` to approve only selected labels.
+
+Minimal `vrt.config.json`:
+
+```json
+{
+  "baseUrl": "http://localhost:3000",
+  "routes": [
+    "/",
+    { "path": "/issues?severity=critical", "label": "critical-issues" }
+  ],
+  "outputDir": "test-results/snapshots/sample-webapp-2026",
+  "threshold": 0.1,
+  "failOnDiff": true,
+  "maxDiffRatio": 0.01
+}
+```
+
+When `vrt.config.json` exists in the current directory, `vrt snapshot` loads it automatically. Use `--config <path>` to point at another file, and pass URLs or flags directly when you want CLI values to override config defaults.
 
 ### Workflow Commands
 

--- a/src/snapshot-approve.test.ts
+++ b/src/snapshot-approve.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it } from "node:test";
+import { approveSnapshotsFromReport } from "./snapshot-approve.ts";
+
+describe("approveSnapshotsFromReport", () => {
+  it("promotes all current screenshots to baseline paths from the report", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vrt-snapshot-approve-"));
+    const currentDesktop = join(dir, "home-desktop-current.png");
+    const baselineDesktop = join(dir, "home-desktop-baseline.png");
+    const currentMobile = join(dir, "home-mobile-current.png");
+    const baselineMobile = join(dir, "home-mobile-baseline.png");
+    const reportPath = join(dir, "snapshot-report.json");
+
+    await writeFile(currentDesktop, "desktop-current", "utf-8");
+    await writeFile(baselineDesktop, "desktop-old", "utf-8");
+    await writeFile(currentMobile, "mobile-current", "utf-8");
+    await writeFile(baselineMobile, "mobile-old", "utf-8");
+    await writeFile(reportPath, JSON.stringify({
+      results: [
+        {
+          label: "home",
+          viewport: "desktop",
+          screenshotPath: currentDesktop,
+          baselinePath: baselineDesktop,
+          isNew: false,
+        },
+        {
+          label: "home",
+          viewport: "mobile",
+          screenshotPath: currentMobile,
+          baselinePath: baselineMobile,
+          isNew: false,
+        },
+      ],
+    }), "utf-8");
+
+    const result = await approveSnapshotsFromReport(reportPath, []);
+
+    assert.equal(result.updated, 2);
+    assert.deepEqual(result.labels, ["home"]);
+    assert.equal(await readFile(baselineDesktop, "utf-8"), "desktop-current");
+    assert.equal(await readFile(baselineMobile, "utf-8"), "mobile-current");
+  });
+
+  it("filters by label when requested", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vrt-snapshot-approve-"));
+    const currentHome = join(dir, "home-desktop-current.png");
+    const baselineHome = join(dir, "home-desktop-baseline.png");
+    const currentIssues = join(dir, "critical-issues-desktop-current.png");
+    const baselineIssues = join(dir, "critical-issues-desktop-baseline.png");
+    const reportPath = join(dir, "snapshot-report.json");
+
+    await writeFile(currentHome, "home-current", "utf-8");
+    await writeFile(baselineHome, "home-old", "utf-8");
+    await writeFile(currentIssues, "issues-current", "utf-8");
+    await writeFile(baselineIssues, "issues-old", "utf-8");
+    await writeFile(reportPath, JSON.stringify({
+      results: [
+        {
+          label: "home",
+          viewport: "desktop",
+          screenshotPath: currentHome,
+          baselinePath: baselineHome,
+          isNew: false,
+        },
+        {
+          label: "critical-issues",
+          viewport: "desktop",
+          screenshotPath: currentIssues,
+          baselinePath: baselineIssues,
+          isNew: false,
+        },
+      ],
+    }), "utf-8");
+
+    const result = await approveSnapshotsFromReport(reportPath, ["critical-issues"]);
+
+    assert.equal(result.updated, 1);
+    assert.deepEqual(result.labels, ["critical-issues"]);
+    assert.equal(await readFile(baselineHome, "utf-8"), "home-old");
+    assert.equal(await readFile(baselineIssues, "utf-8"), "issues-current");
+  });
+
+  it("derives a baseline path when the report entry omits it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vrt-snapshot-approve-"));
+    const currentDesktop = join(dir, "home-desktop-current.png");
+    const reportPath = join(dir, "snapshot-report.json");
+
+    await writeFile(currentDesktop, "desktop-current", "utf-8");
+    await writeFile(reportPath, JSON.stringify({
+      results: [
+        {
+          label: "home",
+          viewport: "desktop",
+          screenshotPath: currentDesktop,
+          isNew: true,
+        },
+      ],
+    }), "utf-8");
+
+    const result = await approveSnapshotsFromReport(reportPath, []);
+
+    assert.equal(result.updated, 1);
+    assert.equal(
+      await readFile(join(dir, "home-desktop-baseline.png"), "utf-8"),
+      "desktop-current",
+    );
+  });
+
+  it("fails when the requested label does not exist in the report", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vrt-snapshot-approve-"));
+    const currentDesktop = join(dir, "home-desktop-current.png");
+    const baselineDesktop = join(dir, "home-desktop-baseline.png");
+    const reportPath = join(dir, "snapshot-report.json");
+
+    await writeFile(currentDesktop, "desktop-current", "utf-8");
+    await writeFile(baselineDesktop, "desktop-old", "utf-8");
+    await writeFile(reportPath, JSON.stringify({
+      results: [
+        {
+          label: "home",
+          viewport: "desktop",
+          screenshotPath: currentDesktop,
+          baselinePath: baselineDesktop,
+          isNew: false,
+        },
+      ],
+    }), "utf-8");
+
+    await assert.rejects(
+      () => approveSnapshotsFromReport(reportPath, ["unknown"]),
+      /No snapshot results matched --label filters: unknown/,
+    );
+  });
+});

--- a/src/snapshot-approve.ts
+++ b/src/snapshot-approve.ts
@@ -1,0 +1,72 @@
+import { copyFile, readFile } from "node:fs/promises";
+
+export interface SnapshotApproveEntry {
+  label: string;
+  viewport: string;
+  currentPath: string;
+  baselinePath: string;
+}
+
+export interface SnapshotApproveResult {
+  updated: number;
+  labels: string[];
+  entries: SnapshotApproveEntry[];
+}
+
+interface SnapshotReportEntry {
+  label: string;
+  viewport: string;
+  screenshotPath: string;
+  baselinePath?: string;
+}
+
+interface SnapshotReportFile {
+  results: SnapshotReportEntry[];
+}
+
+function deriveBaselinePath(currentPath: string): string {
+  if (!currentPath.endsWith("-current.png")) {
+    throw new Error(`Expected snapshot current PNG path, got: ${currentPath}`);
+  }
+  return currentPath.replace(/-current\.png$/u, "-baseline.png");
+}
+
+function resolveApproveEntries(
+  report: SnapshotReportFile,
+  labelFilters: string[],
+): SnapshotApproveEntry[] {
+  const normalizedFilters = [...new Set(labelFilters)];
+  const results = normalizedFilters.length === 0
+    ? report.results
+    : report.results.filter((entry) => normalizedFilters.includes(entry.label));
+
+  if (normalizedFilters.length > 0 && results.length === 0) {
+    throw new Error(`No snapshot results matched --label filters: ${normalizedFilters.join(", ")}`);
+  }
+
+  return results.map((entry) => ({
+    label: entry.label,
+    viewport: entry.viewport,
+    currentPath: entry.screenshotPath,
+    baselinePath: entry.baselinePath ?? deriveBaselinePath(entry.screenshotPath),
+  }));
+}
+
+export async function approveSnapshotsFromReport(
+  reportPath: string,
+  labelFilters: string[],
+): Promise<SnapshotApproveResult> {
+  const raw = await readFile(reportPath, "utf-8");
+  const report = JSON.parse(raw) as SnapshotReportFile;
+  const entries = resolveApproveEntries(report, labelFilters);
+
+  for (const entry of entries) {
+    await copyFile(entry.currentPath, entry.baselinePath);
+  }
+
+  return {
+    updated: entries.length,
+    labels: [...new Set(entries.map((entry) => entry.label))],
+    entries,
+  };
+}

--- a/src/snapshot-cli.test.ts
+++ b/src/snapshot-cli.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  parseSnapshotCliArgs,
+  parseSnapshotConfig,
+  determineSnapshotExitCode,
+  resolveSnapshotLabels,
+  urlToSnapshotLabel,
+} from "./snapshot-cli.ts";
+
+describe("urlToSnapshotLabel", () => {
+  it("includes canonicalized query params in the default label", () => {
+    assert.equal(
+      urlToSnapshotLabel("http://localhost:3000/?severity=critical&view=list"),
+      "localhost_3000_root__query_severity_critical__view_list",
+    );
+  });
+
+  it("normalizes query param order so equivalent URLs map to the same label", () => {
+    const a = urlToSnapshotLabel("http://localhost:3000/issues?view=list&severity=critical");
+    const b = urlToSnapshotLabel("http://localhost:3000/issues?severity=critical&view=list");
+
+    assert.equal(a, b);
+  });
+
+  it("includes hash fragments so hash-routed pages do not collide", () => {
+    assert.equal(
+      urlToSnapshotLabel("http://localhost:3000/#/settings/profile"),
+      "localhost_3000_root__hash_settings_profile",
+    );
+  });
+});
+
+describe("resolveSnapshotLabels", () => {
+  it("uses an explicit label for a single URL", () => {
+    assert.deepEqual(
+      resolveSnapshotLabels(["http://localhost:3000/"], ["home"]),
+      ["home"],
+    );
+  });
+
+  it("supports one explicit label per URL", () => {
+    assert.deepEqual(
+      resolveSnapshotLabels(
+        ["http://localhost:3000/", "http://localhost:3000/issues?severity=critical"],
+        ["home", "critical-issues"],
+      ),
+      ["home", "critical-issues"],
+    );
+  });
+
+  it("rejects mismatched label counts", () => {
+    assert.throws(
+      () => resolveSnapshotLabels(
+        ["http://localhost:3000/", "http://localhost:3000/issues"],
+        ["home"],
+      ),
+      /--label must be provided either once for a single URL or once per URL/i,
+    );
+  });
+});
+
+describe("determineSnapshotExitCode", () => {
+  it("does not fail by default", () => {
+    const result = determineSnapshotExitCode(
+      [{ label: "home", viewport: "desktop", isNew: false, diffRatio: 0.12 }],
+      {},
+    );
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.reasons, []);
+  });
+
+  it("fails when diff is detected under --fail-on-diff", () => {
+    const result = determineSnapshotExitCode(
+      [{ label: "home", viewport: "desktop", isNew: false, diffRatio: 0.12 }],
+      { failOnDiff: true },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.reasons[0] ?? "", /diff detected/i);
+  });
+
+  it("fails when a new baseline is created under --fail-on-new-baseline", () => {
+    const result = determineSnapshotExitCode(
+      [{ label: "home", viewport: "desktop", isNew: true }],
+      { failOnNewBaseline: true },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.reasons[0] ?? "", /new baseline/i);
+  });
+
+  it("fails when diff ratio exceeds the configured threshold", () => {
+    const result = determineSnapshotExitCode(
+      [
+        { label: "home", viewport: "desktop", isNew: false, diffRatio: 0.009 },
+        { label: "home", viewport: "mobile", isNew: false, diffRatio: 0.025 },
+      ],
+      { maxDiffRatio: 0.01 },
+    );
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.reasons[0] ?? "", /max diff ratio/i);
+  });
+
+  it("accepts ratios up to the configured threshold", () => {
+    const result = determineSnapshotExitCode(
+      [{ label: "home", viewport: "desktop", isNew: false, diffRatio: 0.01 }],
+      { maxDiffRatio: 0.01 },
+    );
+
+    assert.equal(result.exitCode, 0);
+  });
+});
+
+describe("parseSnapshotConfig", () => {
+  it("parses baseUrl, routes, outputDir, and threshold from JSON", () => {
+    const config = parseSnapshotConfig(`{
+      "baseUrl": "http://localhost:3000",
+      "routes": [
+        "/",
+        { "path": "/issues?severity=critical", "label": "critical-issues" }
+      ],
+      "outputDir": "artifacts/snapshots",
+      "threshold": 0.2,
+      "mask": [".hero", ".badge"],
+      "failOnDiff": true,
+      "maxDiffRatio": 0.01
+    }`);
+
+    assert.equal(config.baseUrl, "http://localhost:3000");
+    assert.equal(config.outputDir, "artifacts/snapshots");
+    assert.equal(config.threshold, 0.2);
+    assert.equal(config.failOnDiff, true);
+    assert.equal(config.maxDiffRatio, 0.01);
+    assert.deepEqual(config.mask, [".hero", ".badge"]);
+    assert.deepEqual(config.routes, [
+      { path: "/" },
+      { path: "/issues?severity=critical", label: "critical-issues" },
+    ]);
+  });
+});
+
+describe("parseSnapshotCliArgs", () => {
+  it("uses config routes when URLs are omitted", () => {
+    const options = parseSnapshotCliArgs([], {
+      baseUrl: "http://localhost:3000",
+      routes: [
+        { path: "/", label: undefined },
+        { path: "/issues?severity=critical", label: "critical-issues" },
+      ],
+      outputDir: "artifacts/snapshots",
+      threshold: 0.2,
+      failOnDiff: true,
+      failOnNewBaseline: false,
+      maxDiffRatio: 0.01,
+      mask: [".hero"],
+    });
+
+    assert.equal(options.mode, "capture");
+    assert.deepEqual(options.urls, [
+      "http://localhost:3000/",
+      "http://localhost:3000/issues?severity=critical",
+    ]);
+    assert.deepEqual(options.labels, [
+      "localhost_3000_root",
+      "critical-issues",
+    ]);
+    assert.equal(options.outputDir, "artifacts/snapshots");
+    assert.equal(options.threshold, 0.2);
+    assert.equal(options.failOnDiff, true);
+    assert.equal(options.maxDiffRatio, 0.01);
+    assert.deepEqual(options.maskSelectors, [".hero"]);
+  });
+
+  it("lets CLI URLs and flags override config defaults", () => {
+    const options = parseSnapshotCliArgs([
+      "http://localhost:4100/",
+      "--label", "home",
+      "--output", "tmp/out",
+      "--threshold", "0.3",
+      "--fail-on-new-baseline",
+      "--mask", ".runtime-mask",
+    ], {
+      baseUrl: "http://localhost:3000",
+      routes: [{ path: "/ignored", label: "ignored" }],
+      outputDir: "artifacts/snapshots",
+      threshold: 0.2,
+      failOnDiff: true,
+      failOnNewBaseline: false,
+      mask: [".config-mask"],
+    });
+
+    assert.equal(options.mode, "capture");
+    assert.deepEqual(options.urls, ["http://localhost:4100/"]);
+    assert.deepEqual(options.labels, ["home"]);
+    assert.equal(options.outputDir, "tmp/out");
+    assert.equal(options.threshold, 0.3);
+    assert.equal(options.failOnDiff, true);
+    assert.equal(options.failOnNewBaseline, true);
+    assert.deepEqual(options.maskSelectors, [".runtime-mask"]);
+  });
+
+  it("supports snapshot approve with config-derived outputDir", () => {
+    const options = parseSnapshotCliArgs(["approve"], {
+      outputDir: "artifacts/snapshots",
+    });
+
+    assert.equal(options.mode, "approve");
+    assert.equal(options.outputDir, "artifacts/snapshots");
+  });
+
+  it("rejects relative routes without baseUrl", () => {
+    assert.throws(
+      () => parseSnapshotCliArgs([], {
+        routes: [{ path: "/issues", label: undefined }],
+      }),
+      /baseUrl is required when snapshot routes are relative/i,
+    );
+  });
+});

--- a/src/snapshot-cli.ts
+++ b/src/snapshot-cli.ts
@@ -1,0 +1,344 @@
+export interface SnapshotFailureOptions {
+  failOnDiff?: boolean;
+  failOnNewBaseline?: boolean;
+  maxDiffRatio?: number;
+}
+
+export interface SnapshotFailureResult {
+  exitCode: number;
+  reasons: string[];
+}
+
+export interface SnapshotSummaryEntry {
+  label: string;
+  viewport: string;
+  isNew: boolean;
+  diffRatio?: number;
+}
+
+export interface SnapshotRouteConfig {
+  path: string;
+  label?: string;
+}
+
+export interface SnapshotConfig {
+  baseUrl?: string;
+  routes?: SnapshotRouteConfig[];
+  outputDir?: string;
+  threshold?: number;
+  failOnDiff?: boolean;
+  failOnNewBaseline?: boolean;
+  maxDiffRatio?: number;
+  mask?: string[];
+}
+
+export interface ParsedSnapshotCliOptions {
+  mode: "capture" | "approve";
+  urls: string[];
+  labels: string[];
+  outputDir: string;
+  threshold: number;
+  failOnDiff: boolean;
+  failOnNewBaseline: boolean;
+  maxDiffRatio?: number;
+  maskSelectors: string[];
+}
+
+function sanitizeLabelPart(value: string): string {
+  return value
+    .trim()
+    .replace(/%/g, "_")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+}
+
+function defaultPort(protocol: string): string {
+  if (protocol === "https:") return "443";
+  return "80";
+}
+
+export function urlToSnapshotLabel(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const path = sanitizeLabelPart(parsed.pathname.replace(/\.html$/i, "").replace(/\//g, "_")) || "root";
+    const base = sanitizeLabelPart(parsed.hostname) || "page";
+    const port = parsed.port || defaultPort(parsed.protocol);
+
+    const queryPairs = Array.from(parsed.searchParams.entries())
+      .map(([key, value]) => [sanitizeLabelPart(key), sanitizeLabelPart(value)] as const)
+      .sort(([aKey, aValue], [bKey, bValue]) => aKey.localeCompare(bKey) || aValue.localeCompare(bValue));
+
+    const querySuffix = queryPairs.length > 0
+      ? `__query_${queryPairs.map(([key, value]) => `${key}_${value || "empty"}`).join("__")}`
+      : "";
+
+    const hashPart = sanitizeLabelPart(parsed.hash.replace(/^#\/?/, ""));
+    const hashSuffix = hashPart ? `__hash_${hashPart}` : "";
+
+    return `${base}_${port}_${path}${querySuffix}${hashSuffix}`;
+  } catch {
+    return "page";
+  }
+}
+
+export function resolveSnapshotLabels(urls: string[], explicitLabels: string[]): string[] {
+  if (explicitLabels.length === 0) {
+    return urls.map((url) => urlToSnapshotLabel(url));
+  }
+
+  if (urls.length === 1 && explicitLabels.length === 1) {
+    return explicitLabels;
+  }
+
+  if (explicitLabels.length !== urls.length) {
+    throw new Error("--label must be provided either once for a single URL or once per URL");
+  }
+
+  return explicitLabels;
+}
+
+export function parseSnapshotConfig(raw: string): SnapshotConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Invalid snapshot config JSON: ${String(error)}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Snapshot config must be an object");
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const routes = record.routes == null ? undefined : parseSnapshotRoutes(record.routes);
+  const mask = record.mask == null ? undefined : parseStringArray(record.mask, "snapshot config mask must be a string array");
+  const threshold = record.threshold == null ? undefined : parseRatio(record.threshold, "snapshot config threshold must be between 0 and 1");
+  const maxDiffRatio = record.maxDiffRatio == null
+    ? undefined
+    : parseNonNegativeNumber(record.maxDiffRatio, "snapshot config maxDiffRatio must be a non-negative number");
+
+  return {
+    baseUrl: record.baseUrl == null ? undefined : parseString(record.baseUrl, "snapshot config baseUrl must be a non-empty string"),
+    routes,
+    outputDir: record.outputDir == null ? undefined : parseString(record.outputDir, "snapshot config outputDir must be a non-empty string"),
+    threshold,
+    failOnDiff: record.failOnDiff == null ? undefined : parseBoolean(record.failOnDiff, "snapshot config failOnDiff must be a boolean"),
+    failOnNewBaseline: record.failOnNewBaseline == null
+      ? undefined
+      : parseBoolean(record.failOnNewBaseline, "snapshot config failOnNewBaseline must be a boolean"),
+    maxDiffRatio,
+    mask,
+  };
+}
+
+export function parseSnapshotCliArgs(
+  cliArgs: string[],
+  config: SnapshotConfig = {},
+  cwd = process.cwd(),
+): ParsedSnapshotCliOptions {
+  const positional: string[] = [];
+  const explicitLabels: string[] = [];
+  const maskSelectors: string[] = [];
+  let outputDir = config.outputDir ?? `${cwd}/test-results/snapshots`;
+  let threshold = config.threshold ?? 0.1;
+  let failOnDiff = config.failOnDiff ?? false;
+  let failOnNewBaseline = config.failOnNewBaseline ?? false;
+  let maxDiffRatio = config.maxDiffRatio;
+
+  for (let i = 0; i < cliArgs.length; i++) {
+    const arg = cliArgs[i]!;
+    switch (arg) {
+      case "--output":
+      case "--output-dir": {
+        const value = cliArgs[++i];
+        if (!value) throw new Error(`Missing value for ${arg}`);
+        outputDir = value;
+        break;
+      }
+      case "--label": {
+        const value = cliArgs[++i];
+        if (!value) throw new Error("Missing value for --label");
+        explicitLabels.push(value);
+        break;
+      }
+      case "--threshold": {
+        const value = cliArgs[++i];
+        threshold = parseRatio(value == null ? value : Number(value), "Invalid --threshold value");
+        break;
+      }
+      case "--fail-on-diff":
+        failOnDiff = true;
+        break;
+      case "--fail-on-new-baseline":
+        failOnNewBaseline = true;
+        break;
+      case "--max-diff-ratio": {
+        const value = cliArgs[++i];
+        maxDiffRatio = parseNonNegativeNumber(value == null ? value : Number(value), "Invalid --max-diff-ratio value");
+        break;
+      }
+      case "--mask": {
+        const value = cliArgs[++i];
+        if (!value) throw new Error("Missing value for --mask");
+        for (const selector of value.split(",")) {
+          const trimmed = selector.trim();
+          if (trimmed) maskSelectors.push(trimmed);
+        }
+        break;
+      }
+      case "--config": {
+        i++;
+        break;
+      }
+      case "--help":
+      case "-h":
+        break;
+      default:
+        if (arg.startsWith("--")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        positional.push(arg);
+        break;
+    }
+  }
+
+  if (positional[0] === "approve") {
+    if (positional.length > 1) {
+      throw new Error("`vrt snapshot approve` does not accept positional URLs");
+    }
+    return {
+      mode: "approve",
+      urls: [],
+      labels: explicitLabels,
+      outputDir,
+      threshold,
+      failOnDiff,
+      failOnNewBaseline,
+      maxDiffRatio,
+      maskSelectors: maskSelectors.length > 0 ? maskSelectors : (config.mask ?? []),
+    };
+  }
+
+  const configuredUrls = positional.length > 0
+    ? positional
+    : resolveSnapshotConfigUrls(config);
+
+  const configuredLabels = positional.length > 0
+    ? []
+    : (config.routes ?? []).map((route) => route.label);
+
+  const labels = explicitLabels.length > 0
+    ? resolveSnapshotLabels(configuredUrls, explicitLabels)
+    : configuredUrls.map((url, index) => configuredLabels[index] ?? urlToSnapshotLabel(url));
+
+  return {
+    mode: "capture",
+    urls: configuredUrls,
+    labels,
+    outputDir,
+    threshold,
+    failOnDiff,
+    failOnNewBaseline,
+    maxDiffRatio,
+    maskSelectors: maskSelectors.length > 0 ? maskSelectors : (config.mask ?? []),
+  };
+}
+
+export function determineSnapshotExitCode(
+  results: SnapshotSummaryEntry[],
+  options: SnapshotFailureOptions,
+): SnapshotFailureResult {
+  const reasons: string[] = [];
+
+  if (options.failOnNewBaseline && results.some((result) => result.isNew)) {
+    reasons.push("New baseline detected while --fail-on-new-baseline is enabled");
+  }
+
+  if (options.failOnDiff && results.some((result) => !result.isNew && (result.diffRatio ?? 0) > 0)) {
+    reasons.push("Diff detected while --fail-on-diff is enabled");
+  }
+
+  if (options.maxDiffRatio !== undefined) {
+    const exceeded = results.find((result) => !result.isNew && (result.diffRatio ?? 0) > options.maxDiffRatio!);
+    if (exceeded) {
+      reasons.push(
+        `Max diff ratio exceeded: ${exceeded.label} ${exceeded.viewport} is ${((exceeded.diffRatio ?? 0) * 100).toFixed(2)}%`,
+      );
+    }
+  }
+
+  return {
+    exitCode: reasons.length > 0 ? 1 : 0,
+    reasons,
+  };
+}
+
+function parseSnapshotRoutes(value: unknown): SnapshotRouteConfig[] {
+  if (!Array.isArray(value)) {
+    throw new Error("snapshot config routes must be an array");
+  }
+
+  return value.map((entry, index) => {
+    if (typeof entry === "string" && entry.trim() !== "") {
+      return { path: entry };
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`snapshot config route at index ${index} must be a string or object`);
+    }
+    const record = entry as Record<string, unknown>;
+    const path = record.path ?? record.url;
+    return {
+      path: parseString(path, `snapshot config route at index ${index} must have a path`),
+      label: record.label == null ? undefined : parseString(record.label, `snapshot config route at index ${index} has an invalid label`),
+    };
+  });
+}
+
+function resolveSnapshotConfigUrls(config: SnapshotConfig): string[] {
+  const routes = config.routes ?? [];
+  return routes.map((route) => {
+    if (/^https?:\/\//i.test(route.path)) {
+      return route.path;
+    }
+    if (!config.baseUrl) {
+      throw new Error("baseUrl is required when snapshot routes are relative");
+    }
+    return new URL(route.path, config.baseUrl).toString();
+  });
+}
+
+function parseString(value: unknown, message: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function parseBoolean(value: unknown, message: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function parseStringArray(value: unknown, message: string): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.trim() === "")) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function parseRatio(value: unknown, message: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function parseNonNegativeNumber(value: unknown, message: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(message);
+  }
+  return value;
+}

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -6,17 +6,18 @@
  *   vrt snapshot http://localhost:4156/todomvc --output snapshots/luna/
  *   vrt snapshot http://localhost:3000/ http://localhost:3000/luna/ --output snapshots/sol/
  */
-import { mkdir, writeFile, access } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { access, copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import { chromium } from "playwright";
 import { compareScreenshots, generateDiffReport } from "./heatmap.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "./terminal-colors.ts";
-import { getArg, getPositionalArgs, args } from "./cli-args.ts";
-import { applyMask, parseMaskSelectors } from "./mask.ts";
+import { applyMask } from "./mask.ts";
+import { approveSnapshotsFromReport } from "./snapshot-approve.ts";
+import { determineSnapshotExitCode, parseSnapshotCliArgs, parseSnapshotConfig, type SnapshotConfig } from "./snapshot-cli.ts";
 import type { VrtSnapshot } from "./types.ts";
 
-const OUTPUT_DIR = resolve(getArg("output", join(process.cwd(), "test-results", "snapshots")));
-const MASK_SELECTORS = parseMaskSelectors(args);
+const DEFAULT_SNAPSHOT_CONFIG_FILE = "vrt.config.json";
 const VIEWPORTS = [
   { width: 1280, height: 900, label: "desktop" },
   { width: 375, height: 812, label: "mobile" },
@@ -35,32 +36,118 @@ interface SnapshotResult {
   shiftOnly?: boolean;
 }
 
-function urlToLabel(url: string): string {
-  try {
-    const u = new URL(url);
-    const path = u.pathname.replace(/\//g, "_").replace(/^_|_$/g, "") || "root";
-    return `${u.hostname}_${u.port || "80"}_${path}`.replace(/\.html$/, "");
-  } catch {
-    return "page";
+function formatSnapshotUsage(): string {
+  return [
+    "Usage:",
+    "  vrt snapshot <url1> [url2] ... [--output dir] [--label name] [--threshold 0.1] [--fail-on-diff] [--fail-on-new-baseline] [--max-diff-ratio n] [--config vrt.config.json]",
+    "  vrt snapshot approve [--output dir] [--label name] [--config vrt.config.json]",
+  ].join("\n");
+}
+
+function findSnapshotConfigPath(cliArgs: string[], cwd: string): string | undefined {
+  for (let i = 0; i < cliArgs.length; i++) {
+    if (cliArgs[i] === "--config") {
+      const value = cliArgs[i + 1];
+      if (!value) {
+        throw new Error("Missing value for --config");
+      }
+      return resolve(cwd, value);
+    }
   }
+
+  const defaultPath = resolve(cwd, DEFAULT_SNAPSHOT_CONFIG_FILE);
+  return existsSync(defaultPath) ? defaultPath : undefined;
+}
+
+async function loadSnapshotConfigForCli(cliArgs: string[], cwd: string): Promise<{
+  config: SnapshotConfig;
+  configPath?: string;
+}> {
+  const configPath = findSnapshotConfigPath(cliArgs, cwd);
+  if (!configPath) {
+    return { config: {} };
+  }
+
+  const raw = await readFile(configPath, "utf-8");
+  const config = parseSnapshotConfig(raw);
+  if (config.outputDir && !config.outputDir.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(config.outputDir)) {
+    config.outputDir = resolve(dirname(configPath), config.outputDir);
+  }
+  return { config, configPath };
+}
+
+async function approve(options: {
+  outputDir: string;
+  labels: string[];
+  configPath?: string;
+}) {
+  const reportPath = join(options.outputDir, "snapshot-report.json");
+  let result: Awaited<ReturnType<typeof approveSnapshotsFromReport>>;
+  try {
+    result = await approveSnapshotsFromReport(reportPath, options.labels);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`No snapshot report found at ${reportPath}. Run \`vrt snapshot <url...>\` first.`);
+    }
+    throw error;
+  }
+
+  console.log();
+  console.log(`${BOLD}${CYAN}Snapshot Approve${RESET}`);
+  console.log(`  ${DIM}Output: ${options.outputDir}${RESET}`);
+  if (options.configPath) {
+    console.log(`  ${DIM}Config: ${options.configPath}${RESET}`);
+  }
+  if (options.labels.length > 0) {
+    console.log(`  ${DIM}Labels: ${options.labels.join(", ")}${RESET}`);
+  }
+  console.log();
+  for (const entry of result.entries) {
+    console.log(`  ${GREEN}${entry.label}${RESET} ${DIM}${entry.viewport}${RESET}`);
+  }
+  console.log();
+  console.log(`  ${GREEN}Approved baselines:${RESET} ${result.updated}`);
+  console.log(`  ${DIM}Report: ${reportPath}${RESET}`);
+  console.log();
 }
 
 async function main() {
-  const urls = getPositionalArgs();
-  if (urls.length === 0) {
-    console.log(`Usage: vrt snapshot <url1> [url2] ... [--output dir]`);
-    process.exit(1);
+  const cliArgs = process.argv.slice(2);
+  if (cliArgs.length === 0 || cliArgs.includes("--help") || cliArgs.includes("-h") || cliArgs.includes("help")) {
+    console.log(formatSnapshotUsage());
+    process.exit(cliArgs.length === 0 ? 1 : 0);
   }
 
-  await mkdir(OUTPUT_DIR, { recursive: true });
+  const cwd = process.cwd();
+  const { config, configPath } = await loadSnapshotConfigForCli(cliArgs, cwd);
+  const parsed = parseSnapshotCliArgs(cliArgs, config, cwd);
+  const outputDir = resolve(parsed.outputDir);
+
+  if (parsed.mode === "approve") {
+    await approve({ outputDir, labels: parsed.labels, configPath });
+    return;
+  }
+
+  const urls = parsed.urls;
+  if (urls.length === 0) {
+    console.log(formatSnapshotUsage());
+    throw new Error("No snapshot URLs provided. Pass URLs directly or configure routes in vrt.config.json.");
+  }
+  const labels = parsed.labels;
+
+  await mkdir(outputDir, { recursive: true });
 
   console.log();
   console.log(`${BOLD}${CYAN}╔════════════════════════════════════════════════════════════════════════╗${RESET}`);
   console.log(`${BOLD}${CYAN}║  VRT Snapshot                                                        ║${RESET}`);
   console.log(`${BOLD}${CYAN}╚════════════════════════════════════════════════════════════════════════╝${RESET}`);
-  console.log(`  ${DIM}URLs: ${urls.length} | Viewports: ${VIEWPORTS.map((v) => v.label).join(", ")} | Output: ${OUTPUT_DIR}${RESET}`);
-  if (MASK_SELECTORS.length > 0) {
-    console.log(`  ${DIM}Mask: ${MASK_SELECTORS.join(", ")}${RESET}`);
+  console.log(`  ${DIM}URLs: ${urls.length} | Viewports: ${VIEWPORTS.map((v) => v.label).join(", ")} | Output: ${outputDir}${RESET}`);
+  console.log(`  ${DIM}Threshold: ${parsed.threshold}${RESET}`);
+  if (configPath) {
+    console.log(`  ${DIM}Config: ${configPath}${RESET}`);
+  }
+  if (parsed.maskSelectors.length > 0) {
+    console.log(`  ${DIM}Mask: ${parsed.maskSelectors.join(", ")}${RESET}`);
   }
   console.log();
 
@@ -68,28 +155,28 @@ async function main() {
   const results: SnapshotResult[] = [];
 
   try {
-    for (const url of urls) {
-      const label = urlToLabel(url);
+    for (const [index, url] of urls.entries()) {
+      const label = labels[index]!;
       console.log(`  ${BOLD}${label}${RESET} ${DIM}(${url})${RESET}`);
 
       for (const vp of VIEWPORTS) {
         const page = await browser.newPage({ viewport: { width: vp.width, height: vp.height } });
         await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
-        await applyMask(page, MASK_SELECTORS);
+        await applyMask(page, parsed.maskSelectors);
 
-        const currentPath = join(OUTPUT_DIR, `${label}-${vp.label}-current.png`);
+        const currentPath = join(outputDir, `${label}-${vp.label}-current.png`);
         await page.screenshot({ path: currentPath, fullPage: true });
 
         // Save HTML on first viewport only
         if (vp === VIEWPORTS[0]) {
           const html = await page.content();
-          await writeFile(join(OUTPUT_DIR, `${label}.html`), html);
+          await writeFile(join(outputDir, `${label}.html`), html);
         }
 
         await page.close();
 
         // Check for previous baseline
-        const baselinePath = join(OUTPUT_DIR, `${label}-${vp.label}-baseline.png`);
+        const baselinePath = join(outputDir, `${label}-${vp.label}-baseline.png`);
         let hasBaseline = false;
         try {
           await access(baselinePath);
@@ -105,12 +192,12 @@ async function main() {
             baselinePath,
             status: "changed",
           };
-          const diff = await compareScreenshots(snap, { outputDir: OUTPUT_DIR });
+          const diff = await compareScreenshots(snap, { outputDir, threshold: parsed.threshold });
           const diffRatio = diff?.diffRatio ?? 0;
 
           // Shift detection for enhanced analysis
           const report = diffRatio > 0
-            ? await generateDiffReport(snap, { outputDir: OUTPUT_DIR, detectShift: true })
+            ? await generateDiffReport(snap, { outputDir, detectShift: true, threshold: parsed.threshold })
             : null;
           const globalShift = report?.globalShift ?? 0;
           const compensatedDiffRatio = report ? report.compensatedDiffCount / report.totalPixels : diffRatio;
@@ -135,7 +222,6 @@ async function main() {
           });
         } else {
           // First run: promote current to baseline
-          const { copyFile } = await import("node:fs/promises");
           await copyFile(currentPath, baselinePath);
           console.log(`    ${vp.label.padEnd(10)} ${DIM}(new baseline)${RESET}`);
           results.push({ url, label, viewport: vp.label, screenshotPath: currentPath, isNew: true });
@@ -170,14 +256,41 @@ async function main() {
     }
   }
 
+  const exitStatus = determineSnapshotExitCode(results, {
+    failOnDiff: parsed.failOnDiff,
+    failOnNewBaseline: parsed.failOnNewBaseline,
+    maxDiffRatio: parsed.maxDiffRatio,
+  });
+
   // Write JSON summary
   await writeFile(
-    join(OUTPUT_DIR, "snapshot-report.json"),
-    JSON.stringify({ timestamp: new Date().toISOString(), urls, results }, null, 2),
+    join(outputDir, "snapshot-report.json"),
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      urls,
+      labels,
+      options: {
+        threshold: parsed.threshold,
+        failOnDiff: parsed.failOnDiff,
+        failOnNewBaseline: parsed.failOnNewBaseline,
+        maxDiffRatio: parsed.maxDiffRatio ?? null,
+        configPath: configPath ?? null,
+      },
+      results,
+      exitStatus,
+    }, null, 2),
   );
 
   console.log();
-  console.log(`  ${DIM}Report: ${join(OUTPUT_DIR, "snapshot-report.json")}${RESET}`);
+  console.log(`  ${DIM}Report: ${join(outputDir, "snapshot-report.json")}${RESET}`);
+  if (exitStatus.reasons.length > 0) {
+    console.log();
+    console.log(`  ${RED}Snapshot failed:${RESET}`);
+    for (const reason of exitStatus.reasons) {
+      console.log(`    ${RED}- ${reason}${RESET}`);
+    }
+    process.exitCode = exitStatus.exitCode;
+  }
   console.log();
 }
 

--- a/src/vrt-command-router.test.ts
+++ b/src/vrt-command-router.test.ts
@@ -65,6 +65,7 @@ describe("formatRootUsage", () => {
     assert.match(usage, /Workflow Commands:/);
     assert.match(usage, /API Commands:/);
     assert.match(usage, /png-diff <baseline\.png> <current\.png>/);
+    assert.match(usage, /snapshot approve/);
     assert.match(usage, /workflow verify/);
     assert.match(usage, /api serve/);
   });

--- a/src/vrt-command-router.ts
+++ b/src/vrt-command-router.ts
@@ -93,6 +93,7 @@ Core Commands:
   png-diff <baseline.png> <current.png>
                               Compare existing PNG screenshots directly
   snapshot <url...>           Capture multi-viewport snapshots with baseline diff
+  snapshot approve            Promote accepted snapshot diffs to baselines
   elements [options]          Element-level comparison with shift isolation
   smoke <file-or-url>         A11y-driven smoke test
   discover <file>             Discover responsive breakpoints from HTML/CSS
@@ -119,6 +120,7 @@ Examples:
   vrt compare before.html after.html
   vrt png-diff baseline.png current.png
   vrt snapshot http://localhost:3000/ --output snapshots/
+  vrt snapshot approve --output snapshots/
   vrt workflow verify
   vrt workflow report
   vrt api serve --port 3456`;


### PR DESCRIPTION
## Summary
- make `vrt snapshot` labels query-aware and support explicit `--label` overrides
- add CI-oriented snapshot failure policies and include exit metadata in `snapshot-report.json`
- add `vrt snapshot approve` and official `vrt.config.json` support for route-driven snapshot runs
- document the new snapshot workflow in the README and CLI help text

## Why
The snapshot dogfooding follow-up in `TODO.md` exposed three gaps:
- URL identity could collapse when query strings differed
- CI integration needed first-class exit conditions instead of wrapper scripts
- snapshot approval and config-driven runs were only possible through project-specific wrappers

## Impact
- snapshot baselines are stable across query/hash variants
- CI can fail directly on diffs, new baselines, or diff-ratio thresholds
- external projects can drive snapshot runs from `vrt.config.json` and promote approved baselines with `vrt snapshot approve`

## Validation
- `node --test src/snapshot-cli.test.ts src/snapshot-approve.test.ts src/vrt-command-router.test.ts src/vrt-verify.test.ts src/package-manifest.test.ts`
- `pnpm build`

## Notes
- `TODO.md` had unrelated local edits in the worktree, so it was intentionally left out of this PR
- full `pnpm test` still hits the existing Playwright sandbox/browser-launch restriction in this environment