### PR TITLE
Route flaker CLI errors through handleCliError (closes #15)

### DIFF
--- a/src/experiments/flaker/flaker-vrt-report-adapter.ts
+++ b/src/experiments/flaker/flaker-vrt-report-adapter.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { handleCliError } from "@mizchi/vrt-core/cli-error.ts";
 import type { MigrationCompareReport } from "../migration/migration-compare.ts";
 import {
   convertMigrationReportToFlakerResults,
@@ -71,9 +72,5 @@ function getArg(args: string[], name: string): string | undefined {
 
 const invokedPath = process.argv[1];
 if (invokedPath && import.meta.url === new URL(`file://${invokedPath}`).href) {
-  main().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exitCode = 1;
-  });
+  main().catch(handleCliError);
 }

--- a/src/experiments/flaker/flaker-vrt-runner.ts
+++ b/src/experiments/flaker/flaker-vrt-runner.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { handleCliError } from "@mizchi/vrt-core/cli-error.ts";
 import { loadFlakerVrtConfig, toViewportSpec, type FlakerVrtConfig, type FlakerVrtMigrationScenario } from "./flaker-vrt-config.ts";
 import {
   runMigrationCompare,
@@ -297,7 +298,14 @@ async function main() {
 
 const invokedPath = process.argv[1];
 if (invokedPath && import.meta.url === new URL(`file://${invokedPath}`).href) {
+  // Non-TTY stdout = runner-style invocation (flaker pipes stdout to
+  // parse the FlakerExecuteResult envelope). Preserve that shape.
+  // Interactive TTY = developer running directly; route through the
+  // shared CLI error prettifier instead of dumping a raw stack.
   main().catch((error) => {
+    if (process.stdout.isTTY) {
+      handleCliError(error);
+    }
     const message = error instanceof Error ? error.message : String(error);
     console.log(JSON.stringify({
       exitCode: 0,


### PR DESCRIPTION
Closes #15.

## Summary

PR #13 unified twelve user-facing CLI catch handlers under `handleCliError`. The two flaker scripts (`flaker-vrt-runner.ts`, `flaker-vrt-report-adapter.ts`) were intentionally skipped because they're not exposed via `vrt help`, but running them directly during local development still surfaces raw Node stack traces (EISDIR / ENOENT) the central fix was meant to eliminate. This PR closes the consistency gap.

## Changes

- **`flaker-vrt-report-adapter.ts`** — straight swap to `main().catch(handleCliError)`. The script never emitted structured stdout on error, so there's no shape to preserve.

- **`flaker-vrt-runner.ts`** — TTY-gated. The runner is invoked by the flaker harness via pipe, and its stdout is parsed as a `FlakerExecuteResult` JSON envelope. The catch now:
  - If `process.stdout.isTTY` → calls `handleCliError` (prettified ENOENT / EISDIR / Playwright errors; exit 1).
  - Else → keeps the existing JSON envelope, so the harness's stdout parser is untouched.

## Smoke

```
$ node --experimental-strip-types src/experiments/flaker/flaker-vrt-report-adapter.ts --file /nonexistent.json
error: file not found: /nonexistent.json
$ echo \$?
1

$ node --experimental-strip-types src/experiments/flaker/flaker-vrt-runner.ts execute --config /nonexistent.json | cat
{"exitCode":0,"results":[],"durationMs":0,"stdout":"","stderr":"ENOENT: no such file or directory, open '/nonexistent.json'"}
```

## Test plan

- [x] `pnpm test` → 760/760 PASS
- [x] TTY smoke (adapter) shows prettified error, not stack trace
- [x] Pipe smoke (runner) preserves JSON envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)