### PR TITLE
Isolate verify-pipeline test from the host repo's git history

### DIFF
--- a/src/cli/workflow/verify.test.ts
+++ b/src/cli/workflow/verify.test.ts
@@ -1,12 +1,19 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { encodePng } from "@mizchi/vrt-core/png-utils.ts";
 import { runVerifyPipeline } from "./verify.ts";
 
-const TMP = join(import.meta.dirname!, "..", "..", "..", "test-results", "vrt-verify-test");
+// Use the OS tmp dir (outside the repo) so `git` invoked from the
+// verify pipeline can't walk up and find the project's `.git`, which
+// would otherwise pull the current branch's HEAD~1..HEAD diff into
+// the intent inference and make the cross-validation outcome depend
+// on whatever the latest commit message happens to contain (e.g.
+// any commit body with `css`/`theme`/`font` flips changeType to
+// `style`, which auto-approves visual-only diffs).
 
 function createPalettePng(
   width: number,
@@ -44,13 +51,13 @@ function createPalettePng(
 
 describe("runVerifyPipeline", () => {
   it("compares existing PNG snapshots without Playwright capture", async () => {
+    const TMP = await mkdtemp(join(tmpdir(), "vrt-verify-test-"));
     const baselinesDir = join(TMP, "baselines");
     const snapshotsDir = join(TMP, "snapshots");
     const outputDir = join(TMP, "output");
     const reportPath = join(TMP, "vrt-report.json");
     const expectationPath = join(TMP, "expectation.json");
 
-    await rm(TMP, { recursive: true, force: true });
     await mkdir(baselinesDir, { recursive: true });
     await mkdir(snapshotsDir, { recursive: true });
 


### PR DESCRIPTION
## Summary

`src/cli/workflow/verify.test.ts` was deterministic-but-environment-dependent: any commit body anywhere on the working branch that contained `css`, `theme`, `color`, `font`, or `layout` flipped the assertion.

## Root cause

The test creates its TMP under `<repo>/test-results/vrt-verify-test/` and passes that as `projectRoot` to `runVerifyPipeline`. The pipeline calls `extractDiffSemantics(projectRoot)`, which runs `git diff HEAD~1..HEAD` with that path as `cwd`. `git` walks up and finds the project's own `.git`.

That feeds the test the actual repo's most recent commit message. `inferChangeType` at `packages/vrt-ai/src/intent.ts:125` then matches against `/css|theme|color|font|layout/` (substring, anywhere). When the body trips that regex:

- `changeType` becomes `"style"`
- `crossValidate` hits the "Visual-only change consistent with style intent" branch (`src/experiments/detection/cross-validation.ts:100`)
- The synthetic diff auto-approves
- `escalated` drops to 0
- `result.needsReview` is `false`
- `assert.equal(result.needsReview, true)` at `verify.test.ts:87` fails

Reproduces deterministically: `git -c advice.detachedHead=false checkout <commit-with-"css"-in-body>` then `node --test --experimental-strip-types src/cli/workflow/verify.test.ts` fails. `main`'s latest commit (`e2bf496`, starts with `feat:`) escapes the trap because `^feat[:(]` matches first and returns `"feature"`.

## Fix

Move the test's TMP to `os.tmpdir()` via `mkdtemp`. `git` invoked from there has no `.git` to walk up to, `extractDiffSemantics` throws, the existing catch branch in `runVerifyPipeline` sets `intent.changeType = "unknown"`, and the verdict deterministically escalates.

Test-only change.

## Test plan

- [x] `node --test --experimental-strip-types src/cli/workflow/verify.test.ts` at `main` → PASS
- [x] Reproduction confirmed: detach to `4c27358` (a commit whose body mentions `css-challenge-core`) → old test fails (`Escalated: 0`)
- [x] Same `4c27358` HEAD + fixed test → PASS (`Escalated: 1`)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)