### PR TITLE
Add per-section diffRatio to vrt diff-for-agent (closes #19)

### DIFF
--- a/src/vrt/compare/diff-for-agent.test.ts
+++ b/src/vrt/compare/diff-for-agent.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { formatMigrationReportForAgent, type DfaReport } from "./diff-for-agent.ts";
+import { computeSectionDiffRows, formatMigrationReportForAgent, type DfaReport } from "./diff-for-agent.ts";
 
 function sampleReport(over: Partial<DfaReport> = {}): DfaReport {
   return {
@@ -109,5 +109,71 @@ describe("formatMigrationReportForAgent", () => {
   it("handles empty reports gracefully", () => {
     const md = formatMigrationReportForAgent(sampleReport({ results: [] }));
     assert.match(md, /Empty report/);
+  });
+
+  it("renders per-section diffRatio when bbox + heatmap data are present", () => {
+    const md = formatMigrationReportForAgent(sampleReport({
+      componentBboxDiffs: [{
+        variantFile: "working.html",
+        perViewport: [{
+          viewport: "mobile",
+          matches: [
+            // Large hero section: 200×100 = 20000 area, fully covered by region → 100%.
+            {
+              rank: 1,
+              baseline: { top: 0, left: 0, width: 200, height: 100, area: 20000, fillColor: "#fff" },
+              variant: { top: 0, left: 0, width: 200, height: 100, area: 20000, fillColor: "#fff" },
+              deltaTop: 0, deltaLeft: 0, deltaWidth: 0, deltaHeight: 0, iou: 1,
+            },
+            // Smaller card: 50×50 = 2500 area, no heatmap intersection → 0%.
+            {
+              rank: 2,
+              baseline: { top: 200, left: 0, width: 50, height: 50, area: 2500, fillColor: "#fff" },
+              variant: { top: 200, left: 0, width: 50, height: 50, area: 2500, fillColor: "#fff" },
+              deltaTop: 0, deltaLeft: 0, deltaWidth: 0, deltaHeight: 0, iou: 1,
+            },
+          ],
+        }],
+      }],
+      heatmapRegions: [{
+        variantFile: "working.html",
+        perViewport: [{
+          viewport: "mobile",
+          regions: [{ top: 0, left: 0, width: 200, height: 100, area: 20000 }],
+        }],
+      }],
+    }));
+    assert.match(md, /Per-section diffRatio/);
+    // Hero is fully covered (200×100 region intersects 200×100 section).
+    assert.match(md, /\| 100\.00% \|/);
+    // Worst row should carry the ⚠ marker — that's the hero, not the card.
+    const heroLine = md.split("\n").find((l) => l.includes("200×100"));
+    assert.ok(heroLine, "hero line present");
+    assert.ok(heroLine!.includes("⚠"), "hero row marked worst");
+  });
+
+  it("computeSectionDiffRows: sorts by sectionRatio desc and skips zero-area sections", () => {
+    const rows = computeSectionDiffRows(
+      {
+        matches: [
+          { rank: 1, baseline: { top: 0, left: 0, width: 100, height: 100 } },
+          { rank: 2, baseline: { top: 200, left: 0, width: 100, height: 100 } },
+          // zero-area: ignored
+          { rank: 3, baseline: { top: 0, left: 0, width: 0, height: 0 } },
+        ],
+      } as any,
+      [
+        { top: 0, left: 0, width: 50, height: 50 },  // 2500px inside rank 1's bbox (10000px) → 25%
+        { top: 200, left: 0, width: 10, height: 10 }, // 100px inside rank 2's bbox (10000px) → 1%
+      ],
+      "mobile",
+      1_000_000,
+      5,
+    );
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].rank, 1);
+    assert.equal(rows[0].sectionRatio, 0.25);
+    assert.equal(rows[1].rank, 2);
+    assert.equal(rows[1].sectionRatio, 0.01);
   });
 });

--- a/src/vrt/compare/diff-for-agent.ts
+++ b/src/vrt/compare/diff-for-agent.ts
@@ -500,6 +500,74 @@ function formatShiftBands(r: DfaResult): string {
     .join(" ");
 }
 
+interface SectionRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface SectionDiffRow {
+  viewport: string;
+  section: SectionRect;
+  sectionRatio: number;
+  totalRatio: number;
+  rank: number;
+}
+
+function rectIntersectionArea(a: SectionRect, b: SectionRect): number {
+  const left = Math.max(a.left, b.left);
+  const top = Math.max(a.top, b.top);
+  const right = Math.min(a.left + a.width, b.left + b.width);
+  const bottom = Math.min(a.top + a.height, b.top + b.height);
+  if (right <= left || bottom <= top) return 0;
+  return (right - left) * (bottom - top);
+}
+
+/**
+ * Per-section diff intensity for one viewport.
+ *
+ * - Sections are the top-N component bboxes (by baseline area). They
+ *   come from `component-bbox`, so they survive DOM rewrites.
+ * - Diff is approximated as the sum of rectangle intersections between
+ *   each section and each heatmap region. This is conservative: it
+ *   overcounts when a region only partially fills its bbox, but the
+ *   ranking — which is what the agent uses — stays correct.
+ * - `sectionRatio` = section_diff_px / section_area_px
+ *   `totalRatio`   = section_diff_px / viewport_total_px
+ */
+export function computeSectionDiffRows(
+  bboxesForViewport: { matches: Array<{ baseline: SectionRect; rank: number }> },
+  regionsForViewport: ReadonlyArray<SectionRect>,
+  viewport: string,
+  viewportTotalPixels: number,
+  topN: number,
+): SectionDiffRow[] {
+  if (bboxesForViewport.matches.length === 0) return [];
+  const sortedSections = [...bboxesForViewport.matches]
+    .sort((a, b) => b.baseline.width * b.baseline.height - a.baseline.width * a.baseline.height)
+    .slice(0, topN);
+
+  const rows: SectionDiffRow[] = [];
+  for (const match of sortedSections) {
+    const section = match.baseline;
+    const sectionArea = section.width * section.height;
+    if (sectionArea === 0) continue;
+    let diffArea = 0;
+    for (const region of regionsForViewport) {
+      diffArea += rectIntersectionArea(section, region);
+    }
+    rows.push({
+      viewport,
+      section,
+      sectionRatio: diffArea / sectionArea,
+      totalRatio: viewportTotalPixels > 0 ? diffArea / viewportTotalPixels : 0,
+      rank: match.rank,
+    });
+  }
+  return rows.sort((a, b) => b.sectionRatio - a.sectionRatio);
+}
+
 export function formatMigrationReportForAgent(
   report: DfaReport,
   options: DfaOptions = {},
@@ -597,6 +665,47 @@ export function formatMigrationReportForAgent(
     lines.push("");
 
     const bboxSummary = (report.componentBboxDiffs ?? []).find((c) => c.variantFile === variantFile);
+    const sectionHeatmapSummary = (report.heatmapRegions ?? []).find((h) => h.variantFile === variantFile);
+    if (bboxSummary && sectionHeatmapSummary && bboxSummary.perViewport.length > 0) {
+      const sectionRows: SectionDiffRow[] = [];
+      for (const vp of bboxSummary.perViewport) {
+        const heatmapVp = sectionHeatmapSummary.perViewport.find((h) => h.viewport === vp.viewport);
+        if (!heatmapVp || heatmapVp.regions.length === 0) continue;
+        const viewportResult = results.find((r) => r.viewport === vp.viewport);
+        const viewportTotalPixels = viewportResult?.totalPixels ?? 0;
+        sectionRows.push(
+          ...computeSectionDiffRows(vp, heatmapVp.regions, vp.viewport, viewportTotalPixels, 5),
+        );
+      }
+      if (sectionRows.length > 0) {
+        lines.push("### Per-section diffRatio (heatmap × component-bbox)");
+        lines.push("");
+        lines.push("For each viewport, the top-5 component bboxes (by baseline area) are " +
+          "intersected with the heatmap regions. `Section %` is diff_area_inside_section / " +
+          "section_area (= how concentrated the change is within this section). " +
+          "`Total %` is diff_area_inside_section / viewport_total (= this section's " +
+          "contribution to the overall viewport diff). The single highest `Section %` " +
+          "row across all viewports is marked ⚠ — fix that one first.");
+        lines.push("");
+        lines.push("| Viewport | Rank | Section (top,left WxH) | Section % | Total % | Worst |");
+        lines.push("|---|---|---|---|---|---|");
+        const worst = sectionRows.reduce<SectionDiffRow | null>(
+          (acc, cur) => (acc === null || cur.sectionRatio > acc.sectionRatio ? cur : acc),
+          null,
+        );
+        for (const row of sectionRows) {
+          const s = row.section;
+          const sectionPct = `${(row.sectionRatio * 100).toFixed(2)}%`;
+          const totalPct = `${(row.totalRatio * 100).toFixed(3)}%`;
+          const badge = row === worst ? "⚠" : "";
+          lines.push(
+            `| \`${row.viewport}\` | #${row.rank} | ${s.left},${s.top} ${s.width}×${s.height} | ${sectionPct} | ${totalPct} | ${badge} |`,
+          );
+        }
+        lines.push("");
+      }
+    }
+
     if (bboxSummary && bboxSummary.perViewport.length > 0) {
       lines.push("### Component bbox diff (image-only — works without DOM correspondence)");
       lines.push("");


### PR DESCRIPTION
Closes #19.

## Summary

`vrt diff-for-agent` today reports one number per viewport. Both subagents in `docs/reports/2026-05-12-subagent-eval.md` independently asked for section-level granularity ("Hero 0.4%, Panel 1.2%, Modal 4.0%"). This PR adds a per-section table.

## Approach

- **Sections** = top-5 baseline component bboxes by area (from `component-bbox`). Survives class renames / DOM rewrites — same property the existing "Component bbox diff" table already trades on.
- **Diff intensity** = `Σ intersect_area(section_bbox, heatmap_region)`. Conservative; ranking stays correct.
- **Two ratios** per row:
  - `Section %` = section_diff / section_area (intra-section concentration)
  - `Total %` = section_diff / viewport_total (contribution to overall diff)
- **Worst-offender badge**: the single highest `Section %` row across all viewports gets ⚠.
- Renders only when both `componentBboxDiffs` and `heatmapRegions` are present.

## Output shape

```
### Per-section diffRatio (heatmap × component-bbox)

| Viewport | Rank | Section (top,left WxH) | Section % | Total % | Worst |
|---|---|---|---|---|---|
| \`mobile\` | #1 | 0,0 200×100 | 100.00% | 0.819% | ⚠ |
| \`mobile\` | #2 | 0,200 50×50 | 0.00% | 0.000% |  |
| \`desktop\` | #1 | 0,0 480×120 | 24.00% | 0.011% |  |
```

## Test plan

- [x] New unit test on `computeSectionDiffRows` (ranker only, no markdown) — covers desc-sort + zero-area skip
- [x] New integration test on `formatMigrationReportForAgent` — covers the marker, the 100% percentage on a fully-covered hero, and the ⚠ landing on the hero row
- [x] `pnpm test` → 762/762 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)