### PR TITLE
Add smoke-dist script for dist/vrt.mjs subcommand surface (#48)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   "scripts": {
     "build": "tsdown",
     "prepack": "pnpm build",
+    "smoke:dist": "pnpm build && bash scripts/smoke-dist.sh",
+    "smoke:dist:strict": "pnpm build && bash scripts/smoke-dist.sh --strict",
     "test": "node --test 'src/**/*.test.ts' 'packages/*/src/**/*.test.ts' 'worker/**/*.test.ts'",
     "demo": "node src/demo/demo.ts",
     "demo:fix": "node src/demo/demo-fix-loop.ts",

--- a/scripts/smoke-dist.sh
+++ b/scripts/smoke-dist.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Smoke test for the built dist/vrt.mjs. Verifies the published bin
+# accepts every top-level subcommand the source CLI exposes.
+#
+# Wired up under issue #48: dist/vrt.mjs's dispatcher currently uses
+# `import.meta.resolve(<source-path-string>)` to route leaves, so the
+# bundled artifact can't resolve leaves once installed standalone.
+# This script catches that class of breakage — until #48's dispatcher
+# rewrite lands, expect FAIL rows here.
+#
+# Strict mode is off by default (exit 0 on failure) so the script can
+# live on main without breaking CI. Pass `--strict` to exit 1 on any
+# failure; flip the default to strict once #48 closes.
+set -u
+
+STRICT=0
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT=1 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+DIST="dist/vrt.mjs"
+if [[ ! -f "$DIST" ]]; then
+  echo "error: $DIST not found. Run 'pnpm build' first." >&2
+  exit 2
+fi
+
+PASS=()
+FAIL=()
+
+probe_help() {
+  local label="$1" expected="$2"; shift 2
+  local out
+  if out=$(node "$DIST" "$@" --help 2>&1); then
+    if echo "$out" | grep -q -F -- "$expected"; then
+      PASS+=("$label")
+      return
+    fi
+  fi
+  FAIL+=("$label  (expected: '$expected')")
+}
+
+probe_exec() {
+  local label="$1" expected="$2"; shift 2
+  local out
+  if out=$(node "$DIST" "$@" 2>&1); then
+    if echo "$out" | grep -q -F -- "$expected"; then
+      PASS+=("$label")
+      return
+    fi
+  fi
+  FAIL+=("$label  (expected: '$expected')")
+}
+
+echo "==> smoke-dist: $(node "$DIST" --version 2>&1)"
+
+# Top-level subcommand surface (matches the new vrt 0.5.0 group structure).
+probe_help "diff html"            "viewport"        diff html
+probe_help "diff agent"           "migration"       diff agent
+probe_help "diff png"             "PNG"             diff png
+probe_help "migration compare"    "viewport"        migration compare
+probe_help "snapshot"             "snapshot"        snapshot
+probe_help "build component"      "image"           build component
+probe_help "scan component"       "component"       scan component
+probe_help "check tokens"         "tokens"          check tokens
+probe_help "check theme"          "theme"           check theme
+probe_help "stress i18n"          "i18n"            stress i18n
+
+# A real (no-flag) invocation that exercises the dispatcher delegate
+# path — catches ERR_MODULE_NOT_FOUND on the bundled artifact.
+probe_exec "diff html exec" "after"  diff html fixtures/element-compare/before.html fixtures/element-compare/after.html --output /tmp/vrt-smoke-dist-exec/
+
+echo
+echo "Pass: ${#PASS[@]} / Fail: ${#FAIL[@]}"
+if (( ${#PASS[@]} > 0 )); then
+  printf '  ✓ %s\n' "${PASS[@]}"
+fi
+if (( ${#FAIL[@]} > 0 )); then
+  echo
+  printf '  ✗ %s\n' "${FAIL[@]}"
+  echo
+  echo "Failures expected until #48 (dist/vrt.mjs dispatcher rewrite) lands."
+  echo "See: https://github.com/mizchi/vrt/issues/48"
+  if (( STRICT )); then
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary

Subagent A (validation v1) was blocked because `dist/vrt.mjs` (the shipped bin) doesn't accept the new `vrt diff html` group surface that the source CLI exposes. Root cause (per the [investigation comment on #48](https://github.com/mizchi/vrt/issues/48#issuecomment-4484424379)): `src/cli/cli.ts` routes leaves via `import.meta.resolve` on relative source-path strings, so the bundled artifact can't resolve its own leaves once installed standalone.

This PR adds an **advisory smoke gate** so the breakage is visible from the moment dist regresses (or, today, stays broken).

## What this does

- New `scripts/smoke-dist.sh` runs `vrt <subcommand> --help` against `dist/vrt.mjs` for the 10 subcommands the source CLI advertises (`diff html/agent/png`, `migration compare`, `snapshot`, `build/scan component`, `check tokens/theme`, `stress i18n`). Plus one real exec probe (`diff html` on a fixture) to catch `ERR_MODULE_NOT_FOUND` end-to-end.
- Defaults to exit 0 (advisory) so the script can live on main without breaking CI. `--strict` flips to exit 1.
- Wired as `pnpm smoke:dist` / `pnpm smoke:dist:strict`.

## What this doesn't do

- It does **not** fix the dispatcher. That's the durable fix tracked in #48; once a contributor rewrites `cli.ts`'s SPECS table to use static `import("./path/to/module.js")` calls (or tsdown bundles every leaf), the smoke will pass and this script can flip default to strict.
- No CI workflow added. Run-on-PR wiring is a separate, 5-line `.github/workflows/dist-smoke.yml` PR that mizchi can drop in once the script lands.

## Current output

```
$ pnpm smoke:dist
==> smoke-dist: vrt/0.5.0 darwin-arm64 node-v24.14.1

Pass: 1 / Fail: 10
  ✓ diff png

  ✗ diff html  (expected: 'viewport')
  ✗ diff agent  (expected: 'migration')
  ✗ migration compare  (expected: 'viewport')
  ✗ snapshot  (expected: 'snapshot')
  ✗ build component  (expected: 'image')
  ✗ scan component  (expected: 'component')
  ✗ check tokens  (expected: 'tokens')
  ✗ check theme  (expected: 'theme')
  ✗ stress i18n  (expected: 'i18n')
  ✗ diff html exec  (expected: 'after')

Failures expected until #48 (dist/vrt.mjs dispatcher rewrite) lands.
```

`diff png` is the lone pass because `vrt-core/png-diff.ts` doesn't go through the dispatcher's source-path delegate path.

## Test plan

- [x] `pnpm smoke:dist` runs, prints pass/fail report, exits 0
- [x] `pnpm smoke:dist:strict` runs, exits 1 today (expected, until #48 lands)
- [x] Script aborts with helpful message when `dist/vrt.mjs` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)