### PR TITLE
Add regression alarm to vrt diff-for-agent (closes #20)

### DIFF
--- a/src/cli/commands/diff-for-agent-cli.ts
+++ b/src/cli/commands/diff-for-agent-cli.ts
@@ -11,18 +11,35 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { formatMigrationReportForAgent, type DfaReport } from "../../vrt/compare/diff-for-agent.ts";
+import {
+  buildPreviousRunSummary,
+  detectRegression,
+  formatMigrationReportForAgent,
+  type DfaReport,
+  type PreviousRunSummary,
+} from "../../vrt/compare/diff-for-agent.ts";
+
+const DEFAULT_HISTORY_PATH = ".vrt/last-diff-for-agent.json";
 
 function usage(): string {
   return [
     "Usage:",
-    "  vrt diff-for-agent <migration-report.json> [--out path] [--max-viewports 1] [--variant working.html] [--show-unverified]",
+    "  vrt diff-for-agent <migration-report.json> [--out path] [--max-viewports 1] [--variant working.html] [--show-unverified] [--previous path] [--persist-summary path] [--no-history] [--fail-on-regression]",
     "",
     "Reads an existing migration-compare report (the report.json written by",
     "`vrt compare`) and prints a Markdown summary tailored for coding agents.",
     "",
     "By default, heuristic fix-candidate rows marked ✗ (value already matches",
     "baseline) are hidden — pass --show-unverified to include them.",
+    "",
+    "Regression detection:",
+    "  - On each run the per-viewport diffRatio is written to .vrt/last-diff-for-agent.json",
+    "  - On the next run that file is loaded as the comparison baseline",
+    "  - If the majority of viewports got worse, a ⚠ REGRESSION banner appears",
+    "  - --previous <path>        explicit comparison source",
+    "  - --persist-summary <path> override the destination",
+    "  - --no-history             skip both load + write (one-shot mode)",
+    "  - --fail-on-regression     exit 1 when a regression is detected",
   ].join("\n");
 }
 
@@ -32,6 +49,10 @@ interface Args {
   maxViewports: number;
   variant?: string;
   showUnverified: boolean;
+  previousPath?: string;
+  persistSummaryPath?: string;
+  noHistory: boolean;
+  failOnRegression: boolean;
 }
 
 function parseArgs(argv: string[]): Args {
@@ -40,6 +61,10 @@ function parseArgs(argv: string[]): Args {
   let maxViewports = 1;
   let variant: string | undefined;
   let showUnverified = false;
+  let previousPath: string | undefined;
+  let persistSummaryPath: string | undefined;
+  let noHistory = false;
+  let failOnRegression = false;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
@@ -69,6 +94,24 @@ function parseArgs(argv: string[]): Args {
       case "--show-unverified":
         showUnverified = true;
         break;
+      case "--previous": {
+        const v = argv[++i];
+        if (!v) throw new Error("Missing value for --previous");
+        previousPath = v;
+        break;
+      }
+      case "--persist-summary": {
+        const v = argv[++i];
+        if (!v) throw new Error("Missing value for --persist-summary");
+        persistSummaryPath = v;
+        break;
+      }
+      case "--no-history":
+        noHistory = true;
+        break;
+      case "--fail-on-regression":
+        failOnRegression = true;
+        break;
       case "--help":
       case "-h":
         console.log(usage());
@@ -82,7 +125,32 @@ function parseArgs(argv: string[]): Args {
   if (positional.length !== 1) {
     throw new Error("Pass exactly one migration-report.json path");
   }
-  return { reportPath: positional[0]!, outPath, maxViewports, variant, showUnverified };
+  return {
+    reportPath: positional[0]!,
+    outPath,
+    maxViewports,
+    variant,
+    showUnverified,
+    previousPath,
+    persistSummaryPath,
+    noHistory,
+    failOnRegression,
+  };
+}
+
+async function loadPreviousSummary(path: string): Promise<PreviousRunSummary | undefined> {
+  if (!existsSync(path)) return undefined;
+  try {
+    const raw = await readFile(path, "utf-8");
+    const parsed = JSON.parse(raw) as PreviousRunSummary;
+    if (parsed && typeof parsed === "object" && parsed.byVariant && typeof parsed.byVariant === "object") {
+      return parsed;
+    }
+    return undefined;
+  } catch {
+    // Corrupt history file should not break the run.
+    return undefined;
+  }
 }
 
 async function main() {
@@ -102,10 +170,21 @@ async function main() {
   const report = JSON.parse(raw) as DfaReport;
   report.reportPath = reportPath;
 
+  // History resolution. Two modes:
+  //   --no-history: skip both load + write entirely (CI one-shots).
+  //   default:      auto-load + auto-persist .vrt/last-diff-for-agent.json,
+  //                 overridable via --previous / --persist-summary.
+  const historyPath = parsed.noHistory ? undefined : resolve(parsed.persistSummaryPath ?? DEFAULT_HISTORY_PATH);
+  const previousPath = parsed.noHistory
+    ? undefined
+    : resolve(parsed.previousPath ?? parsed.persistSummaryPath ?? DEFAULT_HISTORY_PATH);
+  const previous = previousPath ? await loadPreviousSummary(previousPath) : undefined;
+
   const md = formatMigrationReportForAgent(report, {
     maxViewports: parsed.maxViewports,
     variant: parsed.variant,
     showUnverified: parsed.showUnverified,
+    previous,
   });
 
   if (parsed.outPath) {
@@ -116,6 +195,28 @@ async function main() {
   } else {
     process.stdout.write(md);
     if (!md.endsWith("\n")) process.stdout.write("\n");
+  }
+
+  // Persist the current run for next time.
+  if (historyPath) {
+    const summary = buildPreviousRunSummary(report);
+    await mkdir(dirname(historyPath), { recursive: true });
+    await writeFile(historyPath, JSON.stringify(summary, null, 2));
+  }
+
+  // Optionally fail when a regression was detected. We re-run the
+  // detector here so the exit code matches what the markdown shows.
+  if (parsed.failOnRegression && previous) {
+    const variantsToCheck = parsed.variant
+      ? [parsed.variant]
+      : Array.from(new Set(report.results.map((r) => r.variantFile)));
+    for (const variantFile of variantsToCheck) {
+      const results = report.results.filter((r) => r.variantFile === variantFile);
+      const finding = detectRegression(results, previous, variantFile);
+      if (finding?.regressed) {
+        process.exit(1);
+      }
+    }
   }
 }
 

--- a/src/vrt/compare/diff-for-agent.test.ts
+++ b/src/vrt/compare/diff-for-agent.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { computeSectionDiffRows, formatMigrationReportForAgent, type DfaReport } from "./diff-for-agent.ts";
+import {
+  buildPreviousRunSummary,
+  computeSectionDiffRows,
+  detectRegression,
+  formatMigrationReportForAgent,
+  type DfaReport,
+  type PreviousRunSummary,
+} from "./diff-for-agent.ts";
 
 function sampleReport(over: Partial<DfaReport> = {}): DfaReport {
   return {
@@ -175,5 +182,110 @@ describe("formatMigrationReportForAgent", () => {
     assert.equal(rows[0].sectionRatio, 0.25);
     assert.equal(rows[1].rank, 2);
     assert.equal(rows[1].sectionRatio, 0.01);
+  });
+
+  it("fires the regression banner when the majority of viewports got worse", () => {
+    const previous: PreviousRunSummary = {
+      timestamp: "2026-05-18T00:00:00Z",
+      reportPath: "/work/fix/out/migration-report.prev.json",
+      byVariant: { "working.html": { mobile: 0.2, desktop: 0.1 } },
+    };
+    // Both viewports got worse: mobile 0.20 → 0.41, desktop 0.10 → 0.24
+    const md = formatMigrationReportForAgent(sampleReport(), { previous });
+    assert.match(md, /⚠ REGRESSION/);
+    assert.match(md, /2 of 2 viewports got worse/);
+    assert.match(md, /Previous report.*migration-report\.prev\.json/);
+  });
+
+  it("suppresses the regression banner when only a single viewport got worse (noise floor)", () => {
+    const previous: PreviousRunSummary = {
+      byVariant: { "working.html": { mobile: 0.2, desktop: 0.30 } },
+    };
+    // Only mobile got worse (desktop went from 0.30 → 0.24, an
+    // improvement). With totalViewports=2 the default threshold is 2,
+    // so the alarm should not fire on 1/2.
+    const md = formatMigrationReportForAgent(sampleReport(), { previous });
+    assert.doesNotMatch(md, /⚠ REGRESSION/);
+  });
+
+  it("ignores subpixel jitter under the epsilon threshold", () => {
+    const previous: PreviousRunSummary = {
+      // Just barely below current values — within the 0.005 epsilon.
+      byVariant: { "working.html": { mobile: 0.408, desktop: 0.237 } },
+    };
+    const md = formatMigrationReportForAgent(sampleReport(), { previous });
+    assert.doesNotMatch(md, /⚠ REGRESSION/);
+  });
+
+  it("does nothing when there's no comparable previous data for the variant", () => {
+    const previous: PreviousRunSummary = {
+      byVariant: { "other-variant.html": { mobile: 0.1 } },
+    };
+    const md = formatMigrationReportForAgent(sampleReport(), { previous });
+    assert.doesNotMatch(md, /⚠ REGRESSION/);
+  });
+});
+
+describe("detectRegression", () => {
+  const previous: PreviousRunSummary = {
+    timestamp: "2026-05-18T00:00:00Z",
+    byVariant: {
+      "v.html": { vp1: 0.1, vp2: 0.2, vp3: 0.3, vp4: 0.4, vp5: 0.5 },
+    },
+  };
+
+  it("threshold default is max(2, ceil(n/2)); 3 of 5 worsened fires the alarm", () => {
+    const finding = detectRegression(
+      [
+        { viewport: "vp1", diffRatio: 0.15 },  // +0.05  worse
+        { viewport: "vp2", diffRatio: 0.25 },  // +0.05  worse
+        { viewport: "vp3", diffRatio: 0.35 },  // +0.05  worse
+        { viewport: "vp4", diffRatio: 0.40 },  // ±0     unchanged
+        { viewport: "vp5", diffRatio: 0.50 },  // ±0     unchanged
+      ],
+      previous,
+      "v.html",
+    );
+    assert.ok(finding);
+    assert.equal(finding!.regressed, true);
+    assert.equal(finding!.worsenedViewports.length, 3);
+    assert.equal(finding!.threshold, 3);
+  });
+
+  it("2 of 5 worsened does NOT fire (below threshold)", () => {
+    const finding = detectRegression(
+      [
+        { viewport: "vp1", diffRatio: 0.15 },
+        { viewport: "vp2", diffRatio: 0.25 },
+        { viewport: "vp3", diffRatio: 0.30 },
+        { viewport: "vp4", diffRatio: 0.40 },
+        { viewport: "vp5", diffRatio: 0.50 },
+      ],
+      previous,
+      "v.html",
+    );
+    assert.ok(finding);
+    assert.equal(finding!.regressed, false);
+  });
+
+  it("1 worsened viewport never fires even when n=1 (floor of 2)", () => {
+    const prevOne: PreviousRunSummary = {
+      byVariant: { "v.html": { only: 0.1 } },
+    };
+    const finding = detectRegression(
+      [{ viewport: "only", diffRatio: 0.99 }],
+      prevOne,
+      "v.html",
+    );
+    assert.ok(finding);
+    assert.equal(finding!.regressed, false);
+    assert.equal(finding!.threshold, 2);
+  });
+
+  it("buildPreviousRunSummary round-trips per-variant per-viewport diff", () => {
+    const summary = buildPreviousRunSummary(sampleReport(), { timestamp: "fixed" });
+    assert.equal(summary.timestamp, "fixed");
+    assert.equal(summary.byVariant["working.html"]?.mobile, 0.4113);
+    assert.equal(summary.byVariant["working.html"]?.desktop, 0.2398);
   });
 });

--- a/src/vrt/compare/diff-for-agent.ts
+++ b/src/vrt/compare/diff-for-agent.ts
@@ -254,6 +254,115 @@ export interface DfaOptions {
    * at unverified rows. Subagent eval surfaced this as noise.
    */
   showUnverified?: boolean;
+  /**
+   * Previous run's per-viewport diffRatio (from
+   * `.vrt/last-diff-for-agent.json` or any callable source). When
+   * supplied, the report includes a regression banner if the majority
+   * of viewports got worse since the previous run.
+   */
+  previous?: PreviousRunSummary;
+  /**
+   * Tuning for the regression detector. Defaults are picked to ignore
+   * single-viewport noise (`minViewports >= 2`) and subpixel jitter
+   * (`epsilon = 0.005`).
+   */
+  regression?: {
+    epsilon?: number;
+    minViewports?: number;
+  };
+}
+
+/**
+ * Per-viewport diffRatio recorded at the end of one diff-for-agent run.
+ * The CLI persists this to `.vrt/last-diff-for-agent.json` and the next
+ * invocation passes it as `DfaOptions.previous` to drive the regression
+ * banner.
+ */
+export interface PreviousRunSummary {
+  /** ISO timestamp of the previous run, if known. */
+  timestamp?: string;
+  /** Absolute path of the previous migration-report.json. */
+  reportPath?: string;
+  /** variantFile → viewport label → diffRatio at the previous run. */
+  byVariant: Record<string, Record<string, number>>;
+}
+
+export interface RegressionFinding {
+  regressed: boolean;
+  worsenedViewports: Array<{ viewport: string; previous: number; current: number; delta: number }>;
+  totalViewports: number;
+  threshold: number;
+  previousTimestamp?: string;
+  previousReportPath?: string;
+}
+
+/**
+ * Decide whether the current per-viewport diff is a regression vs.
+ * the previous run.
+ *
+ * - "got worse" requires `current > previous + epsilon` (default 0.005
+ *   = 0.5% absolute). Filters out subpixel jitter, anti-aliasing
+ *   noise, etc.
+ * - "regression" requires worsened viewports >= threshold. Default
+ *   threshold = `max(2, ceil(total / 2))`. The 2-floor means a single
+ *   noisy viewport never triggers the alarm.
+ * - Returns `null` when there's no comparable previous data for the
+ *   variant — first-run, different variant set, etc.
+ */
+export function detectRegression(
+  results: ReadonlyArray<{ viewport: string; diffRatio: number }>,
+  previous: PreviousRunSummary,
+  variantFile: string,
+  options: { epsilon?: number; minViewports?: number } = {},
+): RegressionFinding | null {
+  const prevByViewport = previous.byVariant[variantFile];
+  if (!prevByViewport) return null;
+  const epsilon = options.epsilon ?? 0.005;
+  const totalViewports = results.length;
+  if (totalViewports === 0) return null;
+  const threshold = options.minViewports ?? Math.max(2, Math.ceil(totalViewports / 2));
+  const worsened = results
+    .filter((r) => {
+      const prev = prevByViewport[r.viewport];
+      return typeof prev === "number" && r.diffRatio > prev + epsilon;
+    })
+    .map((r) => {
+      const prev = prevByViewport[r.viewport]!;
+      return {
+        viewport: r.viewport,
+        previous: prev,
+        current: r.diffRatio,
+        delta: r.diffRatio - prev,
+      };
+    });
+  return {
+    regressed: worsened.length >= threshold,
+    worsenedViewports: worsened,
+    totalViewports,
+    threshold,
+    previousTimestamp: previous.timestamp,
+    previousReportPath: previous.reportPath,
+  };
+}
+
+/**
+ * Build the persistable summary for the *current* run. Pair with
+ * `detectRegression` on the next invocation.
+ */
+export function buildPreviousRunSummary(
+  report: DfaReport,
+  options: { timestamp?: string } = {},
+): PreviousRunSummary {
+  const byVariant: Record<string, Record<string, number>> = {};
+  for (const r of report.results) {
+    const variantBucket = byVariant[r.variantFile] ?? (byVariant[r.variantFile] = {});
+    variantBucket[r.viewport] = r.diffRatio;
+  }
+  return {
+    timestamp: options.timestamp ?? new Date().toISOString(),
+    reportPath: report.reportPath,
+    byVariant,
+  };
 }
 
 interface FixCandidateAggregate {
@@ -627,6 +736,33 @@ export function formatMigrationReportForAgent(
         "**Forced-state diff** section below. This pattern usually means the " +
         "variant forgot to wire up interaction-state styles.");
       lines.push("");
+    }
+
+    // Regression alarm — fires when the majority of viewports got
+    // worse since the previous run. See the 2026-05-12 subagent eval:
+    // both subagents wasted an iteration on a regression that needed
+    // manual reverting. The threshold floor of 2 viewports prevents a
+    // single noisy viewport from triggering the alarm.
+    if (options.previous) {
+      const finding = detectRegression(sorted, options.previous, variantFile, options.regression);
+      if (finding?.regressed) {
+        lines.push("### ⚠ REGRESSION");
+        lines.push("");
+        lines.push(`**${finding.worsenedViewports.length} of ${finding.totalViewports} viewports got worse since the previous run** ` +
+          `(threshold ≥ ${finding.threshold}). Consider reverting the last patch and re-running.`);
+        lines.push("");
+        lines.push("| Viewport | Previous | Current | Δ |");
+        lines.push("|---|---|---|---|");
+        for (const w of finding.worsenedViewports) {
+          const deltaPct = `+${(w.delta * 100).toFixed(2)}%`;
+          lines.push(`| \`${w.viewport}\` | ${(w.previous * 100).toFixed(2)}% | ${(w.current * 100).toFixed(2)}% | ${deltaPct} |`);
+        }
+        if (finding.previousReportPath) {
+          lines.push("");
+          lines.push(`Previous report: \`${finding.previousReportPath}\``);
+        }
+        lines.push("");
+      }
     }
 
     // Class-rename map at the top — subagent C called this "the single


### PR DESCRIPTION
Closes #20.

## Summary

The 2026-05-12 subagent eval shows both subagents wasted an iteration on a regression that needed manual reverting — the report after the bad patch reads neutral and the agent pushes ahead. This PR adds a loud \"⚠ REGRESSION\" banner so the case short-circuits.

## Mechanism

- Each run of \`vrt diff-for-agent\` persists the current per-viewport diffRatio to \`.vrt/last-diff-for-agent.json\` (already gitignored).
- The next invocation auto-loads that file as the comparison baseline.
- \`detectRegression\` decides:
  - **\"got worse\"** = \`current > previous + 0.005\` (= 0.5% absolute). Filters subpixel / anti-aliasing jitter.
  - **\"regression\"** = worsened viewports ≥ threshold. Default = \`max(2, ceil(total/2))\`. The 2-floor blocks single-viewport noise from triggering.
- When fired, the markdown gets a \`### ⚠ REGRESSION\` section at the top of the variant block with a Previous / Current / Δ table and a pointer back to the previous report path.

## CLI surface

| Flag | Purpose |
|---|---|
| \`--previous <path>\` | Explicit comparison source |
| \`--persist-summary <path>\` | Override the destination |
| \`--no-history\` | Skip both load + write (CI one-shots) |
| \`--fail-on-regression\` | Exit 1 when a regression is detected |

## Output shape

\`\`\`
### ⚠ REGRESSION

**3 of 5 viewports got worse since the previous run** (threshold ≥ 3). Consider reverting the last patch and re-running.

| Viewport | Previous | Current | Δ |
|---|---|---|---|
| \`mobile-360\` | 20.00% | 41.13% | +21.13% |
| \`desktop-1280\` | 10.00% | 23.98% | +13.98% |
...

Previous report: \`/work/fix/out/migration-report.prev.json\`
\`\`\`

## Test plan

- [x] 4 new cases on \`formatMigrationReportForAgent\` — banner fires (2/2 worsened), noise floor suppresses 1/2, 0.5% epsilon suppresses sub-jitter, variant mismatch is no-op
- [x] 4 new cases on \`detectRegression\` — 3/5 fires, 2/5 does not, n=1 never fires, summary round-trips
- [x] \`pnpm test\` → 768/768 PASS
- [x] CLI \`--help\` shows the new flags + the regression-detection paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)