### PR TITLE
Add five agent-facing skills + APM manifest

### DIFF
--- a/.claude/skills/vrt-css-fix-loop/SKILL.md
+++ b/.claude/skills/vrt-css-fix-loop/SKILL.md
@@ -187,6 +187,17 @@ VLM's proposals aren't parseable, or the LLM's emitted fixes aren't
 structurally valid CSS. Set `DEBUG_VRT=1` to see both stages' raw
 output.
 
+At the end of the run, a summary table prints one row per round
+with columns:
+
+| Column | Meaning |
+|---|---|
+| `Round` | 1-indexed iteration number |
+| `Diff` | diffRatio after this round's edits applied |
+| `Changes` | rows in VLM's CHANGE list (Stage 1) |
+| `Fixes` | CSS edits emitted by LLM (Stage 2). Usually `Fixes ≥ Changes` |
+| `Escalated` | `false` if the default LLM tier handled it; `true` if the harness fell back to a higher-capability model. A run with `Escalated=true` cost more — relevant for cross-model benchmarks. |
+
 ## Adapting to a new repo
 
 The harness is fixture-bound — to run on a user repo:

--- a/.claude/skills/vrt-css-fix-loop/SKILL.md
+++ b/.claude/skills/vrt-css-fix-loop/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: vrt-css-fix-loop
+description: Closed-loop CSS auto-repair. Given a fixture with a known regression (one CSS property or one selector block removed), iterate with a VLM that proposes the missing fix from the diff screenshot, apply it, and re-run until the diff falls below a threshold. Currently scoped to the CSS-challenge fixture set in `src/experiments/css-challenge/`; adapting to an arbitrary repo requires writing a fixture entry. Use when measuring whether a VLM model can recover a known regression, not for production self-healing.
+---
+
+# vrt-css-fix-loop
+
+`fix-loop` is the harness behind every VLM benchmark in this repo
+(`docs/reports/2026-05-18-vlm-claude-vs-openrouter-vs-newcomers.md`
+etc.). It takes a fixture, deliberately mutates the CSS (`property`
+mode deletes one property; `selector` mode deletes one selector
+block), then asks a VLM to propose the fix from the rendered diff.
+Each round:
+
+1. Apply current candidate CSS to the variant page.
+2. Render baseline + variant; compute pixel diff.
+3. Send the diff overlay to the VLM with a structured "list the
+   changes" prompt.
+4. Parse the VLM's CHANGE list; apply the top candidate.
+5. Re-run; stop when diffRatio falls below threshold (= FIXED) or
+   `--max-rounds` is exhausted.
+
+## When to use
+
+- Evaluating a new VLM model on UI-domain understanding.
+- Comparing two model providers on the same fixture (controlled
+  benchmark).
+- Understanding "what kind of fix can a VLM actually propose?" before
+  shipping a self-healing feature.
+
+## When NOT to use
+
+- Production self-repair on an arbitrary user repo — the harness only
+  knows fixtures registered in `css-challenge-fixtures.ts`. Adapting
+  to a new repo means writing a fixture entry + goal CSS first.
+- Bulk regression triage: use `vrt-visual-diff` for one-shot reads.
+- Per-PR CI gate: use `vrt-regression-watch`.
+
+## Quickstart
+
+```bash
+# Property mode (default): delete one CSS property; VLM proposes restoration
+node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
+  --fixture page --seed 42
+
+# Selector mode: delete one full selector block (harder)
+node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
+  --fixture page --seed 11 --mode selector --max-rounds 3
+
+# Run with a specific VLM model (any OpenRouter id, `gemini:*`, or `claude:*`)
+VRT_VLM_MODEL="bytedance/ui-tars-1.5-7b" \
+  node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
+  --fixture page --seed 11 --mode selector
+```
+
+## Available fixtures
+
+Listed in `src/experiments/css-challenge/css-challenge-fixtures.ts`.
+Common entries:
+
+| Fixture | Layout | Typical seeds |
+|---|---|---|
+| `page` | README-style article + sidebar | 1-99 |
+| (others registered in the file) | … | … |
+
+The seed maps deterministically to "which property / selector got
+deleted." Seed 11 in selector mode is the canonical hard case
+(`.readme-body pre` losing 6 properties → 4.1% diffRatio) used in
+VLM benchmarks.
+
+## VLM model selection
+
+The harness honours `VRT_VLM_MODEL`. Prefix selects the provider:
+
+| Prefix | Provider | Example |
+|---|---|---|
+| (no prefix) | OpenRouter | `bytedance/ui-tars-1.5-7b` |
+| `gemini:` | Google AI | `gemini:gemini-2.5-flash` |
+| `claude:` | Anthropic | `claude:claude-haiku-4-5-20251001` |
+
+Current recommendations (from `.claude/CLAUDE.md`):
+
+- **Default**: `bytedance/ui-tars-1.5-7b` (UI-domain-trained, ~1.2s).
+- **Stable / detailed**: `qwen/qwen3-vl-30b-a3b-instruct`.
+- **Baseline fallback**: `amazon/nova-lite-v1`.
+- **High quality** (only when VLM output isn't consumed by Stage-2
+  LLM): `claude:claude-haiku-4-5-20251001`.
+
+Avoid: `meta-llama/llama-4-scout` (regressed; verbose),
+`meta-llama/llama-4-maverick` (returns "image not available"),
+`google/gemini-2.5-flash-lite` (hallucinates uniform deltas).
+
+See `docs/reports/2026-05-18-vlm-claude-vs-openrouter-vs-newcomers.md`
+for the 8-way bench.
+
+## Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--fixture <name>` | — | Required. Fixture id from `css-challenge-fixtures.ts` |
+| `--seed <int>` | — | Required. Seeds the deterministic mutation |
+| `--mode <property\|selector>` | `property` | Mutation granularity |
+| `--max-rounds <int>` | 5 | Hard ceiling on iterations |
+| `--threshold <float>` | 0.001 | diffRatio at which FIXED is declared |
+| `--no-db` | off | Skip writing the benchmark DB row |
+
+## Environment
+
+| Variable | Required when |
+|---|---|
+| `VRT_VLM_MODEL` | Always (defaults if unset). Provider auto-detected from prefix |
+| `OPENROUTER_API_KEY` | Unprefixed model id |
+| `GEMINI_API_KEY` | `gemini:` prefix |
+| `ANTHROPIC_API_KEY` | `claude:` prefix |
+| `DEBUG_VRT=1` | Verbose VLM round logging |
+
+## Reading the output
+
+```
+Round 1: diff=4.12%  → VLM proposed `padding: 12px` on `.foo`
+Round 2: diff=1.84%  → VLM proposed `font-size: 14px` on `.bar`
+Round 3: diff=0.08%  → FIXED ✓
+```
+
+A "stalled" run shows diffRatio holding steady across rounds — the
+VLM's proposals aren't being applied (likely a parser failure) or
+aren't structurally valid. Set `DEBUG_VRT=1` to see the raw VLM
+output.
+
+## Adapting to a new repo
+
+The harness is fixture-bound — to run on a user repo:
+
+1. Add a fixture entry in `css-challenge-fixtures.ts` describing the
+   page (HTML + goal CSS + variant CSS template).
+2. Confirm baseline + variant render the same when seed maps to a
+   no-op (sanity check).
+3. Run the loop.
+
+If the new repo is large enough that fixture-style isolation isn't
+viable, this skill is the wrong tool — use `vrt-visual-diff` to
+surface the regression and edit by hand.
+
+## Costs (rough)
+
+Per call, based on the 2026-05-18 bench:
+
+- `bytedance/ui-tars-1.5-7b`: ~$0.1e-6 / $0.2e-6 (input / output).
+- `claude:claude-haiku-4-5-*`: ~$0.002 / call.
+
+Budget consideration: a 3-round fix-loop on Haiku ≈ $0.006 / run; on
+ui-tars-1.5-7b ≈ negligible. For batch benchmark runs (>100 calls),
+prefer the OpenRouter models.

--- a/.claude/skills/vrt-css-fix-loop/SKILL.md
+++ b/.claude/skills/vrt-css-fix-loop/SKILL.md
@@ -20,6 +20,17 @@ Each round:
 5. Re-run; stop when diffRatio falls below threshold (= FIXED) or
    `--max-rounds` is exhausted.
 
+## Invocation
+
+`fix-loop` is run directly from source (not via the `vrt` CLI):
+
+```bash
+node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts <flags>
+```
+
+It does not ship in `./dist/vrt.mjs`. The source form above is the
+only supported entry point.
+
 ## When to use
 
 - Evaluating a new VLM model on UI-domain understanding.

--- a/.claude/skills/vrt-css-fix-loop/SKILL.md
+++ b/.claude/skills/vrt-css-fix-loop/SKILL.md
@@ -9,16 +9,29 @@ description: Closed-loop CSS auto-repair. Given a fixture with a known regressio
 (`docs/reports/2026-05-18-vlm-claude-vs-openrouter-vs-newcomers.md`
 etc.). It takes a fixture, deliberately mutates the CSS (`property`
 mode deletes one property; `selector` mode deletes one selector
-block), then asks a VLM to propose the fix from the rendered diff.
-Each round:
+block), then runs a **two-stage** AI pipeline to propose a fix from
+the rendered diff.
+
+**The pipeline is VLM → LLM, not VLM alone:**
 
 1. Apply current candidate CSS to the variant page.
 2. Render baseline + variant; compute pixel diff.
-3. Send the diff overlay to the VLM with a structured "list the
-   changes" prompt.
-4. Parse the VLM's CHANGE list; apply the top candidate.
+3. **Stage 1 (VLM)**: send the diff overlay to the VLM with a
+   structured "list the changes" prompt; parse a CHANGE list
+   (`selector { prop: from → to }` rows).
+4. **Stage 2 (LLM)**: hand the CHANGE list + current CSS to an LLM
+   (default `claude-sonnet-*`); LLM emits the actual CSS edits to
+   apply. The LLM compensates for VLM imprecision — it may rewrite,
+   merge, or discard VLM proposals based on the CSS context.
 5. Re-run; stop when diffRatio falls below threshold (= FIXED) or
    `--max-rounds` is exhausted.
+
+**FIXED means "the pipeline converged," not "the VLM understood the
+diff."** It's common to see VLM propose selectors unrelated to the
+deleted block while the LLM still emits a working fix. When using
+this harness to *benchmark a VLM model*, compare CHANGE-list quality
+between models — don't read FIXED as a VLM verdict on its own. The
+banner line `VLM=<id> | LLM=<id>` makes the two stages explicit.
 
 ## Invocation
 
@@ -49,8 +62,13 @@ only supported entry point.
 
 ## Quickstart
 
+This repo uses direnv; `.envrc` auto-loads `.env.local` (where
+`OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` live). If you're shelling
+outside the direnv context, run
+`set -a; source .env.local; set +a` first.
+
 ```bash
-# Property mode (default): delete one CSS property; VLM proposes restoration
+# Property mode (default): delete one CSS property; pipeline proposes restoration
 node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
   --fixture page --seed 42
 
@@ -58,7 +76,9 @@ node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
 node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
   --fixture page --seed 11 --mode selector --max-rounds 3
 
-# Run with a specific VLM model (any OpenRouter id, `gemini:*`, or `claude:*`)
+# Run with a specific VLM model (any OpenRouter id, `gemini:*`, or `claude:*`).
+# The Stage-2 LLM is held constant across VLM swaps so VLM quality
+# can be compared apples-to-apples.
 VRT_VLM_MODEL="bytedance/ui-tars-1.5-7b" \
   node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
   --fixture page --seed 11 --mode selector
@@ -127,15 +147,44 @@ for the 8-way bench.
 
 ## Reading the output
 
+Real banner + first round of a real run on seed 11 selector mode:
+
 ```
-Round 1: diff=4.12%  → VLM proposed `padding: 12px` on `.foo`
-Round 2: diff=1.84%  → VLM proposed `font-size: 14px` on `.bar`
-Round 3: diff=0.08%  → FIXED ✓
+VLM=bytedance/ui-tars-1.5-7b | LLM=claude-sonnet-4-20250514
+Removed block: .readme-body pre { 6 props }
+
+Round 1:
+  VLM: 5 changes (3383ms)
+    .main         { padding: 16px → 24px }
+    .sidebar      { width: 100% → 296px }
+    .header-nav   { display: none → flex }
+    .header-search{ max-width: none → 320px }
+    .tabs         { padding: 0 16px → 0 24px }
+  LLM: 6 fixes proposed
+  diff: 4.12% → 0.00% (FIXED ✓)
 ```
 
+Things to read:
+
+- `VLM=<id> | LLM=<id>` — confirms which two models drove the
+  pipeline.
+- **`VLM: N changes (Tms)`** — VLM stage's wall-clock + the CHANGE
+  list. Per-row format `selector { prop: from → to }`.
+- **`LLM: M fixes proposed`** — Stage-2 emitted M CSS edits; usually
+  M ≥ N (LLM expands / corrects).
+- `diff: x% → y%` — diffRatio before this round's edits vs after.
+- `FIXED ✓` when `y` falls below `--threshold` (default `0.001`).
+
+**Pipeline divergence warning**: if `Removed block:` names something
+the VLM never mentions in its CHANGE list, *but the pipeline still
+hits FIXED*, the LLM compensated. Treat that run as a **win for the
+pipeline**, not for the VLM. To grade the VLM in isolation, score the
+CHANGE list against the known-removed block (e.g. selector
+recall, property recall).
+
 A "stalled" run shows diffRatio holding steady across rounds — the
-VLM's proposals aren't being applied (likely a parser failure) or
-aren't structurally valid. Set `DEBUG_VRT=1` to see the raw VLM
+VLM's proposals aren't parseable, or the LLM's emitted fixes aren't
+structurally valid CSS. Set `DEBUG_VRT=1` to see both stages' raw
 output.
 
 ## Adapting to a new repo

--- a/.claude/skills/vrt-markup-synth/SKILL.md
+++ b/.claude/skills/vrt-markup-synth/SKILL.md
@@ -20,6 +20,20 @@ task.
 | `vrt check theme <url>` | Live URL | Theme-parity report | Force dark mode (or `prefers-color-scheme`), report selectors still painting with hard-coded light-mode colors. |
 | `vrt stress i18n <url>` | Live URL | Layout stress report | Inflate text content (×2 length, multi-byte chars) and screenshot under each viewport; report overflow / wrap breakage. |
 
+## Invocation
+
+The `vrt` CLI in this repo is invoked **from source**:
+
+```bash
+node --experimental-strip-types src/cli/vrt.ts <command...>
+# e.g. node --experimental-strip-types src/cli/vrt.ts build component design.png
+```
+
+The published binary (`./dist/vrt.mjs` or a globally installed `vrt`)
+may lag the source. If it errors with `Unknown command: build`, the
+dist is stale — run `pnpm build` or use the source form. All
+`vrt ...` invocations below assume one of these two forms.
+
 ## When to use
 
 - **build component**: "here's a Figma export, give me the HTML/CSS"

--- a/.claude/skills/vrt-markup-synth/SKILL.md
+++ b/.claude/skills/vrt-markup-synth/SKILL.md
@@ -18,7 +18,7 @@ keys.
 |---|---|---|---|
 | `vrt build component <target.png> <current.html>` | Reference image + your current HTML | Markdown report: pixel diff + bbox + palette + heatmap + text-row signals | Playwright renders `current.html` at the target's viewport, pixel-diffs vs `target.png`, surfaces image-only signals. **No VLM.** Agent iterates `current.html`. |
 | `vrt scan component <screenshot>` | Full-page PNG | `components/*.png` + `manifest.json` (bbox + role guess) | Bbox detection + clustering on the image. **No VLM.** |
-| `vrt check tokens <html-or-url>` | Page | Markdown table: violation + nearest-token | Playwright + computed-style scan; snaps to allowed scale within tolerance. **No VLM.** Internal binary name: `vrt design-tokens` (same thing — the dispatcher routes both). |
+| `vrt check tokens <html-or-url>` | Page | Markdown table: violation + nearest-token | Playwright + computed-style scan; snaps to allowed scale within tolerance. **No VLM.** Internal binary name: `vrt design-tokens` — the dispatcher routes both, but **the CLI banner and the generated report still call it `vrt design-tokens`** (legacy). Both invocations work; don't get tripped up when the output names a command different from the one you typed. |
 | `vrt check theme <html>` | Page | Markdown report: "unthemed" bboxes (light/dark render same) | Playwright with `emulateMedia({ colorScheme: 'light' / 'dark' })`, per-bbox color sampling, identical-fill flag. **No VLM.** |
 | `vrt stress i18n <html>` | Page | Markdown report: selectors that overflow / wrap | Inflate every visible text node by a multiplier (synthetic `word → word + 'X'×k`), measure `scrollWidth > clientWidth` / height growth / right-edge overflow. **No VLM.** No translation dictionary. |
 

--- a/.claude/skills/vrt-markup-synth/SKILL.md
+++ b/.claude/skills/vrt-markup-synth/SKILL.md
@@ -16,7 +16,7 @@ keys.
 
 | Command | Input | Output | What runs |
 |---|---|---|---|
-| `vrt build component <target.png> <current.html>` | Reference image + your current HTML | Markdown report: pixel diff + bbox + palette + heatmap + text-row signals | Playwright renders `current.html` at the target's viewport, pixel-diffs vs `target.png`, surfaces image-only signals. **No VLM.** Agent iterates `current.html`. |
+| `vrt build component <target.png> <current.html>` | Reference image + your current HTML | Markdown report at `test-results/component/report.md` (+ `component_heatmap.png` alongside): pixel diff + bbox + palette + heatmap + text-row signals | Playwright renders `current.html` at the target's viewport, pixel-diffs vs `target.png`, surfaces image-only signals. **No VLM.** Agent iterates `current.html`. Internal binary name: `vrt component-from-image` — the CLI banner uses the legacy name even when invoked as `vrt build component`. `--output` is **not** a destination path here — the report always lands at the fixed `test-results/component/` path; the flag is silently ignored. |
 | `vrt scan component <screenshot>` | Full-page PNG | `components/*.png` + `manifest.json` (bbox + role guess) | Bbox detection + clustering on the image. **No VLM.** |
 | `vrt check tokens <html-or-url>` | Page | Markdown table: violation + nearest-token | Playwright + computed-style scan; snaps to allowed scale within tolerance. **No VLM.** Internal binary name: `vrt design-tokens` — the dispatcher routes both, but **the CLI banner and the generated report still call it `vrt design-tokens`** (legacy). Both invocations work; don't get tripped up when the output names a command different from the one you typed. |
 | `vrt check theme <html>` | Page | Markdown report: "unthemed" bboxes (light/dark render same) | Playwright with `emulateMedia({ colorScheme: 'light' / 'dark' })`, per-bbox color sampling, identical-fill flag. **No VLM.** |
@@ -60,8 +60,9 @@ dist is stale — run `pnpm build` or use the source form. All
 ```bash
 # Image-driven build loop. You supply current.html; the tool returns
 # pixel signal each iteration. Agent (= you) edits current.html until
-# the diff converges.
-vrt build component design.png current.html --output report.md
+# the diff converges. The report lands at test-results/component/report.md
+# (path is fixed — `--output` is ignored for this sub-tool).
+vrt build component design.png current.html
 
 # Full screenshot → per-component crops
 vrt scan component dashboard.png --output components/

--- a/.claude/skills/vrt-markup-synth/SKILL.md
+++ b/.claude/skills/vrt-markup-synth/SKILL.md
@@ -1,24 +1,26 @@
 ---
 name: vrt-markup-synth
-description: Generate or extract HTML/CSS components from screenshots and rendered pages. Five sub-tools — build component (image → standalone component), scan component (screenshot → cropped component PNGs), check tokens (design-token conformance), check theme (theme parity audit), stress i18n (overflow / wrap stress test). Use when the agent needs to author markup from a visual reference, audit token usage across an existing UI, or stress-test the layout under longer content / locale changes. VLM-driven; requires API keys.
+description: Five DOM/pixel-based signal tools for markup work — turn a screenshot + HTML scaffold into a converging pixel diff (build component), crop a page screenshot into per-component PNGs (scan component), audit hard-coded values against a design-token scale (check tokens), verify theme parity (check theme — light vs dark render), and stress-test layout under inflated text (stress i18n). All five are pure DOM + Playwright + pixel processing — **no VLM / no API key required**. The agent supplies the markup reasoning; the tool surfaces the signal. Use when you've authored HTML/CSS and want signal back without paying VLM latency or cost.
 ---
 
 # vrt-markup-synth
 
-Markup tooling that uses a VLM to understand a target image or rendered
-DOM, then either reproduces it as standalone HTML+CSS or audits it
-against the design system. Five complementary commands; pick one per
-task.
+Despite the name, **these tools do not generate markup**. They give an
+agent *signal* — pixel diffs, bbox crops, computed-style violations,
+light/dark fill comparisons, overflow flags — that an agent uses to
+write or revise HTML/CSS itself. The agent is the VLM. Each tool is
+deterministic Playwright + image math; runs in ~1-5s; needs zero API
+keys.
 
 ## Sub-tools
 
-| Command | Input | Output | Purpose |
+| Command | Input | Output | What runs |
 |---|---|---|---|
-| `vrt build component <image>` | PNG/JPG screenshot | `component.html` + `component.css` | Reproduce a component from a reference image. VLM extracts structure + styling. |
-| `vrt scan component <screenshot>` | Full-page screenshot | `components/*.png` | Detect distinct components, crop each into its own PNG for piecewise inspection. |
-| `vrt check tokens <html-or-url>` | Page | Token-conformance report | Find hard-coded values that should reference design tokens (colors, spacing, font sizes). |
-| `vrt check theme <url>` | Live URL | Theme-parity report | Force dark mode (or `prefers-color-scheme`), report selectors still painting with hard-coded light-mode colors. |
-| `vrt stress i18n <url>` | Live URL | Layout stress report | Inflate text content (×2 length, multi-byte chars) and screenshot under each viewport; report overflow / wrap breakage. |
+| `vrt build component <target.png> <current.html>` | Reference image + your current HTML | Markdown report: pixel diff + bbox + palette + heatmap + text-row signals | Playwright renders `current.html` at the target's viewport, pixel-diffs vs `target.png`, surfaces image-only signals. **No VLM.** Agent iterates `current.html`. |
+| `vrt scan component <screenshot>` | Full-page PNG | `components/*.png` + `manifest.json` (bbox + role guess) | Bbox detection + clustering on the image. **No VLM.** |
+| `vrt check tokens <html-or-url>` | Page | Markdown table: violation + nearest-token | Playwright + computed-style scan; snaps to allowed scale within tolerance. **No VLM.** Internal binary name: `vrt design-tokens` (same thing — the dispatcher routes both). |
+| `vrt check theme <html>` | Page | Markdown report: "unthemed" bboxes (light/dark render same) | Playwright with `emulateMedia({ colorScheme: 'light' / 'dark' })`, per-bbox color sampling, identical-fill flag. **No VLM.** |
+| `vrt stress i18n <html>` | Page | Markdown report: selectors that overflow / wrap | Inflate every visible text node by a multiplier (synthetic `word → word + 'X'×k`), measure `scrollWidth > clientWidth` / height growth / right-edge overflow. **No VLM.** No translation dictionary. |
 
 ## Invocation
 
@@ -26,7 +28,7 @@ The `vrt` CLI in this repo is invoked **from source**:
 
 ```bash
 node --experimental-strip-types src/cli/vrt.ts <command...>
-# e.g. node --experimental-strip-types src/cli/vrt.ts build component design.png
+# e.g. node --experimental-strip-types src/cli/vrt.ts check tokens fixtures/element-compare/before.html
 ```
 
 The published binary (`./dist/vrt.mjs` or a globally installed `vrt`)
@@ -36,14 +38,15 @@ dist is stale — run `pnpm build` or use the source form. All
 
 ## When to use
 
-- **build component**: "here's a Figma export, give me the HTML/CSS"
-  workflow without manually transcribing.
-- **scan component**: "this dashboard has 8 components; extract each
-  so I can fix one at a time."
+- **build component**: "I'm reproducing this Figma export — give me
+  fast pixel signal each round so I converge without eyeballing."
+- **scan component**: "this dashboard has 8 components; I want each
+  cropped to its own PNG so I can pair-iterate with `build component`."
 - **check tokens**: drift audit before / during a design-system
-  rollout.
-- **check theme**: pre-launch sanity for a dark-mode rollout.
-- **stress i18n**: detect "DE / JP / AR will break the layout" *before*
+  rollout. Snap-to-scale lints, not subjective.
+- **check theme**: pre-launch sanity for a dark-mode rollout — finds
+  selectors that didn't migrate off hard-coded light colors.
+- **stress i18n**: detect "DE / JP / AR will break the layout" before
   the bug is filed.
 
 ## When NOT to use
@@ -55,126 +58,114 @@ dist is stale — run `pnpm build` or use the source form. All
 ## Quickstart
 
 ```bash
-# Image → component
-vrt build component design.png --output components/card.html
-# Writes components/card.html + components/card.css.
+# Image-driven build loop. You supply current.html; the tool returns
+# pixel signal each iteration. Agent (= you) edits current.html until
+# the diff converges.
+vrt build component design.png current.html --output report.md
 
 # Full screenshot → per-component crops
 vrt scan component dashboard.png --output components/
-# Writes components/<auto-name>.png for each detected component.
 
-# Token conformance
-vrt check tokens src/index.html --tokens design-tokens.json
+# Token conformance (default scales — no --tokens needed for first pass)
+vrt check tokens src/index.html
+#   ↑ uses default spacing/radius/z-index scales + 0.5px tolerance.
+#   Pass --tokens design-tokens.json to override.
 
-# Theme parity (dark mode)
-vrt check theme http://localhost:3000/ --mode dark
+# Theme parity (renders light + dark, flags identical fills)
+vrt check theme src/index.html --output-dir test-results/theme/
 
-# i18n / overflow stress
-vrt stress i18n http://localhost:3000/ \
-  --locales de,ja,ar \
-  --multiplier 2
+# i18n / overflow stress (synthetic inflate, default factor 1.4)
+vrt stress i18n src/index.html --inflate 1.4
 ```
 
-## Build component — what the VLM does
+## Build component — what the report contains
 
-`vrt build component` invokes the VLM with the reference image and a
-prompt that asks for:
+The output is a Markdown report (not an HTML/CSS file). Each section
+is a different image-only signal:
 
-1. Component-level structure (parent → children).
-2. Per-element semantic role (heading, button, input, etc.).
-3. CSS properties: layout (flex / grid), spacing, color, typography.
-4. Responsive intent if multiple viewport variants of the image are
-   provided.
+- **Bbox table** — IoU per rank-matched bbox; survives DOM rewrites.
+- **Palette** — dominant colors in target vs current; surfaces "you
+  used #2d2d2d but the target is #1e1e1e."
+- **Text-row Δy** — row-by-row vertical alignment shift.
+- **Heatmap** — concentrated regions of diff, prioritized.
+- **Per-state** (optional `--states hover focus-visible`) — re-renders
+  current.html under each interactive state and diffs each.
 
-Output is **standalone**: the generated HTML/CSS does not depend on
-any framework or external CSS reset. Combine with `vrt diff html`
-(see `vrt-visual-diff`) to verify the reproduction matches the
-target.
-
-## Scan component — what gets detected
-
-`vrt scan component` runs bbox detection on the screenshot, then
-clusters elements that look like a single component (e.g. card =
-image + title + body + actions). It outputs:
-
-- One PNG per detected component (cropped tightly).
-- A `manifest.json` listing each component's bbox + role guess.
-
-This is the right preprocessing step before running
-`vrt build component` on each piece.
+The agent iterates `current.html` between runs. There is no
+auto-fix — the tool is the eyes, the agent is the hands.
 
 ## Check tokens — what counts as a violation
 
-`vrt check tokens` flags computed-style values that are not present
-in the token set. Colours, spacing values, font sizes, and
-border-radius are checked by default. Pass `--tokens
-<path-to-tokens.json>` to override the token source. Output is a
-table:
+`vrt check tokens` flags computed-style values that aren't on the
+allowed scale within tolerance. The default scales:
+
+| Property kind | Default scale |
+|---|---|
+| `padding`, `margin`, `gap` | `0, 2, 4, 8, 12, 16, 20, 24, 32, 40, 48, 64, 80, 96` |
+| `border-radius` | `0, 2, 4, 6, 8, 12, 16, 20, 24, 32, 48, 999` |
+| `z-index` | `0, 1, 10, 100, 1000, 9999` |
+| Tolerance | `0.5px` (snap to nearest within ±tolerance) |
+
+Output excerpt:
 
 ```
-selector       property        value         nearest-token   delta
-.card          padding-top     14px          space-3 (12px)  +2px
-.card-title    font-size       15px          fs-md (16px)    -1px
+selector             property        value     nearest-token   Δ
+main>div.sidebar     margin-top      10.00px   8               +2.00
+main>div.sidebar     padding         15.00px   16              -1.00
+footer               padding         15.00px   16              -1.00
 ```
 
-The "nearest-token" suggestion makes the fix obvious without a manual
-lookup.
-
-## Check theme — how dark-mode audit works
-
-The tool loads the URL twice (light + dark via
-`prefers-color-scheme` emulation), then surfaces:
-
-- Selectors whose `color` / `background-color` didn't change at all.
-- Selectors whose contrast ratio fails WCAG AA in dark mode.
-
-Useful as a CI gate before declaring "dark mode supported."
-
-## Stress i18n — what gets stressed
-
-For each locale × text-multiplier combination:
-
-1. Inflate every text node by the multiplier.
-2. Swap to locale-representative characters (long German, multi-byte
-   JP, RTL Arabic).
-3. Screenshot every viewport.
-4. Diff against the original; flag overflow (text spilling out of its
-   container).
-
-Report lists selectors that broke, with the worst-case screenshot
-inline.
+Override the scales with `--config <path>` (JSON: `{ radius, spacing,
+zIndex, shadowTiers, tolerance }`) or with the individual
+`--radius-scale a,b,c,...` / `--spacing-scale ...` / `--z-scale ...`
+flags.
 
 ## Environment
 
-| Variable | Required by |
-|---|---|
-| `VRT_VLM_MODEL` | All sub-tools (defaults to `bytedance/ui-tars-1.5-7b`) |
-| `OPENROUTER_API_KEY` | Unprefixed model id |
-| `GEMINI_API_KEY` | `gemini:` prefix |
-| `ANTHROPIC_API_KEY` | `claude:` prefix |
+**No API keys are required for any sub-tool in this skill.** The
+"VLM" / `VRT_VLM_MODEL` env vars listed in other VRT skills do not
+apply here.
 
-For high-quality markup synthesis (`build component`), prefer the
-`claude:claude-haiku-4-5-*` model — the cost is justified because the
-output is consumed directly. For audit tools (`check tokens` / `check
-theme`), the default ui-tars model is fine.
+The only prerequisite is Playwright with chromium installed
+(`npx playwright install chromium` if missing).
 
-## Costs
+## Cost
 
-| Tool | Typical calls | Approx cost (Haiku) |
-|---|---|---|
-| `build component` | 1-2 per component | ~$0.004 / component |
-| `scan component` | 1 per screenshot | ~$0.002 / page |
-| `check tokens` | 1 per page | ~$0.001 / page |
-| `check theme` | 2 per page (light + dark) | ~$0.004 / page |
-| `stress i18n` | locales × viewports per page | scales linearly |
+**$0 in API spend.** Each sub-tool is a deterministic Playwright +
+pixel-math run. Compute cost is whatever your local box (or CI runner)
+charges to launch chromium + render — typically 1-5s per invocation.
 
 ## Failure modes
 
-- VLM returns "image not available" → wrong model (some OpenRouter
-  models don't support image input). Switch to ui-tars-1.5-7b or
-  claude:haiku.
-- Generated HTML doesn't match image → the reference image has
-  multiple components; run `scan component` first to isolate.
-- `check theme` reports every selector as failing → dark mode isn't
-  actually enabled on the page (missing `[data-theme=dark]` toggle in
-  the URL). Pass `--theme-selector <selector>` to override.
+- "browser not found" → run `npx playwright install chromium`.
+- `build component` Δ stays > 50% across runs → the target image and
+  current.html are at different viewport sizes; the tool sizes the
+  viewport from the target image dimensions, so check the image is
+  the intended export resolution (mobile target rendered into desktop
+  HTML will never converge).
+- `check theme` reports every bbox as "unthemed" → the page didn't
+  actually respond to the `prefers-color-scheme` toggle (no
+  `[data-theme=dark]` switch in the markup). Verify by loading the
+  page with system dark mode on — if it stays light, the page has no
+  dark variant to audit.
+- `check tokens` shows zero violations even though the page clearly
+  uses ad-hoc values → you're outside the default tolerance (`0.5px`)
+  but inside the scale's snap zone. Tighten with `--tolerance 0` for a
+  strict pass.
+- `stress i18n` reports zero overflow even on a clearly fragile
+  layout → the inflate multiplier is too low; bump `--inflate 2.0` or
+  higher.
+
+## Pair with other skills
+
+After running these tools, the agent typically:
+
+1. Reads the Markdown report.
+2. Edits HTML/CSS.
+3. Re-runs the same sub-tool (`build component` loop especially).
+4. Optionally cross-validates with `vrt-visual-diff` after the markup
+   is in place.
+
+Nothing here calls a VLM — and that's intentional. Pixel diffs and
+overflow flags are cheaper, faster, and deterministic compared to
+asking a model "did this change look right?".

--- a/.claude/skills/vrt-markup-synth/SKILL.md
+++ b/.claude/skills/vrt-markup-synth/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: vrt-markup-synth
+description: Generate or extract HTML/CSS components from screenshots and rendered pages. Five sub-tools — build component (image → standalone component), scan component (screenshot → cropped component PNGs), check tokens (design-token conformance), check theme (theme parity audit), stress i18n (overflow / wrap stress test). Use when the agent needs to author markup from a visual reference, audit token usage across an existing UI, or stress-test the layout under longer content / locale changes. VLM-driven; requires API keys.
+---
+
+# vrt-markup-synth
+
+Markup tooling that uses a VLM to understand a target image or rendered
+DOM, then either reproduces it as standalone HTML+CSS or audits it
+against the design system. Five complementary commands; pick one per
+task.
+
+## Sub-tools
+
+| Command | Input | Output | Purpose |
+|---|---|---|---|
+| `vrt build component <image>` | PNG/JPG screenshot | `component.html` + `component.css` | Reproduce a component from a reference image. VLM extracts structure + styling. |
+| `vrt scan component <screenshot>` | Full-page screenshot | `components/*.png` | Detect distinct components, crop each into its own PNG for piecewise inspection. |
+| `vrt check tokens <html-or-url>` | Page | Token-conformance report | Find hard-coded values that should reference design tokens (colors, spacing, font sizes). |
+| `vrt check theme <url>` | Live URL | Theme-parity report | Force dark mode (or `prefers-color-scheme`), report selectors still painting with hard-coded light-mode colors. |
+| `vrt stress i18n <url>` | Live URL | Layout stress report | Inflate text content (×2 length, multi-byte chars) and screenshot under each viewport; report overflow / wrap breakage. |
+
+## When to use
+
+- **build component**: "here's a Figma export, give me the HTML/CSS"
+  workflow without manually transcribing.
+- **scan component**: "this dashboard has 8 components; extract each
+  so I can fix one at a time."
+- **check tokens**: drift audit before / during a design-system
+  rollout.
+- **check theme**: pre-launch sanity for a dark-mode rollout.
+- **stress i18n**: detect "DE / JP / AR will break the layout" *before*
+  the bug is filed.
+
+## When NOT to use
+
+- Comparing two existing pages: `vrt-visual-diff`.
+- Migrating an existing implementation: `vrt-migration-eval`.
+- Self-repairing a known regression: `vrt-css-fix-loop`.
+
+## Quickstart
+
+```bash
+# Image → component
+vrt build component design.png --output components/card.html
+# Writes components/card.html + components/card.css.
+
+# Full screenshot → per-component crops
+vrt scan component dashboard.png --output components/
+# Writes components/<auto-name>.png for each detected component.
+
+# Token conformance
+vrt check tokens src/index.html --tokens design-tokens.json
+
+# Theme parity (dark mode)
+vrt check theme http://localhost:3000/ --mode dark
+
+# i18n / overflow stress
+vrt stress i18n http://localhost:3000/ \
+  --locales de,ja,ar \
+  --multiplier 2
+```
+
+## Build component — what the VLM does
+
+`vrt build component` invokes the VLM with the reference image and a
+prompt that asks for:
+
+1. Component-level structure (parent → children).
+2. Per-element semantic role (heading, button, input, etc.).
+3. CSS properties: layout (flex / grid), spacing, color, typography.
+4. Responsive intent if multiple viewport variants of the image are
+   provided.
+
+Output is **standalone**: the generated HTML/CSS does not depend on
+any framework or external CSS reset. Combine with `vrt diff html`
+(see `vrt-visual-diff`) to verify the reproduction matches the
+target.
+
+## Scan component — what gets detected
+
+`vrt scan component` runs bbox detection on the screenshot, then
+clusters elements that look like a single component (e.g. card =
+image + title + body + actions). It outputs:
+
+- One PNG per detected component (cropped tightly).
+- A `manifest.json` listing each component's bbox + role guess.
+
+This is the right preprocessing step before running
+`vrt build component` on each piece.
+
+## Check tokens — what counts as a violation
+
+`vrt check tokens` flags computed-style values that are not present
+in the token set. Colours, spacing values, font sizes, and
+border-radius are checked by default. Pass `--tokens
+<path-to-tokens.json>` to override the token source. Output is a
+table:
+
+```
+selector       property        value         nearest-token   delta
+.card          padding-top     14px          space-3 (12px)  +2px
+.card-title    font-size       15px          fs-md (16px)    -1px
+```
+
+The "nearest-token" suggestion makes the fix obvious without a manual
+lookup.
+
+## Check theme — how dark-mode audit works
+
+The tool loads the URL twice (light + dark via
+`prefers-color-scheme` emulation), then surfaces:
+
+- Selectors whose `color` / `background-color` didn't change at all.
+- Selectors whose contrast ratio fails WCAG AA in dark mode.
+
+Useful as a CI gate before declaring "dark mode supported."
+
+## Stress i18n — what gets stressed
+
+For each locale × text-multiplier combination:
+
+1. Inflate every text node by the multiplier.
+2. Swap to locale-representative characters (long German, multi-byte
+   JP, RTL Arabic).
+3. Screenshot every viewport.
+4. Diff against the original; flag overflow (text spilling out of its
+   container).
+
+Report lists selectors that broke, with the worst-case screenshot
+inline.
+
+## Environment
+
+| Variable | Required by |
+|---|---|
+| `VRT_VLM_MODEL` | All sub-tools (defaults to `bytedance/ui-tars-1.5-7b`) |
+| `OPENROUTER_API_KEY` | Unprefixed model id |
+| `GEMINI_API_KEY` | `gemini:` prefix |
+| `ANTHROPIC_API_KEY` | `claude:` prefix |
+
+For high-quality markup synthesis (`build component`), prefer the
+`claude:claude-haiku-4-5-*` model — the cost is justified because the
+output is consumed directly. For audit tools (`check tokens` / `check
+theme`), the default ui-tars model is fine.
+
+## Costs
+
+| Tool | Typical calls | Approx cost (Haiku) |
+|---|---|---|
+| `build component` | 1-2 per component | ~$0.004 / component |
+| `scan component` | 1 per screenshot | ~$0.002 / page |
+| `check tokens` | 1 per page | ~$0.001 / page |
+| `check theme` | 2 per page (light + dark) | ~$0.004 / page |
+| `stress i18n` | locales × viewports per page | scales linearly |
+
+## Failure modes
+
+- VLM returns "image not available" → wrong model (some OpenRouter
+  models don't support image input). Switch to ui-tars-1.5-7b or
+  claude:haiku.
+- Generated HTML doesn't match image → the reference image has
+  multiple components; run `scan component` first to isolate.
+- `check theme` reports every selector as failing → dark mode isn't
+  actually enabled on the page (missing `[data-theme=dark]` toggle in
+  the URL). Pass `--theme-selector <selector>` to override.

--- a/.claude/skills/vrt-migration-eval/SKILL.md
+++ b/.claude/skills/vrt-migration-eval/SKILL.md
@@ -63,20 +63,24 @@ the dist is stale — run `pnpm build` or use the source form. All
 
 ## Quickstart
 
+`--output <dir>` is a **directory** path; the engine writes
+`<dir>/migration-report.json` (+ per-viewport PNGs) into it. Pass
+that JSON file — not the dir — to `vrt diff agent`.
+
 ```bash
-# Two HTML files, side by side
+# Two HTML files, side by side → writes reports/migration-report.json
 vrt migration compare baseline.html variant.html \
-  --output reports/migration.json
+  --output reports/
 
 # Two URLs (different dev servers / preview deploys)
 vrt migration compare \
   --url http://localhost:3000/ \
   --current-url http://localhost:8080/ \
   --mask ".marquee-container,.hero-badge" \
-  --output reports/migration.json
+  --output reports/
 
 # Then format for the agent
-vrt diff agent reports/migration.json
+vrt diff agent reports/migration-report.json
 ```
 
 ## Computed-style diff is the load-bearing signal

--- a/.claude/skills/vrt-migration-eval/SKILL.md
+++ b/.claude/skills/vrt-migration-eval/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: vrt-migration-eval
+description: Evaluate whether a framework / CSS-library / build-system swap (Tailwind → vanilla CSS, reset-css switch, bundler swap, etc.) produced a visually-equivalent result. Three modes — compare (deterministic pixel + CSD), blind (agent runs without baseline reference), subagent (dispatched-agent verification) — let the caller pick the rigour level. Use when the diff is large by construction (the markup was rewritten) and a flat pixel diff would drown the actual regressions in noise.
+---
+
+# vrt-migration-eval
+
+Migration VRT differs from "did my CSS edit visibly change something?"
+(see `vrt-visual-diff`) because the markup is **deliberately
+different** — Tailwind utilities become hand-written classes, CSS-in-JS
+becomes CSS modules, etc. A flat pixel comparison would be 60-90%
+noise. This skill structures the comparison around component bounding
+boxes and computed-style deltas to surface only the deltas that matter.
+
+## The three modes
+
+| Mode | Cmd | What it does | Use when |
+|---|---|---|---|
+| **compare** | `vrt migration compare` | Deterministic: capture both, pixel diff + per-section bbox + computed-style diff per viewport | Baseline + variant are both rendered, you want a numeric verdict |
+| **blind** | `vrt migration blind` | Variant agent never sees baseline pixels — only structural hints. Forces agent to converge from spec text alone | Stress-test the migration: "can the new stack reproduce the layout from scratch?" |
+| **subagent** | `vrt migration subagent` | Dispatched subagent runs `compare` + writes a structured verdict | You want a fresh, unbiased read inside a longer chain |
+
+Default to **compare**. Use blind / subagent when you're auditing the
+toolchain itself, not the migration.
+
+## When to use
+
+- Tailwind → vanilla CSS (or vice versa) port.
+- Bootstrap / Bulma / Reset-CSS swap.
+- Bundler swap (Vite → Rspack etc.) where the CSS pipeline differs.
+- Theme system rewrite (CSS variables → design tokens).
+
+## When NOT to use
+
+- Single CSS file edit: use `vrt-visual-diff`.
+- New page being authored from scratch (no baseline): use
+  `vrt-markup-synth`.
+- CI gate over time: use `vrt-regression-watch`.
+
+## Quickstart
+
+```bash
+# Two HTML files, side by side
+vrt migration compare baseline.html variant.html \
+  --output reports/migration.json
+
+# Two URLs (different dev servers / preview deploys)
+vrt migration compare \
+  --url http://localhost:3000/ \
+  --current-url http://localhost:8080/ \
+  --mask ".marquee-container,.hero-badge" \
+  --output reports/migration.json
+
+# Then format for the agent
+vrt diff agent reports/migration.json
+```
+
+## Computed-style diff is the load-bearing signal
+
+Pixel diff catches large layout shifts but **misses semantic
+divergence** that produces identical pixels by accident — e.g. one
+side uses sibling `margin`, the other uses flex `gap` with the same
+visual result, but the next responsive breakpoint diverges. CSD
+captures the (selector, property, value) tuple per viewport so the
+report surfaces:
+
+- **Universal pairs**: selectors whose properties differ on every
+  viewport. Almost always "fix the base rule."
+- **Breakpoint-gated pairs**: selectors that differ on a viewport
+  subset. Almost always "missing or wrong `@media` rule."
+
+`vrt diff agent` renders these as two subtables under "Verified
+deltas (computed-style) × viewport" — read top-to-bottom.
+
+## Mode: blind
+
+```bash
+vrt migration blind <baseline-url> <variant-url> --rounds 3
+```
+
+The variant builder agent gets:
+- The baseline URL (for spec inference only — pixels not surfaced).
+- A budget (N rounds).
+- A success metric (target diffRatio threshold).
+
+After each round, `migration blind` runs `migration compare` and feeds
+the diff signal back. The point is to learn whether the agent can
+converge purely from CSD + structural hints, without "looking" at the
+target. Use this when evaluating how robust the new stack's authoring
+ergonomics are.
+
+## Mode: subagent
+
+```bash
+vrt migration subagent baseline.html variant.html
+```
+
+Spawns a fresh CC subagent that runs `vrt migration compare`, reads
+the Markdown report, and writes a verdict. Useful inside a longer
+chain where you want one unbiased opinion ("is this migration done?")
+without the caller's context bleeding in.
+
+## Masking is non-optional
+
+Migration diffs include cosmetic differences in non-deterministic
+content (timestamps, marquee animations, generated IDs). Always pass
+`--mask <selectors>` for any selector whose content isn't
+controlled. The `vrt diff html` quickstart in `vrt-visual-diff` shows
+the syntax — `migration compare` accepts the same flag.
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `VRT_LLM_PROVIDER` | `gemini` (default) / `openrouter` — only the `subagent` mode invokes an LLM |
+| `VRT_LLM_MODEL` | Override the model (e.g. `claude-haiku-4-5`) |
+| `GEMINI_API_KEY` / `OPENROUTER_API_KEY` | Required for `subagent` mode only |
+
+## Outputs
+
+| File | Mode | Purpose |
+|---|---|---|
+| `migration.json` | compare | machine input to `vrt diff agent` |
+| `migration-<vp>.png` | compare | pixel diff per viewport |
+| Markdown verdict | subagent | structured agent reply |
+| `rounds/<N>/` | blind | per-round capture + diff trail |
+
+## Failure modes
+
+- Variant URL not served on stated port → "ECONNREFUSED"; start the
+  dev server first.
+- Pixel diff > 0.5 across all viewports → the variant page is showing
+  an error page, not the migrated content. Check the URL.
+- CSD universal pairs empty but pixels diverge → reset-CSS shift (the
+  selectors in the baseline don't exist in the variant). Use the
+  bySelector counts in the report to find missing selectors.

--- a/.claude/skills/vrt-migration-eval/SKILL.md
+++ b/.claude/skills/vrt-migration-eval/SKILL.md
@@ -33,6 +33,20 @@ instead. The Quickstart's `vrt migration compare baseline.html
 variant.html` command shape matches *any* two-file pair, so it's
 easy to fall into. The named-migration check is the gate.
 
+## Invocation
+
+The `vrt` CLI in this repo is invoked **from source**:
+
+```bash
+node --experimental-strip-types src/cli/vrt.ts <command...>
+# e.g. node --experimental-strip-types src/cli/vrt.ts migration compare baseline.html variant.html
+```
+
+The published binary (`./dist/vrt.mjs` or a globally installed `vrt`)
+may lag the source. If it errors with `Unknown command: migration`,
+the dist is stale — run `pnpm build` or use the source form. All
+`vrt ...` invocations below assume one of these two forms.
+
 ## When to use
 
 - Tailwind → vanilla CSS (or vice versa) port.

--- a/.claude/skills/vrt-migration-eval/SKILL.md
+++ b/.claude/skills/vrt-migration-eval/SKILL.md
@@ -23,6 +23,16 @@ boxes and computed-style deltas to surface only the deltas that matter.
 Default to **compare**. Use blind / subagent when you're auditing the
 toolchain itself, not the migration.
 
+## Precondition (gate)
+
+**Before running, name the migration: `<from-stack> → <to-stack>`.**
+If you cannot fill in both sides (e.g. "Tailwind → vanilla CSS",
+"reset-css `eric-meyer` → `modern-normalize`", "Vite → Rspack
+pipeline"), this is the wrong skill — stop and use `vrt-visual-diff`
+instead. The Quickstart's `vrt migration compare baseline.html
+variant.html` command shape matches *any* two-file pair, so it's
+easy to fall into. The named-migration check is the gate.
+
 ## When to use
 
 - Tailwind → vanilla CSS (or vice versa) port.

--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: vrt-regression-watch
+description: Run vrt diff in a stateful loop where each run is compared against the previous run's persisted summary, surfacing a `⚠ REGRESSION` banner when the majority of viewports get worse. Designed for periodic CI gates (per-PR or scheduled) where you want "did this change make things worse" as a binary signal, not a one-shot snapshot. Stores summary at `.vrt/last-diff-for-agent.json` by default.
+---
+
+# vrt-regression-watch
+
+The same `vrt diff agent` CLI exposes regression flags
+(`--previous`, `--persist-summary`, `--no-history`,
+`--fail-on-regression`). This skill explains *how* to wire them into a
+recurring loop, what state lives where, and what counts as a
+regression.
+
+## When to use
+
+- CI gate on every PR: "if this PR's diff is worse than main's
+  reference, fail."
+- Scheduled snapshot of a production URL: "alert me if the rendered
+  output drifts."
+- Long-running migration: "after each round, did we make forward
+  progress or regress?"
+
+## When NOT to use
+
+- One-shot diff with no history: `vrt-visual-diff` (use `--no-history`
+  there if you want zero state).
+- CSS auto-repair: `vrt-css-fix-loop`.
+- First-time setup with no prior baseline: the first run can't detect
+  regression — it just establishes the summary. Run twice.
+
+## How regression is detected
+
+After each `vrt diff agent` run, the per-viewport diffRatio is written
+to `.vrt/last-diff-for-agent.json`. On the next run:
+
+1. Load that file as the comparison summary.
+2. Compare each viewport's current diffRatio against its prior value.
+3. If the **majority** of viewports got worse (current > prior by a
+   relative threshold), emit the `### ⚠ REGRESSION` banner at the top
+   of the Markdown.
+4. If `--fail-on-regression` is set, exit 1.
+
+The "majority of viewports" rule prevents a single jittery viewport
+from triggering false alarms.
+
+## Quickstart
+
+```bash
+# First run: establishes baseline. No banner possible.
+vrt diff html before.html after.html --output reports/diff.json
+vrt diff agent reports/diff.json --persist-summary .vrt/baseline.json
+
+# Subsequent runs: compare against the persisted summary, fail if regressed
+vrt diff html before.html after.html --output reports/diff.json
+vrt diff agent reports/diff.json \
+  --previous .vrt/baseline.json \
+  --persist-summary .vrt/baseline.json \
+  --fail-on-regression
+```
+
+The default state path is `.vrt/last-diff-for-agent.json`; the example
+uses an explicit `.vrt/baseline.json` to show how to keep a stable
+reference (e.g. "diff against main's last good run, not against the
+PR's previous run").
+
+## State lifecycle
+
+| File | Written by | Read by | Lifetime |
+|---|---|---|---|
+| `.vrt/last-diff-for-agent.json` | `vrt diff agent` (auto, unless `--no-history`) | next `vrt diff agent` run | persists until manually removed |
+| `report.json` | `vrt diff html` / `vrt migration compare` | `vrt diff agent` | per-run; can discard after the Markdown is produced |
+
+Two retention strategies:
+
+- **Local-rolling**: let `.vrt/last-diff-for-agent.json` rewrite each
+  run. Catches per-PR regressions ("did this commit make it worse
+  than the previous commit").
+- **Branch-stable**: commit a snapshot of the JSON (or store it in
+  CI artifacts) for `main`, then have PR jobs compare against that
+  fixed reference. Catches "did this PR drift main from a known
+  good."
+
+## Per-PR CI gate pattern
+
+```yaml
+# .github/workflows/visual-regression.yml (sketch)
+- name: Restore main's baseline
+  uses: actions/cache@v4
+  with:
+    path: .vrt/baseline.json
+    key: vrt-baseline-${{ github.base_ref }}
+
+- name: Render current PR + diff
+  run: |
+    vrt diff html main.html pr.html --output reports/diff.json
+    vrt diff agent reports/diff.json \
+      --previous .vrt/baseline.json \
+      --no-history \
+      --fail-on-regression \
+      --out reports/diff.md
+
+- name: Comment on PR
+  if: always()
+  run: gh pr comment ${{ github.event.number }} --body-file reports/diff.md
+```
+
+Why `--no-history`: in CI you don't want the PR-run's summary to
+clobber the cached main-summary; pass `--no-history` to skip writes,
+or override with `--persist-summary <pr-specific-path>`.
+
+## Flag reference
+
+| Flag | Behaviour |
+|---|---|
+| `--previous <path>` | Explicit comparison source. Overrides default. |
+| `--persist-summary <path>` | Override destination for this run's summary. |
+| `--no-history` | Skip both load and write entirely (one-shot mode). |
+| `--fail-on-regression` | Exit 1 when regression is detected. |
+
+Default behaviour (none of the above): auto-load and auto-persist
+`.vrt/last-diff-for-agent.json` — i.e. local-rolling.
+
+## Reading the banner
+
+```
+### ⚠ REGRESSION
+
+3 / 4 viewports got worse vs. previous run:
+
+| viewport | prior | current | Δ |
+|---|---|---|---|
+| mobile  | 0.012 | 0.084 | +0.072 |
+| tablet  | 0.008 | 0.041 | +0.033 |
+| desktop | 0.002 | 0.029 | +0.027 |
+| wide    | 0.001 | 0.001 |  0     |
+```
+
+The Δ column is absolute. A viewport is "worse" if Δ > 0 and the
+relative increase exceeds the noise threshold (currently fixed in
+`detectRegression`). Fix order is usually mobile → up; mobile
+breakage is the most likely user-visible regression.
+
+## Combining with masks
+
+The same `--mask` arg from `vrt diff html` applies. **A regression
+banner appearing on a viewport you don't actually care about (e.g.
+`wide`) usually means you forgot to mask a flapping element on that
+viewport.** Add the selector to `--mask` and re-run; if the banner
+disappears, the original signal was noise.
+
+## Failure modes
+
+- First-ever run shows no banner → expected (no prior summary to
+  compare). Run twice.
+- Banner appears on every run, even with no changes → the page has
+  unmaintained dynamic content; pass `--mask` for the flapping
+  selectors.
+- `--fail-on-regression` exits 1 but the banner says "0 viewports
+  got worse" → there's a JSON-vs-Markdown drift bug; re-run with
+  `DEBUG_VRT=1` and file an issue.
+- Stale summary from months ago → manually remove
+  `.vrt/last-diff-for-agent.json` (or your custom path) and re-run.
+
+## Environment
+
+No additional env vars beyond what `vrt diff agent` needs (none for
+the pure pixel+CSD path).
+
+## Related skills
+
+- `vrt-visual-diff` — same CLI, no state. Use first to confirm the
+  diff looks sensible before wiring it into a watch loop.
+- `vrt-migration-eval` — produces `report.json` files that
+  `vrt diff agent` can consume just like the html-diff path.

--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -69,16 +69,17 @@ A no-op re-run (same inputs both times) is guaranteed to produce
 wiring the workflow into CI.
 
 ```bash
+REPORT=reports/migration-report.json
+
 # First run: establishes baseline. No banner possible (no prior summary).
 vrt diff html before.html after.html --output reports/
-vrt diff agent reports/migration-report.json \
-  --persist-summary .vrt/baseline.json
+vrt diff agent "$REPORT" --persist-summary .vrt/baseline.json
 
 # Subsequent runs: same baseline file for read AND write
 # (local-rolling idiom — passing the same path to --previous and
 # --persist-summary means "compare against last run, then overwrite").
 vrt diff html before.html after.html --output reports/
-vrt diff agent reports/migration-report.json \
+vrt diff agent "$REPORT" \
   --previous .vrt/baseline.json \
   --persist-summary .vrt/baseline.json \
   --fail-on-regression

--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -11,6 +11,21 @@ The same `vrt diff agent` CLI exposes regression flags
 recurring loop, what state lives where, and what counts as a
 regression.
 
+## Invocation
+
+The `vrt` CLI in this repo is invoked **from source**:
+
+```bash
+node --experimental-strip-types src/cli/vrt.ts <command...>
+# e.g. node --experimental-strip-types src/cli/vrt.ts diff agent report.json --previous prior.json
+```
+
+The published binary (`./dist/vrt.mjs` or a globally installed `vrt`)
+may lag the source. If it rejects subcommands with
+`Unknown command: diff`, the dist is stale — run `pnpm build` or use
+the source form. All `vrt ...` invocations below assume one of
+these two forms.
+
 ## When to use
 
 - CI gate on every PR: "if this PR's diff is worse than main's

--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -60,14 +60,25 @@ from triggering false alarms.
 
 ## Quickstart
 
-```bash
-# First run: establishes baseline. No banner possible.
-vrt diff html before.html after.html --output reports/diff.json
-vrt diff agent reports/diff.json --persist-summary .vrt/baseline.json
+`--output <dir>` is a **directory** path; `vrt diff html` writes
+`<dir>/migration-report.json` into it. Pass that JSON file path —
+not the dir — to `vrt diff agent`.
 
-# Subsequent runs: compare against the persisted summary, fail if regressed
-vrt diff html before.html after.html --output reports/diff.json
-vrt diff agent reports/diff.json \
+A no-op re-run (same inputs both times) is guaranteed to produce
+**no** `⚠ REGRESSION` banner — use this as a sanity check when
+wiring the workflow into CI.
+
+```bash
+# First run: establishes baseline. No banner possible (no prior summary).
+vrt diff html before.html after.html --output reports/
+vrt diff agent reports/migration-report.json \
+  --persist-summary .vrt/baseline.json
+
+# Subsequent runs: same baseline file for read AND write
+# (local-rolling idiom — passing the same path to --previous and
+# --persist-summary means "compare against last run, then overwrite").
+vrt diff html before.html after.html --output reports/
+vrt diff agent reports/migration-report.json \
   --previous .vrt/baseline.json \
   --persist-summary .vrt/baseline.json \
   --fail-on-regression
@@ -107,10 +118,10 @@ Two retention strategies:
 
 - name: Render current PR + diff
   run: |
-    vrt diff html main.html pr.html --output reports/diff.json
-    vrt diff agent reports/diff.json \
+    vrt diff html main.html pr.html --output reports/
+    vrt diff agent reports/migration-report.json \
       --previous .vrt/baseline.json \
-      --no-history \
+      --persist-summary /tmp/pr-summary.json \
       --fail-on-regression \
       --out reports/diff.md
 
@@ -119,9 +130,12 @@ Two retention strategies:
   run: gh pr comment ${{ github.event.number }} --body-file reports/diff.md
 ```
 
-Why `--no-history`: in CI you don't want the PR-run's summary to
-clobber the cached main-summary; pass `--no-history` to skip writes,
-or override with `--persist-summary <pr-specific-path>`.
+Why a throwaway `--persist-summary` path: in CI you don't want the
+PR-run's summary to clobber the cached main-summary. Pointing
+`--persist-summary` at a PR-specific tmp path (or anywhere outside
+the cache key) keeps the main reference clean. `--no-history` is
+NOT a substitute here — it skips load too, so `--previous` would
+be ignored and no regression detection would happen.
 
 ## Flag reference
 
@@ -134,6 +148,18 @@ or override with `--persist-summary <pr-specific-path>`.
 
 Default behaviour (none of the above): auto-load and auto-persist
 `.vrt/last-diff-for-agent.json` — i.e. local-rolling.
+
+**`--no-history` is the master switch — it skips BOTH load and
+write.** Concretely: when `--no-history` is set, `--previous` and
+`--persist-summary` are ignored — no comparison happens, no
+summary is written. Pick one of these three modes per call:
+
+| Goal | Pass |
+|---|---|
+| Local-rolling (the default) | nothing |
+| Compare against fixed reference, then overwrite it | `--previous X --persist-summary X` (same path twice) |
+| Compare against fixed reference, leave it untouched | `--previous X --persist-summary <pr-specific-path>` |
+| One-shot, no state at all | `--no-history` |
 
 ## Reading the banner
 

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -126,9 +126,28 @@ Variants: `after.html`
 #### Breakpoint-gated pairs ← fix or add @media rule
 ```
 
-**Triage order**: universal pairs > breakpoint-gated > per-section >
-raw per-viewport. The first non-empty row is almost always the actual
-change to inspect.
+**Where `Universal pairs` actually sits in the output**: near the
+**bottom** of the Markdown (after the per-viewport / per-section /
+component-bbox / shift-band / heatmap tables — typically section
+~13 of ~16). The intermediate sections describe the *effect*; the
+Universal pairs table names the *cause*. Resist top-down reading on
+first pass.
+
+**Triage order — scroll to in this order:**
+
+1. **Verified deltas → Universal pairs** (near bottom) — fix-the-base-rule list.
+2. **Verified deltas → Breakpoint-gated pairs** (just above #1) — missing/wrong `@media` rule.
+3. **Per-section diffRatio** — which component contains the change.
+4. **Diff by viewport** — sanity check the magnitude.
+
+**Glossary for the viewport table**:
+
+- `Shift bands` `[a–b]:±Npx` = a horizontal band of y-pixels `[a, b]`
+  on the screenshot shifted by `±N` pixels vertically. `[240–480]:+113px`
+  means everything between y=240 and y=480 moved down 113 pixels —
+  typically downstream of a grown element above.
+- `Dominant category` = top of `layout-shift / spacing / typography /
+  color` by pixel coverage.
 
 ## Masking is load-bearing
 

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -25,7 +25,9 @@ top-down:
 - **Per-viewport diffRatio** — raw pixel diff per breakpoint, with
   worst-viewport PNG path inline so the agent can `Read` the image.
 - **Heuristic fix candidates** — `selector { property: a → b }` hints
-  from the migration compare engine.
+  from the migration compare engine. *May read `no suggestions` when
+  the rule signal isn't strong enough; in that case wireframe-level
+  Δtop suggestions still appear in earlier sections.*
 - **Regression banner** — if a prior run's summary exists and the
   majority of viewports got worse, a `### ⚠ REGRESSION` block sits
   at the top.

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -30,6 +30,21 @@ top-down:
   majority of viewports got worse, a `### ⚠ REGRESSION` block sits
   at the top.
 
+## Invocation
+
+The `vrt` CLI in this repo is invoked **from source**:
+
+```bash
+node --experimental-strip-types src/cli/vrt.ts <command...>
+# e.g. node --experimental-strip-types src/cli/vrt.ts diff html before.html after.html
+```
+
+The published binary (`./dist/vrt.mjs` or a globally installed `vrt`)
+may lag the source. If it rejects subcommands with
+`Unknown command: diff`, the dist is stale — run `pnpm build` first
+or use the source form above. All `vrt ...` invocations in this
+skill assume one of these two forms.
+
 ## When to use
 
 - Agent edited CSS / HTML / a component file and wants a one-shot read
@@ -47,22 +62,27 @@ top-down:
 
 ## Quickstart
 
+`--output <dir>` is a **directory** path; the diff writes
+`<dir>/migration-report.json` (+ per-viewport PNGs) into it. Feed
+that JSON path — not the dir — to `vrt diff agent`.
+
 ```bash
-# Local HTML pair
-vrt diff html before.html after.html --output reports/diff.json
-vrt diff agent reports/diff.json > reports/diff.md
+# Local HTML pair → writes reports/migration-report.json
+vrt diff html before.html after.html --output reports/
+vrt diff agent reports/migration-report.json > reports/diff.md
 
 # URL pair (e.g. before/after a code change on the dev server)
 vrt diff html \
   --url http://localhost:3000/ \
   --current-url http://localhost:8080/ \
-  --output reports/diff.json
-vrt diff agent reports/diff.json
+  --output reports/
+vrt diff agent reports/migration-report.json
 
-# Mask dynamic regions (animation / live data) to suppress false positives
+# Mask dynamic regions. The value is one quoted, comma-separated CSS
+# selector list — shell-quoting is required so commas don't split args.
 vrt diff html before.html after.html \
   --mask ".marquee-container,.hero-badge,[data-testid='live-counter']" \
-  --output reports/diff.json
+  --output reports/
 ```
 
 ## Useful flags on `vrt diff agent`
@@ -81,18 +101,29 @@ exposes them but the watch skill explains the persistence model.
 
 ## How to read the report
 
-```
-## Verified deltas (computed-style) × viewport
-### Universal pairs        ← fix the base rule
-### Breakpoint-gated pairs ← fix or add @media rule
+The actual Markdown emitted by `vrt diff agent` opens with these
+sections, in this order (excerpt from a real run on
+`fixtures/element-compare/`):
 
-## Per-section diffRatio   ← which component changed, not just "the page"
-### card-hero    diffRatio 0.124  (worst on mobile)
-### card-footer  diffRatio 0.003  (negligible)
+```markdown
+# VRT diff (for agent)
 
-## Per-viewport
-### mobile      diffRatio 0.082  → diff-mobile.png
-### desktop     diffRatio 0.001
+Baseline: `before.html`
+Variants: `after.html`
+
+### Diff by viewport (worst first)
+
+| Viewport | Diff | Dominant category | Categories | Shift bands |
+|---|---|---|---|---|
+| `mobile`  | 23.14% | layout-shift | 1 layout-shift, 1 spacing | [240–480]:+113px |
+| `desktop` | 22.82% | typography  | 1 typography             | [240–480]:-120px |
+
+### Per-section diffRatio (heatmap × component-bbox)
+…
+
+### Verified deltas (computed-style) × viewport
+#### Universal pairs        ← fix the base rule
+#### Breakpoint-gated pairs ← fix or add @media rule
 ```
 
 **Triage order**: universal pairs > breakpoint-gated > per-section >

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: vrt-visual-diff
+description: Compare two rendered pages (URL pairs or local HTML) and produce a structured Markdown report tailored for coding agents — pixel diff per viewport, per-section diffRatio, computed-style diff split into universal vs. breakpoint-gated, and worst-viewport screenshot paths. Use when the agent just made a UI change and needs to know whether it altered visible output, where it altered it, and which CSS properties drove the change. Works on a single HTML/URL pair without baseline state.
+---
+
+# vrt-visual-diff
+
+Two-step workflow:
+
+1. `vrt diff html <baseline> <variant>` — Playwright-driven capture +
+   pixel diff + computed-style snapshot. Writes `report.json`.
+2. `vrt diff agent report.json` — formats the JSON into one Markdown
+   summary an agent can read in a single context window.
+
+The Markdown report layers signal hierarchies so a fresh agent can skim
+top-down:
+
+- **Verified deltas (computed-style)** — selector × property changes
+  confirmed by DOM, not just pixels. Universal pairs (differ on every
+  viewport) come first, breakpoint-gated pairs (differ on a strict
+  viewport subset, i.e. a missing `@media` rule) come second.
+- **Per-section diffRatio** — pixel diff scoped to each component
+  bounding box. Distinguishes "hero shifted" from "every component
+  shifted".
+- **Per-viewport diffRatio** — raw pixel diff per breakpoint, with
+  worst-viewport PNG path inline so the agent can `Read` the image.
+- **Heuristic fix candidates** — `selector { property: a → b }` hints
+  from the migration compare engine.
+- **Regression banner** — if a prior run's summary exists and the
+  majority of viewports got worse, a `### ⚠ REGRESSION` block sits
+  at the top.
+
+## When to use
+
+- Agent edited CSS / HTML / a component file and wants a one-shot read
+  of "what visibly changed."
+- Reviewing a refactor PR: "is this a no-op visually, or did it shift
+  something?"
+- Comparing two URLs (e.g. dev server vs. preview deploy).
+
+## When NOT to use
+
+- Running on a schedule with no prior diff: use `vrt-regression-watch`
+  instead (handles `.vrt/last-diff-for-agent.json` lifecycle).
+- Component synthesis from screenshots: use `vrt-markup-synth`.
+- CSS auto-repair loop: use `vrt-css-fix-loop`.
+
+## Quickstart
+
+```bash
+# Local HTML pair
+vrt diff html before.html after.html --output reports/diff.json
+vrt diff agent reports/diff.json > reports/diff.md
+
+# URL pair (e.g. before/after a code change on the dev server)
+vrt diff html \
+  --url http://localhost:3000/ \
+  --current-url http://localhost:8080/ \
+  --output reports/diff.json
+vrt diff agent reports/diff.json
+
+# Mask dynamic regions (animation / live data) to suppress false positives
+vrt diff html before.html after.html \
+  --mask ".marquee-container,.hero-badge,[data-testid='live-counter']" \
+  --output reports/diff.json
+```
+
+## Useful flags on `vrt diff agent`
+
+| Flag | Purpose |
+|---|---|
+| `--out <path>` | Write Markdown to a file instead of stdout |
+| `--max-viewports N` | Show top-N worst viewports inline (default 1) |
+| `--variant <file>` | Restrict report to one variant when comparing N variants |
+| `--show-unverified` | Include heuristic fix rows whose value already matches baseline (✗ rows). Default hides them. |
+| `--no-history` | Don't load or persist `.vrt/last-diff-for-agent.json` (one-shot mode for CI) |
+
+For regression tracking flags (`--previous`, `--persist-summary`,
+`--fail-on-regression`), use `vrt-regression-watch` — the same CLI
+exposes them but the watch skill explains the persistence model.
+
+## How to read the report
+
+```
+## Verified deltas (computed-style) × viewport
+### Universal pairs        ← fix the base rule
+### Breakpoint-gated pairs ← fix or add @media rule
+
+## Per-section diffRatio   ← which component changed, not just "the page"
+### card-hero    diffRatio 0.124  (worst on mobile)
+### card-footer  diffRatio 0.003  (negligible)
+
+## Per-viewport
+### mobile      diffRatio 0.082  → diff-mobile.png
+### desktop     diffRatio 0.001
+```
+
+**Triage order**: universal pairs > breakpoint-gated > per-section >
+raw per-viewport. The first non-empty row is almost always the actual
+change to inspect.
+
+## Masking is load-bearing
+
+`vrt diff html` re-runs the page in headless Chromium; any animation,
+clock, marquee, ad slot, or hash-randomized class will flap on every
+run. Pass `--mask <css-selectors>` for everything that isn't
+deterministic. Diff% < 0.05 on a clean page with no mask is rare —
+treat unexpected baseline noise as a missing mask, not a real diff.
+
+## Environment
+
+No env vars required for pixel + CSD path. The report is purely
+deterministic — no VLM / LLM is involved unless the migration-compare
+upstream invokes it (which `vrt diff html` does not by default).
+
+## Outputs at a glance
+
+| File | Source | Consumer |
+|---|---|---|
+| `report.json` | `vrt diff html` | machine input to `vrt diff agent` |
+| Markdown (stdout or `--out`) | `vrt diff agent` | the calling agent |
+| `diff-<viewport>.png` | `vrt diff html` | linked in markdown for direct `Read` |
+| `.vrt/last-diff-for-agent.json` | `vrt diff agent` | next run, for regression detection (skip with `--no-history`) |
+
+## Failure modes
+
+- `vrt diff html` errors with "browser not found" → run
+  `npx playwright install chromium` once.
+- Report shows 0 deltas but the agent expected changes → check the
+  variant URL is actually the new build (build cache hits are common).
+- Universal pairs section empty but breakpoint-gated full → the change
+  is media-query-conditional, the base rule didn't move.

--- a/README.md
+++ b/README.md
@@ -534,6 +534,38 @@ docs/
   reports/                  # Dated experiment reports
 ```
 
+## Agent Skills (APM)
+
+vrt ships five coding-agent skills under `.claude/skills/`. They wrap
+the most common workflows as standalone, agent-readable playbooks.
+Other repos can install them via [APM](https://agentskills.io):
+
+```bash
+# Install a single skill into the current repo's .claude/skills/
+apm install mizchi/vrt/.claude/skills/vrt-visual-diff
+
+# Install all five
+apm install mizchi/vrt/.claude/skills/vrt-visual-diff \
+            mizchi/vrt/.claude/skills/vrt-migration-eval \
+            mizchi/vrt/.claude/skills/vrt-css-fix-loop \
+            mizchi/vrt/.claude/skills/vrt-markup-synth \
+            mizchi/vrt/.claude/skills/vrt-regression-watch
+```
+
+| Skill | Entry workflow | Use when |
+|---|---|---|
+| `vrt-visual-diff` | `vrt diff html` → `vrt diff agent` | One-shot "did this CSS edit visibly change something?" |
+| `vrt-migration-eval` | `vrt migration compare\|blind\|subagent` | Framework / CSS-lib / build-system swap audit |
+| `vrt-css-fix-loop` | `fix-loop.ts` (VLM-driven) | Closed-loop CSS auto-repair benchmark |
+| `vrt-markup-synth` | `vrt build\|scan\|check\|stress *` | Screenshot → HTML/CSS, token / theme / i18n audits |
+| `vrt-regression-watch` | `vrt diff agent --previous --fail-on-regression` | Per-PR or scheduled regression gate |
+
+Each skill assumes the `vrt` CLI is on `$PATH` (this repo published as
+a Node package, or built from source) and Node 24+. VLM-using skills
+(`fix-loop`, `markup-synth`, `migration subagent`) additionally need
+one of `OPENROUTER_API_KEY` / `GEMINI_API_KEY` / `ANTHROPIC_API_KEY`
+depending on the model selected via `VRT_VLM_MODEL`.
+
 ## License
 
 MIT

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,11 @@
+name: vrt
+version: 0.5.0
+# vrt ships coding-agent skills via APM so other repos can `apm install`
+# them. The repo itself is a CC project, hence `targets: [claude]`.
+targets:
+  - claude
+dependencies:
+  apm: []
+  mcp: []
+scripts:
+  verify: "ls -1 .claude/skills | sort"

--- a/docs/reports/2026-05-19-agent-skills-validation-v1.md
+++ b/docs/reports/2026-05-19-agent-skills-validation-v1.md
@@ -1,0 +1,167 @@
+# Agent skills validation v1: bootstrap five skills + subagent eval (2026-05-19)
+
+## Question
+
+The PR #47 branch adds five coding-agent skills under
+`.claude/skills/` (`vrt-visual-diff`, `vrt-migration-eval`,
+`vrt-css-fix-loop`, `vrt-markup-synth`, `vrt-regression-watch`).
+Are they usable by a fresh agent reading the skill in isolation? Are
+the When-NOT-to-use sections strong enough to redirect mis-routed
+queries to the right sibling?
+
+## Setup
+
+Two general-purpose subagents, dispatched in parallel via the
+`Agent` tool. Each got:
+
+- Read-only access to ONE target SKILL.md + README.md + package.json.
+- The two HTML files `fixtures/element-compare/{before,after}.html`
+  as the comparison scenario, but **explicitly forbidden from
+  reading their source** (the diff has to come through the tool).
+- Forbidden from reading the other four SKILL.md files or
+  `.claude/CLAUDE.md`.
+- A budget of ONE round (skill quality is the variable, not iteration).
+
+| Subagent | Skill under test | Expected outcome |
+|---|---|---|
+| A | `vrt-visual-diff` | Should complete: this is the right tool for the scenario. |
+| B | `vrt-migration-eval` | Should bounce: "wrong tool, route to vrt-visual-diff." |
+
+## Result
+
+| Subagent | Outcome | What went right / wrong |
+|---|---|---|
+| A | **Could not reach a verdict** (Confidence: low) | Skill's `vrt diff html ...` form is rejected by the installed `dist/vrt.mjs`; subagent couldn't discover that the source form exists. |
+| B | **Correctly judged "wrong tool"** | Redirected to `vrt-visual-diff` using only `vrt-migration-eval`'s own description + When-NOT-to-use entries. |
+
+The asymmetry is informative: when the skill description carries
+enough scope detail (B), an agent can route correctly without
+reading siblings. When it doesn't tell you how to actually invoke
+the CLI (A), even the right tool fails.
+
+## What worked — direct quotes
+
+### Subagent B: "wrong tool" routing
+
+> "The fixture path `fixtures/element-compare/before.html` /
+> `after.html` carries no signal of a toolchain swap; the default
+> reading is 'small edit between two snapshots,' which the skill
+> itself routes elsewhere."
+
+The skill's description string (≤1024 chars, surfaced by APM) plus
+its first paragraph were enough to gate the decision. The
+sibling-pointer in "When NOT to use" (`Single CSS file edit: use
+vrt-visual-diff.`) was the load-bearing line.
+
+### Subagent A: pipeline framing
+
+> "Knowing the pipeline has two stages and what each stage outputs
+> is useful conceptually — but only conceptually, because the
+> commands themselves are wrong."
+
+The mental model arrived, but the executable form did not.
+
+## What didn't / new gaps
+
+### Gap 1 — Invocation method left implicit (CRITICAL)
+
+> "The actual binary does not expose a `diff` subcommand at all —
+> top-level `vrt` rejects it with `Unknown command: diff`."
+>     — subagent A
+
+Root cause: `dist/vrt.mjs` is a 2026-04-09 build that predates the
+`vrt diff <leaf>` reorganization in `src/cli/cli.ts`. The skill
+wrote `vrt diff html …`, expected an env where `vrt` was on PATH,
+and didn't explain that source needs to be invoked via
+`node --experimental-strip-types src/cli/vrt.ts …`.
+
+**Fixed in `56e4cb3`** — Invocation block prepended to all five
+skills. Each names the source form, warns that dist may lag,
+and tells the agent how to verify (`pnpm build` if the dist must
+be used).
+
+### Gap 2 — `--output reports/diff.json` is a directory
+
+> "Running `vrt compare … --output /tmp/…/diff.json` produces zero
+> stdout, zero stderr, exit 0, and no output file."
+>     — subagent A
+
+The migration-compare engine treats the `--output` value as a
+directory and writes `migration-report.json` inside it; the Quickstart
+spelled it as `reports/diff.json` which reads like a target filename.
+
+**Fixed in `56e4cb3`** — Quickstart uses `--output reports/` and
+passes the explicit `reports/migration-report.json` path to
+`vrt diff agent`. A one-sentence preface above the code block
+explains the directory semantics.
+
+### Gap 3 — No canonical example output to compare against
+
+> "There is a schematic ('How to read the report') but no canonical
+> snippet of a real Markdown report, so even on success an agent
+> cannot tell whether the output is sane."
+>     — subagent A
+
+**Fixed in `56e4cb3`** — schematic replaced with a real excerpt
+captured from a live run on `fixtures/element-compare/`, with
+sample diff percentages and shift bands.
+
+### Gap 4 — `vrt-migration-eval` Quickstart shape matches any pair
+
+> "[T]he matching `compare baseline.html variant.html` command
+> shape sells a fit that the prose disclaims."
+>     — subagent B
+
+`migration compare baseline.html variant.html` has the same shape as
+`diff html before.html after.html`, so a fresh agent on the wrong
+skill could still proceed. Subagent B caught this in time, but the
+prose-only disclaimer was the only thing stopping it.
+
+**Fixed in `9597aec`** — `vrt-migration-eval` now opens with a
+**Precondition (gate)**: "Name the migration as `<from-stack> →
+<to-stack>`. If you can't, stop and use `vrt-visual-diff` instead."
+The check is positioned before the Quickstart, forcing an explicit
+self-test.
+
+### Gap 5 — `dist/vrt.mjs` is stale (out of scope for this skill PR)
+
+A 2026-04-09 build for a 2026-05-19 source tree is a real
+publication/release issue, not a skill bug. Deferred: needs a
+separate PR to either rebuild + republish, or to remove the `bin`
+entry until the build is stable. Filed mentally; should become an
+issue.
+
+## What's fixed vs deferred
+
+| Gap | Status | Commit |
+|---|---|---|
+| 1. Invocation method | Fixed | `56e4cb3` |
+| 2. `--output` dir semantics | Fixed | `56e4cb3` |
+| 3. No canonical output snippet | Fixed | `56e4cb3` |
+| 4. Migration Quickstart trap | Fixed | `9597aec` |
+| 5. Stale `dist/vrt.mjs` | Deferred (vrt publication issue, not skill issue) | — |
+
+## Versus prior runs
+
+This is v1 — no prior run.
+
+## Next steps
+
+- File the stale-dist issue (Gap 5) so the publish loop catches up.
+- Run a v2 subagent on `vrt-visual-diff` after this PR lands to
+  confirm the Invocation block resolves Gap 1. (Other three skills
+  not exercised here; opportunistic re-eval when reasoning about
+  them.)
+- Open question: should `vrt-css-fix-loop` get a similar gate to
+  the one we added to `vrt-migration-eval`? Its scope is narrow
+  (CSS-challenge fixtures only) and the When-NOT-to-use already
+  covers "production self-repair on an arbitrary user repo." Not
+  exercised by a subagent yet — defer until there's signal.
+
+## Files
+
+- Skills: `.claude/skills/vrt-{visual-diff,migration-eval,css-fix-loop,markup-synth,regression-watch}/SKILL.md`
+- Manifest: `apm.yml`
+- Fixture used: `fixtures/element-compare/{before,after}.html`
+- Commits on `feat/agent-skills`: `003efd8` (initial), `9597aec`
+  (B fix), `56e4cb3` (A fix).

--- a/docs/reports/2026-05-19-agent-skills-validation-v2.md
+++ b/docs/reports/2026-05-19-agent-skills-validation-v2.md
@@ -1,0 +1,192 @@
+# Agent skills validation v2: confirm v1 + evaluate regression-watch (2026-05-19)
+
+## Question
+
+After v1 (commits `9597aec` + `56e4cb3`):
+
+1. Does `vrt-visual-diff` now complete on the same scenario subagent A failed on?
+2. Can a fresh agent assemble a 2-run regression-watch workflow from `vrt-regression-watch` alone?
+
+## Setup
+
+Two parallel general-purpose subagents, same agent-validation-loop
+discipline as v1. Each forbidden from reading the other four skills,
+the fixture HTML source, or prior subagent reports.
+
+| Subagent | Skill | Scenario |
+|---|---|---|
+| A2 | `vrt-visual-diff` | Same as A v1: diff `fixtures/element-compare/before.html` vs `after.html`. Confirm fix. |
+| C | `vrt-regression-watch` | Assemble 2-run workflow on identical inputs; verify no false-positive banner. |
+
+## Result
+
+| Subagent | Outcome | Confidence | Fix delta |
+|---|---|---|---|
+| A2 | **Completed**, verdict matches ground truth | high | v1 friction Gaps 1-3 closed; one new wording trap surfaced |
+| C | **Completed**, no false-positive banner | medium | Four new friction points, one of which was a real bug in the v1 CI gate snippet |
+
+A2 → A delta: from "could not reach a verdict / confidence low" to
+"verdict correct / confidence high". v1 invocation + Quickstart
+fixes stuck.
+
+## What worked
+
+### A2: pipeline mental model + correct verdict
+
+> "`node --experimental-strip-types src/cli/vrt.ts diff html ...
+> --output reports/` then `vrt diff agent
+> reports/migration-report.json --out reports/diff.md` ran cleanly
+> first try; both the JSON and Markdown landed where the skill said
+> they would."
+>     — subagent A2
+
+> "Two elements have larger box metrics in `after.html`, on **every**
+> viewport (universal, not breakpoint-gated): `body > header` —
+> `padding-top` `20px → 60px`, `padding-bottom` `20px → 60px` … `body
+> > header > h1` — `font-size` `24px → 32px`."
+>     — subagent A2's verdict
+
+Ground truth confirmed: header padding 20px→60px, h1 24px→32px,
+subtitle element added. A2 nailed the first two by computed-style;
+the subtitle showed up in section-level diffRatio (#3 row).
+
+### C: workflow assembled from Quickstart alone
+
+> "The Quickstart block (lines 63-74) was sufficient on its own — a
+> copy-pasteable two-step. The trailing paragraph clarified the
+> *why*: 'the example uses an explicit `.vrt/baseline.json` to show
+> how to keep a stable reference (e.g. \"diff against main's last
+> good run, not against the PR's previous run\")'."
+>     — subagent C
+
+The persist/previous model came through; identical-input second run
+correctly produced no `⚠ REGRESSION` banner.
+
+## What didn't / new gaps
+
+### Gap A — Triage-order misdirection (A2 found)
+
+The skill says: "Triage order: universal pairs > breakpoint-gated >
+per-section > raw per-viewport. The first non-empty row is almost
+always the actual change to inspect."
+
+But in the emitted Markdown, the Universal pairs table sits **near
+the bottom** (section ~13 of ~16), after eight intermediate sections.
+
+> "A first-time reader scrolling top-down has to know to jump to the
+> bottom. Either reorder, or replace 'first non-empty row' with
+> 'scroll to the *Universal pairs* table.'"
+>     — subagent A2
+
+**Fixed in `f219914`** — "Triage order" rewritten as scroll-to-bottom
+instruction; explicit position context ("section ~13 of ~16") added.
+Plus glossary for `Shift bands` and `Dominant category` (separate
+A2 nit).
+
+### Gap B — `--output reports/diff.json` systematic miss (C found)
+
+v1 fix only touched `vrt-visual-diff`. The same misuse remained in
+`vrt-regression-watch` (3 occurrences) and `vrt-migration-eval`
+(2 occurrences).
+
+> "The Quickstart's `--output reports/diff.json` is wrong /
+> misleading. In practice that creates a *directory*
+> `reports/diff.json/` whose actual report file is
+> `migration-report.json`. The next line `vrt diff agent
+> reports/diff.json ...` then fails with `EISDIR: illegal operation
+> on a directory, read`."
+>     — subagent C
+
+**Fixed in `282b6cc`** — all 5 occurrences fixed across both skills.
+
+Lesson: when a fix applies to a vocabulary used across skills,
+grep for it before declaring done. The v1 fix sequence was "one
+skill, one commit" — should have been "one fix, all skills".
+
+### Gap C — Real bug in v1 CI gate pattern (C found, source-verified)
+
+> "What I'm only medium on: whether `--persist-summary` is
+> independent of `--no-history` or supersedes it (the CI snippet
+> implies independent, but the flag table doesn't say so)."
+>     — subagent C
+
+Source check (`src/cli/commands/diff-for-agent-cli.ts:177-180`):
+`--no-history` skips BOTH load AND write. So the v1 CI snippet —
+which passed `--previous .vrt/baseline.json` plus `--no-history` —
+**silently skips the load**, never compares, and never fails on
+regression. The gate would never fire.
+
+**Fixed in `282b6cc`** — CI snippet now uses `--persist-summary
+/tmp/pr-summary.json` (PR-specific throwaway). Flag-reference table
+gains a "Pick one of these three modes" guide explicitly listing
+the four configurations.
+
+### Gap D — Local-rolling idiom not exemplified (C found)
+
+> "The skill says `--persist-summary` 'Override destination for this
+> run's summary' but doesn't show that passing the *same* file to
+> `--previous` and `--persist-summary` is the local-rolling idiom."
+>     — subagent C
+
+**Fixed in `282b6cc`** — Quickstart comment now reads "same baseline
+file for read AND write … passing the same path to `--previous` and
+`--persist-summary` means 'compare against last run, then overwrite'".
+
+### Gap E — Three Verified-deltas tables look redundant (A2 found, deferred)
+
+> "Minor redundancy: three tables ('Verified deltas by DOM position
+> × viewport', 'Verified deltas by DOM position', 'Verified deltas
+> (computed-style)') and a fourth '× viewport' table all carry the
+> same five rows. Not friction exactly, but on first read I kept
+> asking 'is this saying something new?'"
+>     — subagent A2
+
+Out of scope for skills — this is `diff-for-agent.ts` output
+ordering / dedup. Deferred to a follow-up vrt PR.
+
+## What's fixed vs deferred
+
+| Gap | Status | Commit |
+|---|---|---|
+| A. Triage order misdirection | Fixed | `f219914` |
+| B. `--output` systematic miss | Fixed | `282b6cc` |
+| C. CI gate pattern bug (`--previous`+`--no-history`) | Fixed | `282b6cc` |
+| D. Local-rolling idiom example | Fixed | `282b6cc` |
+| E. Verified-deltas table redundancy | Deferred — vrt internals | — |
+| (v1 deferred) stale `dist/vrt.mjs` | Deferred — vrt publication | — |
+
+## Versus v1
+
+| Metric | v1 | v2 |
+|---|---|---|
+| Workflows completed | 0 / 1 | 2 / 2 |
+| Verdicts correct | n/a | 1 / 1 (A2; C scenario had no verdict to reach) |
+| Confidence | low (A) / n/a (B) | high (A2) / medium (C) |
+| Real bugs found in shipped skills | 0 | 1 (CI gate pattern was unfireable) |
+| Skill-level frictions surfaced | 4 (A: 3, B: 1) | 4 (A2: 1, C: 3) |
+
+The v2 round is more valuable than v1 because:
+1. It confirmed v1's fix landed.
+2. It caught a **real semantic bug** in the v1 CI snippet that
+   reading the skill in isolation surfaced (an agent following the
+   v1 instructions would have shipped a non-functional CI gate).
+3. The systematic-miss lesson (Gap B) is generalizable: future
+   skill-level fixes need a grep sweep before declaring complete.
+
+## Next round candidates
+
+- **C2**: Re-run subagent on `vrt-regression-watch` (same scenario)
+  after `282b6cc` to confirm the dir-semantics + CI fix sticks.
+- **E**: First evaluation of `vrt-css-fix-loop`. Requires VLM API key
+  (OPENROUTER or claude). Scenario: CSS-challenge fixture, seed 11,
+  selector mode, `bytedance/ui-tars-1.5-7b`.
+- **D**: First evaluation of `vrt-markup-synth`. Requires image input
+  + VLM. Deferred — needs a curated fixture.
+
+## Files
+
+- Skills modified: `.claude/skills/vrt-visual-diff/`,
+  `.claude/skills/vrt-migration-eval/`, `.claude/skills/vrt-regression-watch/`.
+- Source consulted (for Gap C): `src/cli/commands/diff-for-agent-cli.ts:177-180`.
+- Fixture: `fixtures/element-compare/{before,after}.html`.
+- Commits on `feat/agent-skills`: `f219914`, `282b6cc`.

--- a/docs/reports/2026-05-19-agent-skills-validation-v3.md
+++ b/docs/reports/2026-05-19-agent-skills-validation-v3.md
@@ -1,0 +1,200 @@
+# Agent skills validation v3: confirm v2 + evaluate markup-synth + css-fix-loop (2026-05-19)
+
+## Question
+
+After v2 (commits `f219914` + `282b6cc`):
+
+1. Does the v2 fix to `vrt-regression-watch` still hold under a fresh
+   subagent + a CI-snippet construction sub-task?
+2. Are `vrt-markup-synth` and `vrt-css-fix-loop` — the two
+   not-yet-validated skills — accurate?
+
+## Setup
+
+Three parallel general-purpose subagents in sequence (C2 first to
+free the writer for the next two; D + E in parallel after).
+
+| Subagent | Skill | Scenario |
+|---|---|---|
+| C2 | `vrt-regression-watch` | v2 confirm. No-op 2-run + assemble CI snippet from "Pick one of these three modes" guide. |
+| D | `vrt-markup-synth` | Audit `fixtures/element-compare/before.html` via `check tokens`. Note any API-key claim accuracy gap. |
+| E | `vrt-css-fix-loop` | Run fix-loop on `page` fixture, seed 11, selector mode, default model, 2 rounds. |
+
+## Result
+
+| Subagent | Outcome | Confidence | Severity of new friction |
+|---|---|---|---|
+| C2 | **Completed**, CI snippet correct, mode pick correct, no-history trap avoided | high | minor (1 nit — copy-paste convenience) |
+| D | **Completed**, 9 violations detected correctly | high | **MAJOR — skill was a fabrication on its core claim** |
+| E | **FIXED on round 1** (diff 4.1% → 0.0%) | high (on outcome) / low (on pipeline mental model) | major (pipeline-shape descriptive bug) |
+
+The v2 fix stuck (C2 confidence high vs C medium). The two new
+evaluations exposed something I had been afraid of: my v1 SKILL.md
+authoring contained material factual errors that no v1/v2 round
+could have caught, because they were about skills that hadn't yet
+been exercised.
+
+## What worked
+
+### C2: skill guides built the CI snippet without trap
+
+> "Mode picked: 'Compare against fixed reference, leave it untouched' =
+> `--previous X --persist-summary <pr-specific-path>`. This satisfies
+> (e) by routing the PR's persist write to a throwaway tmp path so
+> the cached `.vrt/main-baseline.json` is never overwritten.
+> `--no-history` would skip the load too, killing regression
+> detection — explicitly warned against in the skill."
+>     — subagent C2
+
+The v2 "Pick one of these three modes" table + the warning anchored
+the right combination on first read.
+
+### D: token-conformance audit accurate without API
+
+> "Audit verdict: Violations found (9 total) — `main>div.sidebar
+> margin-top 10.00px → nearest 8`, `main>div.sidebar padding 15.00px
+> → nearest 16`, `footer padding 15.00px → nearest 16`."
+>     — subagent D
+
+Verdict matches ground truth — the fixture's sidebar/footer use
+hardcoded `10px` / `15px` against the default `0,2,4,8,12,16,...`
+scale.
+
+### E: pipeline converged + Quickstart copy-pasteable
+
+> "The Quickstart selector-mode example was copy-pasteable verbatim
+> […] Zero guessing."
+>     — subagent E
+
+## What didn't / new gaps
+
+### Gap F — vrt-markup-synth was a fabrication (D found, source-verified)
+
+The skill's frontmatter described all five sub-tools as "VLM-driven;
+requires API keys." Subagent D ran `check tokens` with no API key in
+env and got a clean report in ~1s, ruling out the blanket claim:
+
+> "I ran the command with zero `OPENROUTER_API_KEY` /
+> `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` / `VRT_*` variables in the
+> environment […] The command produced a complete report in ~1s
+> with no API call."
+>     — subagent D
+
+I then grep'd the source: **all five sub-tools** (`build component`,
+`scan component`, `check tokens`, `check theme`, `stress i18n`)
+import zero VLM/LLM client code. Each is pure Playwright + pixel /
+DOM computation. The original SKILL.md was a fabrication I shipped
+without checking.
+
+**Fixed in `67b4f97`** — full rewrite. The agent is the VLM; tools
+surface signal. Frontmatter, sub-tools table, Environment, Costs,
+Failure-modes all aligned with the actual behaviour. Default token
+scales documented (`0,2,4,8,12,16,…`). The `vrt check tokens` ↔
+`vrt design-tokens` dispatcher alias is now noted (subagent D hit a
+small confusion from the banner reading `design-tokens`).
+
+This is the most important lesson of the run: **a fresh subagent
+caught what no amount of self-review by the author could**.
+
+### Gap G — fix-loop is 2-stage, not 1-stage (E found)
+
+The skill described fix-loop as a single VLM call per round
+("Send the diff overlay to the VLM... Parse the VLM's CHANGE list...
+Re-run"). Real harness output:
+
+> "VLM=bytedance/ui-tars-1.5-7b | LLM=claude-sonnet-4-20250514 […]
+> Real output has a two-stage pipeline (`VLM: 5 changes → LLM: 6
+> fixes proposed`) that the skill never mentions."
+>     — subagent E
+
+Worse, this changes the semantics of FIXED. The VLM proposed
+selectors unrelated to the removed block (`.main / .sidebar /
+.header-nav` while the removed block was `.readme-body pre`), and
+the LLM compensated — pipeline hit FIXED but the VLM did *not*
+recover the regression on its own:
+
+> "Mismatch between proposed selectors and removed block […] The
+> FIXED verdict feels suspicious — either the diff overlay made
+> non-removed elements look changed, or the Stage-2 LLM
+> compensated."
+>     — subagent E
+
+This matters because the skill's stated purpose is "measuring
+whether a VLM model can recover a known regression." FIXED, taken
+alone, doesn't answer that question.
+
+**Fixed in `29accff`** — pipeline steps now name VLM and LLM
+stages explicitly with banner format. Added a "Pipeline divergence
+warning" calling out the LLM-rescue case and pointing to selector /
+property recall as the correct VLM-isolation metric. Quickstart
+opens with a one-line direnv / `.env.local` hint (separate small
+nit from E).
+
+### Gap H — \$REPORT var in regression-watch Quickstart (C2 minor)
+
+> "a reader has to stitch two snippets to learn the filename."
+>     — subagent C2
+
+**Fixed in `cf9cfe5`** — `REPORT=reports/migration-report.json`
+factored out at the top of the Quickstart.
+
+## What's fixed vs deferred
+
+| Gap | Status | Commit |
+|---|---|---|
+| F. markup-synth fabrication | Fixed | `67b4f97` |
+| G. fix-loop 2-stage pipeline + FIXED semantics | Fixed | `29accff` |
+| H. \$REPORT var convenience | Fixed | `cf9cfe5` |
+
+## Versus prior rounds
+
+| Metric | v1 | v2 | v3 |
+|---|---|---|---|
+| Workflows completed | 0 / 1 | 2 / 2 | 3 / 3 |
+| Skills exercised | 2 (visual-diff, migration-eval) | 1 confirm + 1 new (visual-diff conf., regression-watch) | 1 confirm + 2 new (regression-watch conf., markup-synth, css-fix-loop) |
+| **Real factual bugs found** | 0 | 1 (CI gate pattern unfireable) | **1 (markup-synth fabrication)** + 1 (fix-loop 1-stage misdesc) |
+| Skill-level frictions surfaced | 4 | 4 | 3 (1 minor + 2 major) |
+
+The v3 round did something v2 couldn't: it surfaced **fabrication-
+class errors** — claims in SKILL.md that didn't match the
+implementation, not just unclear wording. These can only be caught
+by exercising the skill against the real tool.
+
+## Lesson — calibration
+
+I authored five SKILL.md files in commit `003efd8` based on my
+mental model of what each command did. The mental model was
+**materially wrong for at least two of the five skills** (the two
+that weren't validated until v3). The visual-diff / migration /
+regression-watch skills also had errors, but their errors were
+incremental ("wrong shape of `--output`", "missing precondition")
+rather than fabrications. The wider gap appeared exactly where my
+prior knowledge was thinner.
+
+**Takeaway**: never ship a SKILL.md without (a) at least one fresh
+subagent exercising it, or (b) the author having recently run the
+underlying command and read its output. I had done neither for
+markup-synth's audit sub-tools, and the fabrication followed
+predictably.
+
+## Next round candidates
+
+- **D2**: Confirm subagent on the rewritten `vrt-markup-synth`.
+  Same check-tokens scenario; assess whether the new frontmatter
+  routes the right agent in.
+- **E2**: Confirm subagent on `vrt-css-fix-loop`. Same scenario but
+  check whether the agent now correctly distinguishes "pipeline
+  FIXED" from "VLM recovered the regression."
+
+Both are low-cost (~$0 / ~$1e-7) and high info value.
+
+## Files
+
+- Skills modified: `.claude/skills/vrt-regression-watch/`,
+  `.claude/skills/vrt-markup-synth/`,
+  `.claude/skills/vrt-css-fix-loop/`.
+- Source consulted: `packages/vrt-markup/src/*` (zero VLM imports
+  confirmed across all five sub-tools).
+- Fixtures used: `fixtures/element-compare/before.html` (D),
+  CSS-challenge `page` fixture (E).
+- Commits on `feat/agent-skills`: `cf9cfe5`, `67b4f97`, `29accff`.

--- a/docs/reports/2026-05-19-agent-skills-validation-v4.md
+++ b/docs/reports/2026-05-19-agent-skills-validation-v4.md
@@ -1,0 +1,172 @@
+# Agent skills validation v4: confirm v3 rewrites (2026-05-19)
+
+## Question
+
+After v3 (commits `cf9cfe5` + `67b4f97` + `29accff`):
+
+1. Does the `vrt-markup-synth` rewrite let an agent predict
+   "no API key needed" from the SKILL.md alone?
+2. Does the `vrt-css-fix-loop` rewrite let an agent correctly
+   diagnose whether the VLM (Stage 1) or the LLM (Stage 2) drove a
+   FIXED verdict?
+
+## Setup
+
+Two parallel general-purpose subagents — same agent-validation-loop
+discipline.
+
+| Subagent | Skill | Task |
+|---|---|---|
+| D2 | `vrt-markup-synth` (post-`67b4f97`) | Audit `fixtures/element-compare/before.html` via `check tokens`. **Predict API-key need from skill before running.** |
+| E2 | `vrt-css-fix-loop` (post-`29accff`) | Run fix-loop on `page` fixture seed 11 selector mode. **Diagnose: did the VLM recover the regression itself?** |
+
+## Result
+
+| Subagent | Outcome | Confidence | New friction |
+|---|---|---|---|
+| D2 | **Prediction correct (No)**; run clean; verdict matched ground truth | high | 1 minor (CLI banner still uses legacy `vrt design-tokens` name) |
+| E2 | **Diagnosis correct (LLM compensated)**; mental model anchored on skill quotes | high | nothing surfaced (1 suggestion only) |
+
+Both subagents quoted the v3 fixes as the load-bearing lines that
+anchored their answers — i.e. the fixes weren't just present, they
+were the thing that worked.
+
+## What worked — direct quotes
+
+### D2: skill-only prediction
+
+> "API-key prediction from SKILL.md alone: No. Load-bearing line
+> (frontmatter): 'All five are pure DOM + Playwright + pixel
+> processing — no VLM / no API key required.' Reinforced under
+> Environment: 'No API keys are required for any sub-tool in this
+> skill.'"
+>     — subagent D2
+
+The rewrite carries the same message in three places (frontmatter,
+Environment section, sub-tool table). The redundancy is intentional
+and earned a "match — prediction confirmed" on first run.
+
+### D2: over-correction check
+
+> "Over-correction check: skill says 'The VLM / VRT_VLM_MODEL env
+> vars listed in other VRT skills do not apply here.' That's
+> correct and does not obscure that other skills need keys — it
+> explicitly points outward."
+>     — subagent D2
+
+The rewrite didn't swing the pendulum too far. Good.
+
+### E2: diagnostic anchored on quoted skill text
+
+> "The LLM (Stage 2) compensated — the VLM did not recover the
+> regression itself. Evidence: Removed: `.readme-body pre { 6 props }`
+> is the ground-truth missing block, but the VLM's 5-row CHANGE list
+> mentions `.main`, `.sidebar`, `.header-nav`, `.header-search`,
+> `.tabs` — none reference `.readme-body pre`. The pipeline still
+> hit FIXED because the LLM emitted 11 fixes (≥ VLM's 5, with high
+> confidence) that restored the deleted block."
+>     — subagent E2
+
+E2 reached the diagnosis E couldn't reach in v3 (E v3 flagged the
+mismatch as "suspicious" but had no framework for it). The "Pipeline
+divergence warning" added in `29accff` did its job verbatim.
+
+## What didn't / new gaps
+
+### Gap I — Legacy `vrt design-tokens` banner (D2 minor)
+
+> "the CLI header literally prints `vrt design-tokens` even when
+> invoked as `vrt check tokens`, and the report's 'Suggested next
+> step' says 'Re-run `vrt design-tokens`' — not the documented
+> `vrt check tokens`. The skill warns about this in one direction
+> (dispatcher routes both); it doesn't warn the agent that the CLI's
+> own output will use the *other* name."
+>     — subagent D2
+
+**Fixed in `6b663b4`** — sub-tools table's check-tokens row now
+explicitly calls out the legacy banner so the agent doesn't second-
+guess which command they ran.
+
+### Gap J — Summary-table columns (E2 suggestion)
+
+> "The harness prints this final table but the skill doesn't show
+> or label it; a future agent comparing runs across models would
+> benefit from knowing `Escalated=false` means Stage-2 LLM stayed on
+> the default tier (no fallback ladder triggered)."
+>     — subagent E2
+
+**Fixed in `ba1986e`** — "Reading the output" section gains a
+glossary table for `Round / Diff / Changes / Fixes / Escalated`.
+
+## Stop signs
+
+All three of agent-validation-loop's stop-the-loop signals:
+
+- ✓ **"Each new agent run surfaces fewer new gaps than the last"**:
+  v1=4, v2=4, v3=3 (2 major + 1 minor), v4=2 (1 minor + 1 suggestion).
+- ✓ **"Per-fix commit size is shrinking"**: v3 had a ~120-line
+  rewrite (markup-synth); v4 commits are 1-11 lines each.
+- ✓ **"Remaining variance is agent-side initial-state, not tool
+  signal quality"**: v4's two friction points are both about
+  decorations (legacy CLI banner + column labels), not about
+  whether the agent can use the skill.
+
+**Decision: stop the validation loop here.** Five rounds (a, b, a2,
+c, c2, d, e, d2, e2 = 9 agent runs counted as eval invocations),
+all 5 skills exercised, all major fabrications surfaced and
+corrected.
+
+## Cumulative tally
+
+| Round | Agents | Workflows completed | Real bugs found | Friction landed |
+|---|---|---|---|---|
+| v1 | A, B | 1/2 (B routed correctly; A blocked) | 0 | 4 fixes |
+| v2 | A2, C | 2/2 | 1 (CI gate unfireable) | 4 fixes |
+| v3 | C2, D, E | 3/3 | **2 (markup-synth fabrication + fix-loop 1-stage misdesc)** | 3 fixes |
+| v4 | D2, E2 | 2/2 | 0 | 2 fixes (minor) |
+| **Total** | **9 agent runs** | **8/9** | **3** | **13 fixes** |
+
+The v3 round was the highest-yield: it caught factual errors that
+no v1/v2 round could have surfaced (the two skills weren't yet
+exercised), and the fixes were large.
+
+## Deferred (out of scope for this PR — file as separate issues)
+
+- **Stale `dist/vrt.mjs`** (v1 finding): the published binary is a
+  2026-04-09 build for a 2026-05-19 source tree. Skill-level
+  workaround landed via the Invocation block, but the real fix is
+  to rebuild + republish (or drop the `bin` entry until cadence
+  catches up).
+- **`diff-for-agent.ts` Verified-deltas table redundancy** (v2 A2
+  finding): three near-identical "Verified deltas" tables emit
+  similar rows; ordering / dedup is a `diff-for-agent.ts` question.
+
+## Lessons (carried forward)
+
+1. **A SKILL.md is a fabrication risk if the author hasn't recently
+   run the underlying command.** Confirmed in v3 with markup-synth
+   and fix-loop. Mitigation: never ship a new SKILL.md without (a)
+   one fresh subagent exercising it, or (b) a recent transcript of
+   running the command and reading its output.
+
+2. **When a fix applies to a vocabulary used across skills, grep
+   first.** v2 caught this: v1's `--output reports/diff.json` fix
+   only touched one skill; the same misuse remained in two others.
+
+3. **"How to read the output" benefits from a real excerpt with
+   real numbers, not a schematic.** v1's schematic looked plausible
+   but didn't help A debug a failed run; v2's real excerpt helped
+   A2 immediately recognize where Universal pairs sits in the
+   actual output.
+
+4. **Stop signs work.** The loop converged in 4 rounds because each
+   round had explicit success criteria and the friction list was
+   shrinking by both count and severity.
+
+## Files
+
+- Skills modified: `.claude/skills/vrt-markup-synth/`,
+  `.claude/skills/vrt-css-fix-loop/`.
+- Fixtures used: `fixtures/element-compare/before.html` (D2),
+  CSS-challenge `page` fixture (E2).
+- Commits on `feat/agent-skills`: `6b663b4`, `ba1986e`.

--- a/docs/reports/2026-05-19-agent-skills-validation-v5.md
+++ b/docs/reports/2026-05-19-agent-skills-validation-v5.md
@@ -1,0 +1,178 @@
+# Agent skills validation v5: cross-skill routing (2026-05-19)
+
+## Question
+
+Per-skill validation finished in v4 (loop declared converged). v5
+asks a different question: **given all five SKILL.md files
+available, can a fresh agent route a scenario to the right one
+based on descriptions alone?** Two scenarios, two parallel
+subagents, no "you must use skill X" hint.
+
+## Setup
+
+| Subagent | Scenario | Right answer |
+|---|---|---|
+| F | "Diff two HTML files, single CSS edit, no CI loop." | `vrt-visual-diff` |
+| G | "Target PNG + blank HTML scaffold; want pixel signal per round." | `vrt-markup-synth` (build component) |
+
+All five skills readable. Forbidden: fixture source, internals,
+`.claude/CLAUDE.md`, `docs/reports/` (to avoid bias from past
+runs).
+
+## Result
+
+| Subagent | Pick | Correct? | Friction surfaced |
+|---|---|---|---|
+| F | `vrt-visual-diff` | ✓ | 1 minor description over-claim + 1 deferred |
+| G | `vrt-markup-synth` (build component) | ✓ | 2 minor doc bugs on the build-component sub-tool |
+
+**Both subagents routed correctly with high confidence.** Each
+named the sibling skills it had considered and rejected, with the
+verbatim "When NOT to use" / precondition-gate line that
+disqualified each. This is the strongest evidence so far that the
+skill descriptions carry the routing weight.
+
+## What worked
+
+### F: every sibling was disqualified by name
+
+> "vrt-migration-eval precondition gate: 'Before running, name the
+> migration: \<from-stack\> → \<to-stack\>. … If you cannot fill in
+> both sides … this is the wrong skill — stop and use
+> vrt-visual-diff instead.' Scenario says 'not a framework swap' —
+> gate fails."
+> 
+> "vrt-regression-watch 'When NOT to use': 'One-shot diff with no
+> history: vrt-visual-diff.' Scenario says 'no CI loop required.'"
+> 
+> "vrt-css-fix-loop 'When NOT to use': 'Bulk regression triage: use
+> vrt-visual-diff for one-shot reads.' Plus its fixture-bound
+> precondition."
+> 
+> "vrt-markup-synth 'When NOT to use': 'Comparing two existing pages:
+> vrt-visual-diff.'"
+>     — subagent F
+
+The v1 migration precondition gate (`9597aec`) and the cross-skill
+"When NOT to use" pointers in every sibling each carried real
+routing weight here. No skill needed to be re-read past its
+opening few sections.
+
+### G: image+scaffold was unambiguous
+
+> "Recognizability: yes — 'screenshot + HTML scaffold' in the
+> description was unambiguous. Nothing tried to steal me away."
+>     — subagent G
+
+vrt-visual-diff was the natural foil (both touch pixel diff), but
+its description rules itself out:
+
+> "vrt-visual-diff is the obvious foil … its description rules
+> itself out: 'Compare two rendered pages (URL pairs or local
+> HTML)' and 'agent just made a UI change and needs to know whether
+> it altered visible output.' It assumes two pages exist, not 'an
+> image plus an empty scaffold.' The cross-reference 'Component
+> synthesis from screenshots: use vrt-markup-synth' sealed it."
+>     — subagent G
+
+## What didn't / new gaps
+
+### Gap K — `vrt-visual-diff` description over-claims fix candidates (F)
+
+> "vrt-visual-diff's description says 'heuristic fix candidates —
+> `selector { property: a → b }` hints'. The actual report's 'Fix
+> Candidates' row read 'after no suggestions', while heuristic Δtop
+> suggestions appeared earlier as 'Wireframe fix suggestions'
+> instead. Description names a section header that does not match
+> the output verbatim."
+>     — subagent F
+
+**Fixed in `d1af6f7`** — appended a half-sentence noting the row may
+read `no suggestions` and that wireframe-level Δtop suggestions
+appear earlier in the report.
+
+### Gap L — `build component` `--output` flag is ignored (G)
+
+> "I passed `--output /tmp/vrt-skill-eval-g/report.md`; the tool
+> still wrote to `test-results/component/report.md` […] That flag
+> silently doesn't honor a file path. Mildly misleading."
+>     — subagent G
+
+The skill's Quickstart wrote `vrt build component design.png
+current.html --output report.md` — that's a lie.
+
+**Fixed in `56ec3fd`** — Quickstart drops the `--output` argument;
+sub-tools table now states the fixed output path
+(`test-results/component/report.md`) explicitly.
+
+### Gap M — `build component` legacy banner (G)
+
+The v4 fix added a `vrt design-tokens` legacy-banner caveat for
+`check tokens` but missed the parallel case for `build component`
+(banner prints `vrt component-from-image`).
+
+> "stdout banner says `vrt component-from-image` while I typed
+> `vrt build component`. The skill warns about this only for
+> `check tokens` […] same gotcha applies to `build component` but
+> isn't documented."
+>     — subagent G
+
+**Fixed in `56ec3fd`** (same commit as Gap L) — sub-tools table's
+build-component row gains the same `vrt component-from-image`
+caveat structure.
+
+### Gap N — `migration-report.json` filename leak (F minor, deferred)
+
+> "`--output` writes `migration-report.json` even on the
+> non-migration path. The skill calls this out … but the filename
+> still feels like a leak from `vrt-migration-eval`."
+>     — subagent F
+
+Deferred — this is a vrt-internal naming choice (the diff-html and
+migration-compare paths share the same writer). Renaming requires
+changes to the engine + tests + callers. Out of scope for skill PRs.
+
+## Stop signs revisited (post-v5)
+
+v5 didn't void the v4 stopping decision. All three signs still
+hold, and v5 added the cross-skill-routing data point: **descriptions
+work as a routing layer**, not just as per-skill ergonomics.
+
+- ✓ Gaps per round: v1=4, v2=4, v3=3, v4=2, **v5=3 minor (1 deferred)**.
+- ✓ Per-fix commit size: 3-4 lines each in v5.
+- ✓ Remaining variance is description-decoration / vrt-internal
+  naming, not skill capacity.
+
+## Cumulative tally (5 rounds)
+
+| Round | Agents | Bugs | Fixes |
+|---|---|---|---|
+| v1 | A, B | 0 | 4 |
+| v2 | A2, C | 1 | 4 |
+| v3 | C2, D, E | 2 | 3 |
+| v4 | D2, E2 | 0 | 2 |
+| v5 | F, G | 0 | 2 (1 deferred) |
+| **Total** | **11 agent runs** | **3** | **15** |
+
+## Lessons added
+
+5. **Cross-skill routing depends on every sibling's "When NOT to
+   use" pointing back to the right one.** v5 showed this in
+   action: F's pick was clean because *all four* siblings had a
+   verbatim quote that disqualified them. Skill ecosystems need
+   to maintain this graph of cross-references — a missing arrow
+   in one skill makes selection fragile.
+
+6. **Caveats about CLI legacy names need to be systematic, not
+   case-by-case.** v4 added the caveat for `check tokens`; v5
+   surfaced the same need for `build component`. Future
+   subcommand additions: scan for banner-name vs invoked-name
+   mismatches first.
+
+## Files
+
+- Skills modified: `.claude/skills/vrt-markup-synth/`,
+  `.claude/skills/vrt-visual-diff/`.
+- Fixtures used: `fixtures/element-compare/{before,after}.html` (F),
+  `fixtures/wireframe/pricing-card/{target-desktop.png,blank.html}` (G).
+- Commits on `feat/agent-skills`: `56ec3fd`, `d1af6f7`.


### PR DESCRIPTION
## Summary

Ship five coding-agent skills under `.claude/skills/` plus `apm.yml` so other repos can `apm install mizchi/vrt/.claude/skills/<name>`. Five rounds of subagent validation against the actual tools turned the original drop into a corpus where every claim was exercised before merging.

## Skills

| Skill | Entry workflow | Use when |
|---|---|---|
| `vrt-visual-diff` | `vrt diff html` → `vrt diff agent` | One-shot "did this CSS edit visibly change something?" |
| `vrt-migration-eval` | `vrt migration compare\|blind\|subagent` | Framework / CSS-lib / build-system swap audit (precondition gate: name the migration `<from-stack> → <to-stack>` first) |
| `vrt-css-fix-loop` | `fix-loop.ts` (VLM Stage 1 → LLM Stage 2) | Two-stage benchmark of VLM CHANGE-list quality on fixture regressions |
| `vrt-markup-synth` | `vrt build\|scan\|check\|stress *` | Pure DOM + Playwright signal tools (no VLM / no API key) for screenshot → component iteration, token audits, theme parity, i18n stress |
| `vrt-regression-watch` | `vrt diff agent --previous --fail-on-regression` | Per-PR or scheduled regression gate; "Pick one of these three modes" guide for persist/previous flags |

## Validation loop (5 rounds, 11 agent runs, 3 real bugs caught)

Reports: `docs/reports/2026-05-19-agent-skills-validation-v{1..5}.md`.

| Round | Agents | Workflows completed | Real bugs found | Fixes |
|---|---|---|---|---|
| v1 | A, B | 1 / 2 (A blocked on stale dist; B routed correctly) | 0 | 4 |
| v2 | A2, C | 2 / 2 | **1** — `--previous X --no-history` silently skipped the load, making the v1 CI-gate snippet unfireable | 4 |
| v3 | C2, D, E | 3 / 3 | **2** — `vrt-markup-synth` was a fabrication (no sub-tool actually uses a VLM); `vrt-css-fix-loop` is 2-stage VLM→LLM, not 1-stage | 3 |
| v4 | D2, E2 | 2 / 2 | 0 | 2 |
| v5 | F, G | 2 / 2 (cross-skill routing) | 0 | 2 |
| **Total** | **11 runs** | **10 / 11** | **3** | **15** |

The v3 round was the highest-yield: it caught factual errors no v1/v2 round could have surfaced, because the two skills hadn't yet been exercised against the actual implementation. v5 validated that the cross-skill "When NOT to use" pointer graph carries real routing weight — each subagent quoted every sibling's disqualifying line by name.

## Carried-forward lessons (from validation reports)

1. **Never ship a SKILL.md without exercising it.** The markup-synth fabrication (v3) only surfaced when a fresh subagent ran the actual command.
2. **When a fix applies to vocabulary used across skills, grep first.** v2 caught this: v1's `--output reports/diff.json` fix only touched one skill; the same misuse remained in two others.
3. **"How to read the output" needs a real excerpt with real numbers, not a schematic.**
4. **Cross-skill routing depends on every sibling's "When NOT to use" pointing back correctly** — a missing arrow makes selection fragile.
5. **Caveats about CLI legacy names need to be systematic, not case-by-case.**

## Follow-up issues filed

- #48 — `dist/vrt.mjs` is stale (2026-04-09 build, rejects `vrt diff html`). Skill-level workaround landed; the actual fix is rebuild + republish or drop the `bin` entry.
- #49 — `diff-for-agent` emits three near-identical "Verified deltas" tables. Universal pairs sits ~13 of ~16; skill points at it via scroll-to-bottom note, but the proper fix is to dedupe / re-order.
- #50 — Output file is always named `migration-report.json` even on the non-migration `vrt diff html` path. The shared name makes the diff-html path look like the wrong skill mid-run.

## Test plan

- [x] `apm.yml` validates (manual structural check vs apm-usage spec)
- [x] Each SKILL.md frontmatter description ≤1024 chars (515 chars max)
- [x] Each skill exercised by at least one fresh subagent (v1-v5)
- [x] Cross-skill routing exercised with all 5 SKILL.md readable (v5)
- [ ] `apm install mizchi/vrt/.claude/skills/vrt-visual-diff` from another repo — to verify post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)