### PR TITLE
Hoist Universal/Breakpoint-gated table + document legacy filename (closes #49, partial #50)

### DIFF
--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -64,6 +64,11 @@ from triggering false alarms.
 `<dir>/migration-report.json` into it. Pass that JSON file path —
 not the dir — to `vrt diff agent`.
 
+The filename is `migration-report.json` even when there's no migration
+involved because the writer is shared with `vrt migration compare`.
+Legacy name; tracked for rename in #50. Treat it as "the diff
+report" regardless of how you produced it.
+
 A no-op re-run (same inputs both times) is guaranteed to produce
 **no** `⚠ REGRESSION` banner — use this as a sanity check when
 wiring the workflow into CI.

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -128,19 +128,25 @@ Variants: `after.html`
 #### Breakpoint-gated pairs ← fix or add @media rule
 ```
 
-**Where `Universal pairs` actually sits in the output**: near the
-**bottom** of the Markdown (after the per-viewport / per-section /
-component-bbox / shift-band / heatmap tables — typically section
-~13 of ~16). The intermediate sections describe the *effect*; the
-Universal pairs table names the *cause*. Resist top-down reading on
-first pass.
+**Where `Universal pairs` sits in the output**: **early** — the
+`Verified deltas (computed-style) × viewport` section is hoisted to
+position #2, right after `Diff by viewport`. Top-down reading
+works; the cause appears before the per-section / component-bbox /
+heatmap detail tables.
 
-**Triage order — scroll to in this order:**
+**Triage order — read in this order:**
 
-1. **Verified deltas → Universal pairs** (near bottom) — fix-the-base-rule list.
-2. **Verified deltas → Breakpoint-gated pairs** (just above #1) — missing/wrong `@media` rule.
-3. **Per-section diffRatio** — which component contains the change.
-4. **Diff by viewport** — sanity check the magnitude.
+1. **Diff by viewport** — sanity check the magnitude.
+2. **Verified deltas → Universal pairs** — fix-the-base-rule list.
+3. **Verified deltas → Breakpoint-gated pairs** (same section) — missing/wrong `@media` rule.
+4. **Per-section diffRatio** — which component contains the change.
+
+Three more `Verified deltas …` tables emit further down (DOM-position
+collapsed / DOM-position × viewport / computed-style collapsed).
+They overlap with the hoisted one in simple cases; on
+class-renaming or large breakpoint-gated diffs they each surface
+distinct signal. Read them only when the hoisted table is empty or
+ambiguous.
 
 **Glossary for the viewport table**:
 

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -68,6 +68,12 @@ skill assume one of these two forms.
 `<dir>/migration-report.json` (+ per-viewport PNGs) into it. Feed
 that JSON path — not the dir — to `vrt diff agent`.
 
+The filename is `migration-report.json` even on this non-migration
+path because the writer is shared with `vrt migration compare`. The
+name is legacy — treat it as "the diff report" regardless of whether
+you came here via `diff html` or `migration compare`. (Tracked for
+rename in #50.)
+
 ```bash
 # Local HTML pair → writes reports/migration-report.json
 vrt diff html before.html after.html --output reports/

--- a/src/vrt/compare/diff-for-agent.ts
+++ b/src/vrt/compare/diff-for-agent.ts
@@ -819,6 +819,69 @@ export function formatMigrationReportForAgent(
     }
     lines.push("");
 
+    // Hoisted to triage position (right after the viewport summary) so
+    // an agent reading top-down sees the highest-signal table first.
+    // The vrt-visual-diff skill names this as the canonical
+    // start-here triage table.
+    const csdPerVpSummary = (report.computedStyleDiffPerViewport ?? []).find((c) => c.variantFile === variantFile);
+    if (csdPerVpSummary && csdPerVpSummary.result.totalDiffs > 0) {
+      lines.push("### Verified deltas (computed-style) × viewport (catches breakpoint-gated rules)");
+      lines.push("");
+      lines.push("Each (selector, property) is captured at every snapshot viewport. " +
+        "*Universal* pairs differ on every viewport — fix the base rule. " +
+        "*Breakpoint-gated* pairs differ only on a subset — almost always a missing " +
+        "or wrong `@media` rule. Without this split, mobile-only deltas were getting " +
+        "patched into the desktop rule and vice-versa.");
+      lines.push("");
+      lines.push(`Total: **${csdPerVpSummary.result.totalDiffs}** (selector, property, viewport) tuples ` +
+        `across ${csdPerVpSummary.result.byViewport.length} viewports ` +
+        `(${csdPerVpSummary.result.universalPairs.length} universal pair(s), ` +
+        `${csdPerVpSummary.result.breakpointGatedPairs.length} breakpoint-gated pair(s)).`);
+      lines.push("");
+
+      const universalRows = csdPerVpSummary.result.bySelectorProperty.filter(
+        (e) => e.viewports.length === csdPerVpSummary.result.byViewport.length,
+      );
+      if (universalRows.length > 0) {
+        lines.push("#### Universal pairs (every viewport — fix the base rule)");
+        lines.push("");
+        lines.push("| Selector | Property | Baseline | Variant |");
+        lines.push("|---|---|---|---|");
+        for (const row of universalRows.slice(0, 15)) {
+          // All viewports agree, so pick the first sample for the displayed value.
+          const sample = row.samples[0]!;
+          lines.push(`| \`${row.selector}\` | \`${row.property}\` | \`${sample.baseline}\` | \`${sample.variant}\` |`);
+        }
+        if (universalRows.length > 15) {
+          lines.push(`| _…${universalRows.length - 15} more universal pairs_ | | | |`);
+        }
+        lines.push("");
+      }
+
+      const gatedRows = csdPerVpSummary.result.bySelectorProperty.filter(
+        (e) => e.viewports.length < csdPerVpSummary.result.byViewport.length,
+      );
+      if (gatedRows.length > 0) {
+        lines.push("#### Breakpoint-gated pairs (missing or wrong `@media` rule)");
+        lines.push("");
+        lines.push("| Selector | Property | Affected viewports | Sample (viewport: baseline → variant) |");
+        lines.push("|---|---|---|---|");
+        for (const row of gatedRows.slice(0, 15)) {
+          const vps = row.viewports.join(", ");
+          const sampleText = row.samples
+            .slice(0, 3)
+            .map((s) => `\`${s.viewport}\`: \`${s.baseline}\` → \`${s.variant}\``)
+            .join("; ");
+          const moreSamples = row.samples.length > 3 ? ` (+${row.samples.length - 3} more)` : "";
+          lines.push(`| \`${row.selector}\` | \`${row.property}\` | ${vps} | ${sampleText}${moreSamples} |`);
+        }
+        if (gatedRows.length > 15) {
+          lines.push(`| _…${gatedRows.length - 15} more breakpoint-gated pairs_ | | | |`);
+        }
+        lines.push("");
+      }
+    }
+
     const bboxSummary = (report.componentBboxDiffs ?? []).find((c) => c.variantFile === variantFile);
     const sectionHeatmapSummary = (report.heatmapRegions ?? []).find((h) => h.variantFile === variantFile);
     if (bboxSummary && sectionHeatmapSummary && bboxSummary.perViewport.length > 0) {
@@ -1361,65 +1424,6 @@ export function formatMigrationReportForAgent(
         lines.push("Top selectors:");
         for (const s of topSelectors) {
           lines.push(`- \`${s.selector}\` — ${s.count} property change(s)`);
-        }
-        lines.push("");
-      }
-    }
-
-    const csdPerVpSummary = (report.computedStyleDiffPerViewport ?? []).find((c) => c.variantFile === variantFile);
-    if (csdPerVpSummary && csdPerVpSummary.result.totalDiffs > 0) {
-      lines.push("### Verified deltas (computed-style) × viewport (catches breakpoint-gated rules)");
-      lines.push("");
-      lines.push("Each (selector, property) is captured at every snapshot viewport. " +
-        "*Universal* pairs differ on every viewport — fix the base rule. " +
-        "*Breakpoint-gated* pairs differ only on a subset — almost always a missing " +
-        "or wrong `@media` rule. Without this split, mobile-only deltas were getting " +
-        "patched into the desktop rule and vice-versa.");
-      lines.push("");
-      lines.push(`Total: **${csdPerVpSummary.result.totalDiffs}** (selector, property, viewport) tuples ` +
-        `across ${csdPerVpSummary.result.byViewport.length} viewports ` +
-        `(${csdPerVpSummary.result.universalPairs.length} universal pair(s), ` +
-        `${csdPerVpSummary.result.breakpointGatedPairs.length} breakpoint-gated pair(s)).`);
-      lines.push("");
-
-      const universalRows = csdPerVpSummary.result.bySelectorProperty.filter(
-        (e) => e.viewports.length === csdPerVpSummary.result.byViewport.length,
-      );
-      if (universalRows.length > 0) {
-        lines.push("#### Universal pairs (every viewport — fix the base rule)");
-        lines.push("");
-        lines.push("| Selector | Property | Baseline | Variant |");
-        lines.push("|---|---|---|---|");
-        for (const row of universalRows.slice(0, 15)) {
-          // All viewports agree, so pick the first sample for the displayed value.
-          const sample = row.samples[0]!;
-          lines.push(`| \`${row.selector}\` | \`${row.property}\` | \`${sample.baseline}\` | \`${sample.variant}\` |`);
-        }
-        if (universalRows.length > 15) {
-          lines.push(`| _…${universalRows.length - 15} more universal pairs_ | | | |`);
-        }
-        lines.push("");
-      }
-
-      const gatedRows = csdPerVpSummary.result.bySelectorProperty.filter(
-        (e) => e.viewports.length < csdPerVpSummary.result.byViewport.length,
-      );
-      if (gatedRows.length > 0) {
-        lines.push("#### Breakpoint-gated pairs (missing or wrong `@media` rule)");
-        lines.push("");
-        lines.push("| Selector | Property | Affected viewports | Sample (viewport: baseline → variant) |");
-        lines.push("|---|---|---|---|");
-        for (const row of gatedRows.slice(0, 15)) {
-          const vps = row.viewports.join(", ");
-          const sampleText = row.samples
-            .slice(0, 3)
-            .map((s) => `\`${s.viewport}\`: \`${s.baseline}\` → \`${s.variant}\``)
-            .join("; ");
-          const moreSamples = row.samples.length > 3 ? ` (+${row.samples.length - 3} more)` : "";
-          lines.push(`| \`${row.selector}\` | \`${row.property}\` | ${vps} | ${sampleText}${moreSamples} |`);
-        }
-        if (gatedRows.length > 15) {
-          lines.push(`| _…${gatedRows.length - 15} more breakpoint-gated pairs_ | | | |`);
         }
         lines.push("");
       }


### PR DESCRIPTION
## Summary

Two skill-validation findings from PR #47's loop landed as one branch:

### closes #49 — Hoist Universal/Breakpoint-gated to triage position

`vrt-visual-diff` names "Verified deltas → Universal pairs" as the first table to read when triaging a diff. The Markdown previously emitted that section ~13 of ~16; top-down readers had to scroll past 8 intermediate tables.

Move `### Verified deltas (computed-style) × viewport` to position #2 (right after `### Diff by viewport`). Updates the skill's "How to read the report" section to match.

### partial #50 — Document `migration-report.json` legacy filename

Subagent F noted that `--output reports/` writes `migration-report.json` even on the non-migration `vrt diff html` path, which makes the diff-html path look like the wrong skill mid-run. The writer (`migration-compare.ts:1974`) is shared between `vrt diff html` and `vrt migration compare`, so the rename touches 7+ consumer files, tests, README, and CHANGELOG.

This PR documents the legacy name at the skill layer so the friction is no longer surprising; the writer-side rename remains tracked in #50.

## Verification

```
$ node --experimental-strip-types src/cli/vrt.ts diff agent /tmp/hoist-verify/migration-report.json --no-history | grep -nE "^###|^####"
8:### Diff by viewport (worst first)
16:### Verified deltas (computed-style) × viewport (catches breakpoint-gated rules)
22:#### Universal pairs (every viewport — fix the base rule)
32:### Per-section diffRatio (heatmap × component-bbox)
…
```

L22 — Universal pairs now top-down reachable.

## Test plan

- [x] `pnpm test` → 776/776 pass (existing tests assert section content + regex matches, not position)
- [x] Manual: `vrt diff agent` on `fixtures/element-compare/` shows Universal pairs at L22

🤖 Generated with [Claude Code](https://claude.com/claude-code)