### PR TITLE
diff-report.json canonical filename + migration-report.json legacy alias (closes #50)

### DIFF
--- a/.claude/skills/vrt-migration-eval/SKILL.md
+++ b/.claude/skills/vrt-migration-eval/SKILL.md
@@ -64,11 +64,13 @@ the dist is stale — run `pnpm build` or use the source form. All
 ## Quickstart
 
 `--output <dir>` is a **directory** path; the engine writes
-`<dir>/migration-report.json` (+ per-viewport PNGs) into it. Pass
-that JSON file — not the dir — to `vrt diff agent`.
+`<dir>/diff-report.json` (+ per-viewport PNGs) into it. Pass that
+JSON file — not the dir — to `vrt diff agent`. (`migration-report.json`
+is also written as a legacy alias; both files have identical
+content.)
 
 ```bash
-# Two HTML files, side by side → writes reports/migration-report.json
+# Two HTML files, side by side → writes reports/diff-report.json
 vrt migration compare baseline.html variant.html \
   --output reports/
 
@@ -80,7 +82,7 @@ vrt migration compare \
   --output reports/
 
 # Then format for the agent
-vrt diff agent reports/migration-report.json
+vrt diff agent reports/diff-report.json
 ```
 
 ## Computed-style diff is the load-bearing signal

--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -61,15 +61,16 @@ from triggering false alarms.
 ## Quickstart
 
 `--output <dir>` is a **directory** path; `vrt diff html` writes
-`<dir>/migration-report.json` into it. Pass that JSON file path —
-not the dir — to `vrt diff agent`.
+`<dir>/diff-report.json` into it. Pass that JSON file path — not
+the dir — to `vrt diff agent`. (`migration-report.json` is also
+written as a legacy alias; both files have identical content.)
 
 A no-op re-run (same inputs both times) is guaranteed to produce
 **no** `⚠ REGRESSION` banner — use this as a sanity check when
 wiring the workflow into CI.
 
 ```bash
-REPORT=reports/migration-report.json
+REPORT=reports/diff-report.json
 
 # First run: establishes baseline. No banner possible (no prior summary).
 vrt diff html before.html after.html --output reports/
@@ -120,7 +121,7 @@ Two retention strategies:
 - name: Render current PR + diff
   run: |
     vrt diff html main.html pr.html --output reports/
-    vrt diff agent reports/migration-report.json \
+    vrt diff agent reports/diff-report.json \
       --previous .vrt/baseline.json \
       --persist-summary /tmp/pr-summary.json \
       --fail-on-regression \

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -65,20 +65,22 @@ skill assume one of these two forms.
 ## Quickstart
 
 `--output <dir>` is a **directory** path; the diff writes
-`<dir>/migration-report.json` (+ per-viewport PNGs) into it. Feed
-that JSON path — not the dir — to `vrt diff agent`.
+`<dir>/diff-report.json` (+ per-viewport PNGs) into it. Feed that
+JSON path — not the dir — to `vrt diff agent`. (`migration-report.json`
+is still written alongside as a legacy alias for callers pinning
+the old name; the two files are byte-identical.)
 
 ```bash
-# Local HTML pair → writes reports/migration-report.json
+# Local HTML pair → writes reports/diff-report.json
 vrt diff html before.html after.html --output reports/
-vrt diff agent reports/migration-report.json > reports/diff.md
+vrt diff agent reports/diff-report.json > reports/diff.md
 
 # URL pair (e.g. before/after a code change on the dev server)
 vrt diff html \
   --url http://localhost:3000/ \
   --current-url http://localhost:8080/ \
   --output reports/
-vrt diff agent reports/migration-report.json
+vrt diff agent reports/diff-report.json
 
 # Mask dynamic regions. The value is one quoted, comma-separated CSS
 # selector list — shell-quoting is required so commas don't split args.

--- a/src/experiments/migration/migration-compare.ts
+++ b/src/experiments/migration/migration-compare.ts
@@ -9,6 +9,7 @@
  *   npx tsx src/migration-compare.ts before.html after.html
  *   npx tsx src/migration-compare.ts --dir fixtures/migration/reset-css --baseline normalize.html --variants modern-normalize.html destyle.html no-reset.html
  */
+import { existsSync } from "node:fs";
 import { readFile, writeFile, mkdir, access } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -1970,8 +1971,13 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
     }
     console.log();
 
-    // Save JSON report
-    const reportPath = join(outputDir, "migration-report.json");
+    // Save JSON report. The canonical name is `diff-report.json`;
+    // `migration-report.json` is kept as a legacy alias (same content)
+    // so callers pinning the old filename continue to work. Track the
+    // rename completion under issue #50 — once no consumer references
+    // the legacy name, the second write can drop.
+    const reportPath = join(outputDir, "diff-report.json");
+    const legacyReportPath = join(outputDir, "migration-report.json");
     const report: MigrationCompareReport = {
       dir,
       baseline,
@@ -2003,7 +2009,9 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
       reportPath,
     };
     const convergence = summarizeMigrationReportConvergence(report);
-    await writeFile(reportPath, JSON.stringify(report, null, 2));
+    const reportJson = JSON.stringify(report, null, 2);
+    await writeFile(reportPath, reportJson);
+    await writeFile(legacyReportPath, reportJson);
     console.log(`  ${BOLD}Convergence${RESET}`);
     for (const variant of convergence.variants) {
       console.log(`    ${variant.variant.padEnd(18)} ${formatMigrationConvergenceSummary(variant.status, variant)}`);
@@ -2020,9 +2028,16 @@ export async function runMigrationCompare(options: MigrationCompareOptions): Pro
     if (options.againstPreviousPath) {
       try {
         const { diffWatchRuns, formatWatchDelta, summarizeReport } = await import("./watch.ts");
-        const prevPath = options.againstPreviousPath.endsWith(".json")
-          ? options.againstPreviousPath
-          : join(options.againstPreviousPath, "migration-report.json");
+        // Accept a direct .json path; otherwise try the canonical
+        // `diff-report.json` first, falling back to the legacy
+        // `migration-report.json` for previous runs from before the
+        // rename in #50.
+        let prevPath = options.againstPreviousPath;
+        if (!prevPath.endsWith(".json")) {
+          const canonical = join(options.againstPreviousPath, "diff-report.json");
+          const legacy = join(options.againstPreviousPath, "migration-report.json");
+          prevPath = existsSync(canonical) ? canonical : legacy;
+        }
         const prevRaw = await readFile(prevPath, "utf-8");
         const prevReport = JSON.parse(prevRaw) as MigrationCompareReport;
         const prev = summarizeReport(prevReport);


### PR DESCRIPTION
## Summary

`vrt diff html` and `vrt migration compare` share the same writer (`src/experiments/migration/migration-compare.ts`), so both paths previously emitted `migration-report.json` — a name that's a leak when read from the diff-html path.

Subagent F (validation v5):
> "\`--output\` writes \`migration-report.json\` even on the non-migration path … the filename still feels like a leak from \`vrt-migration-eval\`."

## Change

- Writer: emits `diff-report.json` as the canonical artifact, **plus** `migration-report.json` as a byte-identical legacy alias. Console output points at `diff-report.json`.
- `--against-previous <dir>` resolver: tries `diff-report.json` first, falls back to `migration-report.json` so existing run directories continue to load.
- Skills (`vrt-visual-diff`, `vrt-migration-eval`, `vrt-regression-watch`): Quickstarts now show `diff-report.json` as canonical and note the legacy alias inline.

## Backward compatibility

The legacy `migration-report.json` is still written every run. Every existing caller — README examples, `vrt manifest` (`manifest-cli.ts`), `vrt compare-runs`, `vrt migration fix-loop`, the flaker adapter, dogfood scripts in `luna.mbt` / `sol.mbt` — keeps working without changes.

## Out of scope (separate cleanup PR)

CLI usage strings (\`vrt diff-for-agent <migration-report.json>\`), README examples (6 refs), historical CHANGELOG / TODO entries, and per-consumer test fixtures still mention \`migration-report.json\`. They still work since the legacy alias is written every run; a sweep PR can tidy them later.

## Verification

```
$ node --experimental-strip-types src/cli/vrt.ts diff html before.html after.html --output /tmp/x/
  Report: /tmp/x/diff-report.json
$ ls /tmp/x/
diff-report.json  migration-report.json  (+ per-viewport PNGs)
$ diff /tmp/x/diff-report.json /tmp/x/migration-report.json
# (no output — identical)
```

## Test plan

- [x] `pnpm test` → 776/776 pass
- [x] Manual: dual-write produces 2 identical JSON files
- [x] `--against-previous` resolves both naming variants
- [x] All 3 skills' Quickstart Use new canonical name

🤖 Generated with [Claude Code](https://claude.com/claude-code)