### PR TITLE
Capture computed-style at every viewport with breakpoint-gated split (closes #21)

### DIFF
--- a/packages/vrt-core/src/computed-style-diff.test.ts
+++ b/packages/vrt-core/src/computed-style-diff.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { diffComputedStyles, type ComputedStyleSnapshot } from "./computed-style-diff.ts";
+import {
+  aggregateCsdByViewport,
+  diffComputedStyles,
+  type ComputedStyleSnapshot,
+} from "./computed-style-diff.ts";
 
 const A: ComputedStyleSnapshot = {
   ".luna-page": { "padding-left": "20px", "padding-right": "20px", "max-width": "1180px" },
@@ -62,5 +66,71 @@ describe("diffComputedStyles", () => {
     assert.equal(r.totalDiffs, 1);
     assert.equal(r.entries[0]!.baseline, "red");
     assert.equal(r.entries[0]!.variant, "");
+  });
+});
+
+describe("aggregateCsdByViewport", () => {
+  // Mobile: `.btn padding` 10px → 6px. Desktop: same `.btn padding` differs
+  // PLUS `.card gap` 12px → 0px appears only on desktop (= media-gated).
+  const mobileBaseline: ComputedStyleSnapshot = {
+    ".btn": { padding: "10px", "border-radius": "8px" },
+    ".card": { gap: "12px" },
+  };
+  const mobileVariant: ComputedStyleSnapshot = {
+    ".btn": { padding: "6px", "border-radius": "8px" },
+    ".card": { gap: "12px" },
+  };
+  const desktopBaseline: ComputedStyleSnapshot = {
+    ".btn": { padding: "10px", "border-radius": "8px" },
+    ".card": { gap: "12px" },
+  };
+  const desktopVariant: ComputedStyleSnapshot = {
+    ".btn": { padding: "6px", "border-radius": "8px" },
+    ".card": { gap: "0px" }, // only desktop differs
+  };
+
+  it("classifies universal vs. breakpoint-gated (selector, property) pairs", () => {
+    const r = aggregateCsdByViewport([
+      { viewport: "mobile", result: diffComputedStyles(mobileBaseline, mobileVariant) },
+      { viewport: "desktop", result: diffComputedStyles(desktopBaseline, desktopVariant) },
+    ]);
+    // .btn padding differs on both → universal
+    // .card gap differs only on desktop → breakpoint-gated
+    assert.deepEqual(r.universalPairs.sort(), [".btn|padding"]);
+    assert.deepEqual(r.breakpointGatedPairs.sort(), [".card|gap"]);
+    assert.equal(r.totalDiffs, 3); // mobile (.btn) + desktop (.btn + .card)
+    assert.equal(r.byViewport.length, 2);
+  });
+
+  it("samples carry per-viewport baseline + variant values for breakpoint-gated rows", () => {
+    const r = aggregateCsdByViewport([
+      { viewport: "mobile", result: diffComputedStyles(mobileBaseline, mobileVariant) },
+      { viewport: "desktop", result: diffComputedStyles(desktopBaseline, desktopVariant) },
+    ]);
+    const gated = r.bySelectorProperty.find((e) => e.selector === ".card" && e.property === "gap");
+    assert.ok(gated);
+    assert.deepEqual(gated!.viewports, ["desktop"]);
+    assert.equal(gated!.samples.length, 1);
+    assert.equal(gated!.samples[0]!.baseline, "12px");
+    assert.equal(gated!.samples[0]!.variant, "0px");
+  });
+
+  it("sorts bySelectorProperty by viewport-coverage desc (universal first)", () => {
+    const r = aggregateCsdByViewport([
+      { viewport: "mobile", result: diffComputedStyles(mobileBaseline, mobileVariant) },
+      { viewport: "desktop", result: diffComputedStyles(desktopBaseline, desktopVariant) },
+    ]);
+    // Universal (.btn padding, viewports=2) should sort before
+    // breakpoint-gated (.card gap, viewports=1).
+    assert.equal(r.bySelectorProperty[0]!.viewports.length, 2);
+    assert.ok(r.bySelectorProperty[r.bySelectorProperty.length - 1]!.viewports.length < 2);
+  });
+
+  it("returns empty result when given no viewports", () => {
+    const r = aggregateCsdByViewport([]);
+    assert.equal(r.totalDiffs, 0);
+    assert.deepEqual(r.byViewport, []);
+    assert.deepEqual(r.universalPairs, []);
+    assert.deepEqual(r.breakpointGatedPairs, []);
   });
 });

--- a/packages/vrt-core/src/computed-style-diff.ts
+++ b/packages/vrt-core/src/computed-style-diff.ts
@@ -35,6 +35,101 @@ export interface CsdResult {
   selectorsOnlyInVariant: string[];
 }
 
+export interface CsdPerViewportSample {
+  viewport: string;
+  baseline: string;
+  variant: string;
+}
+
+export interface CsdPerViewportEntry {
+  selector: string;
+  property: string;
+  /** Viewports on which this (selector, property) pair differs. */
+  viewports: string[];
+  samples: CsdPerViewportSample[];
+}
+
+export interface CsdPerViewportResult {
+  /** Total (selector, property, viewport) tuples — i.e. Σ per-viewport counts. */
+  totalDiffs: number;
+  byViewport: Array<{ viewport: string; count: number }>;
+  /**
+   * One row per unique (selector, property) pair, listing which viewports
+   * it differs on and the actual baseline/variant samples per viewport.
+   */
+  bySelectorProperty: CsdPerViewportEntry[];
+  /**
+   * "selector|property" tokens for pairs that differ on every viewport.
+   * A consumer rendering "fix the base rule" tables wants this subset.
+   */
+  universalPairs: string[];
+  /**
+   * "selector|property" tokens for pairs that differ on a strict subset
+   * of viewports. Almost always a `@media` rule is missing or wrong.
+   */
+  breakpointGatedPairs: string[];
+}
+
+/**
+ * Roll up N per-viewport CSD results into a single per-viewport report,
+ * surfacing which pairs apply universally vs. which are breakpoint-gated.
+ *
+ * Stable iteration order: results are taken in the input array's order,
+ * which is the same order migration-compare captures viewports (small →
+ * large or whatever the caller chose).
+ */
+export function aggregateCsdByViewport(
+  perViewport: ReadonlyArray<{ viewport: string; result: CsdResult }>,
+): CsdPerViewportResult {
+  const totalViewports = perViewport.length;
+  const pairToEntry = new Map<string, CsdPerViewportEntry>();
+  const byViewport: Array<{ viewport: string; count: number }> = [];
+
+  for (const { viewport, result } of perViewport) {
+    byViewport.push({ viewport, count: result.entries.length });
+    for (const entry of result.entries) {
+      const key = `${entry.selector}|${entry.property}`;
+      const existing = pairToEntry.get(key);
+      if (existing) {
+        existing.viewports.push(viewport);
+        existing.samples.push({ viewport, baseline: entry.baseline, variant: entry.variant });
+      } else {
+        pairToEntry.set(key, {
+          selector: entry.selector,
+          property: entry.property,
+          viewports: [viewport],
+          samples: [{ viewport, baseline: entry.baseline, variant: entry.variant }],
+        });
+      }
+    }
+  }
+
+  const bySelectorProperty = [...pairToEntry.values()].sort((a, b) => {
+    if (b.viewports.length !== a.viewports.length) return b.viewports.length - a.viewports.length;
+    if (a.selector !== b.selector) return a.selector.localeCompare(b.selector);
+    return a.property.localeCompare(b.property);
+  });
+
+  const universalPairs: string[] = [];
+  const breakpointGatedPairs: string[] = [];
+  for (const entry of bySelectorProperty) {
+    const token = `${entry.selector}|${entry.property}`;
+    if (totalViewports > 0 && entry.viewports.length === totalViewports) {
+      universalPairs.push(token);
+    } else {
+      breakpointGatedPairs.push(token);
+    }
+  }
+
+  return {
+    totalDiffs: byViewport.reduce((sum, e) => sum + e.count, 0),
+    byViewport,
+    bySelectorProperty,
+    universalPairs,
+    breakpointGatedPairs,
+  };
+}
+
 const EMPTY: CsdResult = {
   entries: [],
   totalDiffs: 0,

--- a/src/experiments/migration/migration-compare.ts
+++ b/src/experiments/migration/migration-compare.ts
@@ -73,7 +73,7 @@ import {
   type DomEquivalenceResult,
 } from "@mizchi/vrt-core/dom-equivalence.ts";
 import { buildComputedStyleCaptureJsonExpression, parseComputedStyleSnapshot } from "@mizchi/vrt-core/computed-style-capture.ts";
-import { diffComputedStyles, type CsdResult, type ComputedStyleSnapshot } from "@mizchi/vrt-core/computed-style-diff.ts";
+import { aggregateCsdByViewport, diffComputedStyles, type CsdPerViewportResult, type CsdResult, type ComputedStyleSnapshot } from "@mizchi/vrt-core/computed-style-diff.ts";
 import {
   diffDomPositionStyles,
   diffPositionStylesAcrossViewports,
@@ -461,6 +461,15 @@ export interface MigrationCompareReport {
     variantFile: string;
     result: CsdResult;
   }>;
+  /**
+   * Per-viewport CSD: each (selector, property) pair is rolled up with
+   * the viewports it differs on, plus universal vs. breakpoint-gated
+   * sets so consumers can split base rules from `@media`-gated ones.
+   */
+  computedStyleDiffPerViewport?: Array<{
+    variantFile: string;
+    result: CsdPerViewportResult;
+  }>;
   domPositionDiff?: Array<{
     variantFile: string;
     result: DpResult;
@@ -802,6 +811,7 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
     let baselineSanity: RenderSanityResult | undefined;
     let baselineDomFingerprint: DomFingerprint | undefined;
     let baselineComputedStyles: ComputedStyleSnapshot | undefined;
+    const baselineComputedStylesByVp = new Map<string, ComputedStyleSnapshot>();
     let baselineDomPositionStyles: PositionedElement[] | undefined;
     const baselineDomPositionByVp = new Map<string, PositionedElement[]>();
     const baselineBboxesByVp = new Map<string, BboxElement[]>();
@@ -874,13 +884,20 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
         }
       }
 
-      // Capture baseline computed-style snapshot once (first viewport).
-      if (csdEnabled && vpIndex === 0) {
+      // Capture baseline computed-style snapshot at every viewport so
+      // we can flag breakpoint-gated rules. Closes #21 — single-sample
+      // CSD without viewport tag made subagents apply mobile fixes to
+      // desktop and vice-versa. `baselineComputedStyles` (the legacy
+      // single-snapshot field) keeps pointing at the first-viewport
+      // capture for any consumer that only knows the old shape.
+      if (csdEnabled) {
         try {
           const raw = await page.evaluate(buildComputedStyleCaptureJsonExpression());
-          baselineComputedStyles = parseComputedStyleSnapshot(raw) as ComputedStyleSnapshot;
+          const snapshot = parseComputedStyleSnapshot(raw) as ComputedStyleSnapshot;
+          baselineComputedStylesByVp.set(vp.label, snapshot);
+          if (vpIndex === 0) baselineComputedStyles = snapshot;
         } catch (error) {
-          console.log(`  ${YELLOW}Baseline computed-style capture error: ${String(error)}${RESET}`);
+          console.log(`  ${YELLOW}Baseline computed-style capture error (${vp.label}): ${String(error)}${RESET}`);
         }
       }
 
@@ -956,6 +973,7 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
 
     const domEquivalenceReports: Array<{ variantFile: string; result: DomEquivalenceResult }> = [];
     const computedStyleDiffReports: Array<{ variantFile: string; result: CsdResult }> = [];
+    const computedStyleDiffPerViewportReports: Array<{ variantFile: string; result: CsdPerViewportResult }> = [];
     const domPositionDiffReports: Array<{ variantFile: string; result: DpResult }> = [];
     const domPositionDiffPerViewportReports: Array<{ variantFile: string; result: DpPerViewportResult }> = [];
     const shiftOriginsReports: Array<{ variantFile: string; perViewport: Array<{ viewport: string; origins: ShiftOrigin[]; unexplainedBands?: ShiftRegion[] }> }> = [];
@@ -996,6 +1014,7 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
 
       let variantDomFingerprint: DomFingerprint | undefined;
       let variantComputedStyles: ComputedStyleSnapshot | undefined;
+      const variantComputedStylesByVp = new Map<string, ComputedStyleSnapshot>();
       let variantDomPositionStyles: PositionedElement[] | undefined;
       const variantDomPositionByVp = new Map<string, PositionedElement[]>();
       const variantBboxesByVp = new Map<string, BboxElement[]>();
@@ -1071,12 +1090,14 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
             console.log(`  ${YELLOW}Variant DOM fingerprint error (${variantName}): ${String(error)}${RESET}`);
           }
         }
-        if (csdEnabled && vpIndex === 0 && !variantComputedStyles) {
+        if (csdEnabled) {
           try {
             const raw = await page.evaluate(buildComputedStyleCaptureJsonExpression());
-            variantComputedStyles = parseComputedStyleSnapshot(raw) as ComputedStyleSnapshot;
+            const snapshot = parseComputedStyleSnapshot(raw) as ComputedStyleSnapshot;
+            variantComputedStylesByVp.set(vp.label, snapshot);
+            if (vpIndex === 0 && !variantComputedStyles) variantComputedStyles = snapshot;
           } catch (error) {
-            console.log(`  ${YELLOW}Variant computed-style capture error (${variantName}): ${String(error)}${RESET}`);
+            console.log(`  ${YELLOW}Variant computed-style capture error (${variantName} / ${vp.label}): ${String(error)}${RESET}`);
           }
         }
         if (dpEnabled) {
@@ -1389,6 +1410,42 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
             .join(", ");
           console.log(`  ${DIM}Computed-style diff: ${result.totalDiffs} (selector, prop) ` +
             `tuples. Top properties: ${topProps}${RESET}`);
+        }
+
+        // Per-viewport CSD: diff each viewport pair, then aggregate to
+        // surface universal vs. breakpoint-gated (selector, property)
+        // pairs. Quiet when there are no per-viewport captures (e.g.
+        // first-run hiccup) — the legacy single-snapshot diff above
+        // still carries that case.
+        if (baselineComputedStylesByVp.size > 0 && variantComputedStylesByVp.size > 0) {
+          const perViewportDiffs: Array<{ viewport: string; result: CsdResult }> = [];
+          for (const vp of VIEWPORTS) {
+            const baselineSnap = baselineComputedStylesByVp.get(vp.label);
+            const variantSnap = variantComputedStylesByVp.get(vp.label);
+            if (!baselineSnap || !variantSnap) continue;
+            perViewportDiffs.push({
+              viewport: vp.label,
+              result: diffComputedStyles(baselineSnap, variantSnap),
+            });
+          }
+          if (perViewportDiffs.length > 0) {
+            const perViewportResult = aggregateCsdByViewport(perViewportDiffs);
+            // Cap bySelectorProperty to keep migration-report.json under
+            // budget on fixtures with many tiny per-element diffs.
+            const trimmedPerViewport: CsdPerViewportResult = {
+              ...perViewportResult,
+              bySelectorProperty: perViewportResult.bySelectorProperty.slice(0, 200),
+            };
+            computedStyleDiffPerViewportReports.push({
+              variantFile: variantFileLabel,
+              result: trimmedPerViewport,
+            });
+            if (perViewportResult.totalDiffs > 0) {
+              console.log(`  ${DIM}Per-viewport CSD: ${perViewportResult.bySelectorProperty.length} unique pairs ` +
+                `(${perViewportResult.universalPairs.length} universal, ` +
+                `${perViewportResult.breakpointGatedPairs.length} breakpoint-gated)${RESET}`);
+            }
+          }
         }
       }
 
@@ -1928,6 +1985,7 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
       baselineSanity,
       domEquivalence: domEquivalenceReports.length > 0 ? domEquivalenceReports : undefined,
       computedStyleDiff: computedStyleDiffReports.length > 0 ? computedStyleDiffReports : undefined,
+      computedStyleDiffPerViewport: computedStyleDiffPerViewportReports.length > 0 ? computedStyleDiffPerViewportReports : undefined,
       domPositionDiff: domPositionDiffReports.length > 0 ? domPositionDiffReports : undefined,
       domPositionDiffPerViewport: domPositionDiffPerViewportReports.length > 0
         ? domPositionDiffPerViewportReports

--- a/src/vrt/compare/diff-for-agent.test.ts
+++ b/src/vrt/compare/diff-for-agent.test.ts
@@ -289,3 +289,62 @@ describe("detectRegression", () => {
     assert.equal(summary.byVariant["working.html"]?.desktop, 0.2398);
   });
 });
+
+describe("formatMigrationReportForAgent — per-viewport CSD", () => {
+  it("emits universal and breakpoint-gated tables with sample values per viewport", () => {
+    const md = formatMigrationReportForAgent(sampleReport({
+      computedStyleDiffPerViewport: [{
+        variantFile: "working.html",
+        result: {
+          totalDiffs: 3,
+          byViewport: [
+            { viewport: "mobile", count: 1 },
+            { viewport: "desktop", count: 2 },
+          ],
+          universalPairs: [".btn|padding"],
+          breakpointGatedPairs: [".card|gap"],
+          bySelectorProperty: [
+            {
+              selector: ".btn", property: "padding",
+              viewports: ["mobile", "desktop"],
+              samples: [
+                { viewport: "mobile", baseline: "10px", variant: "6px" },
+                { viewport: "desktop", baseline: "10px", variant: "6px" },
+              ],
+            },
+            {
+              selector: ".card", property: "gap",
+              viewports: ["desktop"],
+              samples: [
+                { viewport: "desktop", baseline: "12px", variant: "0px" },
+              ],
+            },
+          ],
+        },
+      }],
+    }));
+    assert.match(md, /Verified deltas \(computed-style\) × viewport/);
+    assert.match(md, /Universal pairs/);
+    assert.match(md, /Breakpoint-gated pairs/);
+    // Universal row shows the simple baseline → variant pair (no viewport column).
+    assert.match(md, /\| `\.btn` \| `padding` \| `10px` \| `6px` \|/);
+    // Breakpoint-gated row shows which viewports + sample with viewport label.
+    assert.match(md, /\| `\.card` \| `gap` \| desktop \| `desktop`: `12px` → `0px`/);
+  });
+
+  it("skips the per-viewport CSD section entirely when totalDiffs is 0", () => {
+    const md = formatMigrationReportForAgent(sampleReport({
+      computedStyleDiffPerViewport: [{
+        variantFile: "working.html",
+        result: {
+          totalDiffs: 0,
+          byViewport: [],
+          universalPairs: [],
+          breakpointGatedPairs: [],
+          bySelectorProperty: [],
+        },
+      }],
+    }));
+    assert.doesNotMatch(md, /Verified deltas \(computed-style\) × viewport/);
+  });
+});

--- a/src/vrt/compare/diff-for-agent.ts
+++ b/src/vrt/compare/diff-for-agent.ts
@@ -50,6 +50,24 @@ export interface DfaCsdSummary {
   };
 }
 
+export interface DfaCsdPerViewportEntry {
+  selector: string;
+  property: string;
+  viewports: string[];
+  samples: Array<{ viewport: string; baseline: string; variant: string }>;
+}
+
+export interface DfaCsdPerViewportSummary {
+  variantFile: string;
+  result: {
+    totalDiffs: number;
+    byViewport: Array<{ viewport: string; count: number }>;
+    bySelectorProperty: DfaCsdPerViewportEntry[];
+    universalPairs: string[];
+    breakpointGatedPairs: string[];
+  };
+}
+
 export interface DfaDpEntry {
   path: string;
   tag: string;
@@ -147,6 +165,7 @@ export interface DfaReport {
   viewports: Array<{ label: string; width: number; height?: number }>;
   results: DfaResult[];
   computedStyleDiff?: DfaCsdSummary[];
+  computedStyleDiffPerViewport?: DfaCsdPerViewportSummary[];
   domPositionDiff?: DfaDpSummary[];
   domPositionDiffPerViewport?: DfaDpPerViewportSummary[];
   shiftOrigins?: DfaShiftOriginsSummary[];
@@ -1347,6 +1366,65 @@ export function formatMigrationReportForAgent(
       }
     }
 
+    const csdPerVpSummary = (report.computedStyleDiffPerViewport ?? []).find((c) => c.variantFile === variantFile);
+    if (csdPerVpSummary && csdPerVpSummary.result.totalDiffs > 0) {
+      lines.push("### Verified deltas (computed-style) × viewport (catches breakpoint-gated rules)");
+      lines.push("");
+      lines.push("Each (selector, property) is captured at every snapshot viewport. " +
+        "*Universal* pairs differ on every viewport — fix the base rule. " +
+        "*Breakpoint-gated* pairs differ only on a subset — almost always a missing " +
+        "or wrong `@media` rule. Without this split, mobile-only deltas were getting " +
+        "patched into the desktop rule and vice-versa.");
+      lines.push("");
+      lines.push(`Total: **${csdPerVpSummary.result.totalDiffs}** (selector, property, viewport) tuples ` +
+        `across ${csdPerVpSummary.result.byViewport.length} viewports ` +
+        `(${csdPerVpSummary.result.universalPairs.length} universal pair(s), ` +
+        `${csdPerVpSummary.result.breakpointGatedPairs.length} breakpoint-gated pair(s)).`);
+      lines.push("");
+
+      const universalRows = csdPerVpSummary.result.bySelectorProperty.filter(
+        (e) => e.viewports.length === csdPerVpSummary.result.byViewport.length,
+      );
+      if (universalRows.length > 0) {
+        lines.push("#### Universal pairs (every viewport — fix the base rule)");
+        lines.push("");
+        lines.push("| Selector | Property | Baseline | Variant |");
+        lines.push("|---|---|---|---|");
+        for (const row of universalRows.slice(0, 15)) {
+          // All viewports agree, so pick the first sample for the displayed value.
+          const sample = row.samples[0]!;
+          lines.push(`| \`${row.selector}\` | \`${row.property}\` | \`${sample.baseline}\` | \`${sample.variant}\` |`);
+        }
+        if (universalRows.length > 15) {
+          lines.push(`| _…${universalRows.length - 15} more universal pairs_ | | | |`);
+        }
+        lines.push("");
+      }
+
+      const gatedRows = csdPerVpSummary.result.bySelectorProperty.filter(
+        (e) => e.viewports.length < csdPerVpSummary.result.byViewport.length,
+      );
+      if (gatedRows.length > 0) {
+        lines.push("#### Breakpoint-gated pairs (missing or wrong `@media` rule)");
+        lines.push("");
+        lines.push("| Selector | Property | Affected viewports | Sample (viewport: baseline → variant) |");
+        lines.push("|---|---|---|---|");
+        for (const row of gatedRows.slice(0, 15)) {
+          const vps = row.viewports.join(", ");
+          const sampleText = row.samples
+            .slice(0, 3)
+            .map((s) => `\`${s.viewport}\`: \`${s.baseline}\` → \`${s.variant}\``)
+            .join("; ");
+          const moreSamples = row.samples.length > 3 ? ` (+${row.samples.length - 3} more)` : "";
+          lines.push(`| \`${row.selector}\` | \`${row.property}\` | ${vps} | ${sampleText}${moreSamples} |`);
+        }
+        if (gatedRows.length > 15) {
+          lines.push(`| _…${gatedRows.length - 15} more breakpoint-gated pairs_ | | | |`);
+        }
+        lines.push("");
+      }
+    }
+
     // Scenario detector. The current "Suggested next step" wording
     // assumes the migration scenario (read PNGs → cross-check fix
     // candidates → write CSS patch). Subagent F's eval showed that
@@ -1357,6 +1435,7 @@ export function formatMigrationReportForAgent(
     const hasDomSignal =
       (dpSummary?.result.totalDiffs ?? 0) > 0 ||
       (csdSummary?.result.totalDiffs ?? 0) > 0 ||
+      (csdPerVpSummary?.result.totalDiffs ?? 0) > 0 ||
       fixCandidates.length > 0;
     const hasWireframeSignal =
       (bboxSummary?.perViewport.length ?? 0) > 0 ||


### PR DESCRIPTION
Closes #21.

## Summary

Today the computed-style diff (CSD) is a single first-viewport sample with no viewport tag. The 2026-05-12 subagent eval shows breakpoint-related fixes getting applied to the wrong place because the report can't tell mobile from desktop. This PR widens capture to every snapshot viewport and renders a **universal vs. breakpoint-gated** split.

## Changes

| Layer | What |
|---|---|
| \`computed-style-diff.ts\` | New \`CsdPerViewportResult\` + \`aggregateCsdByViewport(perViewport)\` — rolls N \`CsdResult\`s into one report with \`universalPairs\` / \`breakpointGatedPairs\` precomputed |
| \`migration-compare.ts\` | Capture baseline + variant computed-style at every viewport (legacy single-snapshot fields still pointed at viewport 0 for back-compat); diff per viewport; aggregate; emit new \`computedStyleDiffPerViewport\` report field |
| \`diff-for-agent.ts\` | New \"Verified deltas (computed-style) × viewport\" section with two subtables: Universal (every viewport — fix base rule) and Breakpoint-gated (missing/wrong \`@media\` — sample shows viewport: baseline → variant) |

## Output shape (markdown)

\`\`\`
### Verified deltas (computed-style) × viewport (catches breakpoint-gated rules)

Total: **3** (selector, property, viewport) tuples across 2 viewports
(1 universal pair(s), 1 breakpoint-gated pair(s)).

#### Universal pairs (every viewport — fix the base rule)
| Selector | Property | Baseline | Variant |
|---|---|---|---|
| \`.btn\` | \`padding\` | \`10px\` | \`6px\` |

#### Breakpoint-gated pairs (missing or wrong \`@media\` rule)
| Selector | Property | Affected viewports | Sample (viewport: baseline → variant) |
|---|---|---|---|
| \`.card\` | \`gap\` | desktop | \`desktop\`: \`12px\` → \`0px\` |
\`\`\`

## Test plan

- [x] 4 new cases on \`aggregateCsdByViewport\` — classification, samples, sort order, empty-input
- [x] 2 new cases on \`formatMigrationReportForAgent\` — both subtables render with samples; skipped when totalDiffs=0
- [x] \`pnpm test\` → 776/776 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)