### PR TITLE
fix(Taskfile): route snapshot tasks through vrt CLI entry

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -227,8 +227,8 @@ local smokeTest = new Task {
 
 local snapshot = new Task {
   name = "snapshot"
-  cmd = "node src/cli/commands/snapshot.ts"
-  inputs { "src/cli/commands/snapshot.ts"; "src/vrt/snapshot/**.ts" }
+  cmd = "node --experimental-strip-types src/cli/vrt.ts snapshot"
+  inputs { "src/cli/vrt.ts"; "src/cli/commands/snapshot.ts"; "src/vrt/snapshot/**.ts" }
 }
 
 // ---- Dogfood ----
@@ -236,7 +236,7 @@ local snapshot = new Task {
 local dogfoodLuna = new Task {
   name = "dogfood-luna"
   cmd = #"""
-    node src/cli/commands/snapshot.ts \
+    node --experimental-strip-types src/cli/vrt.ts snapshot \
       http://localhost:4200/src/examples/todomvc/ \
       http://localhost:4200/src/examples/spa/ \
       http://localhost:4200/src/examples/wc/ \
@@ -250,10 +250,9 @@ local dogfoodLuna = new Task {
 local dogfoodSol = new Task {
   name = "dogfood-sol"
   cmd = #"""
-    node src/cli/commands/snapshot.ts \
+    node --experimental-strip-types src/cli/vrt.ts snapshot \
       http://localhost:3000/ \
       http://localhost:3000/luna/ \
-      http://localhost:3000/luna/tutorial-js/islands/ \
       http://localhost:3000/sol/ \
       http://localhost:3000/benchmark/ \
       --output test-results/snapshots/sol \


### PR DESCRIPTION
## Summary

`src/cli/commands/snapshot.ts` is a library file (525 lines of types + helpers, no main entry). During the 0.5.0 CLI restructure, three `Taskfile.pkl` tasks — `snapshot`, `dogfood-luna`, `dogfood-sol` — kept invoking it directly. `node src/cli/commands/snapshot.ts` exits 0 with no output, so the tasks silently no-op'd.

This PR:

- Routes all three `cmd` blocks through the new `vrt` CLI entry (`node --experimental-strip-types src/cli/vrt.ts snapshot ...`).
- Drops the stale `http://localhost:3000/luna/tutorial-js/islands/` URL from `dogfood-sol` — sol.mbt reorganized that page into `islands_basics` / `islands_state`, so the bare path now 404s.
- Adds `src/cli/vrt.ts` to the `snapshot` task's `inputs` for cache-invalidation correctness.

Closes #54.
Closes #55.

## Test plan

- [x] `pkf list` still validates the Pkl
- [x] `vrt snapshot --help` prints usage (CLI entry reachable)
- [x] `pkf run dogfood-sol` end-to-end: 4 URLs × 2 viewports = 8 baselines, no 404s, ~8 s wall (was silent no-op)
- [ ] `pkf run dogfood-luna` (needs luna.mbt server running on :4200; not tested in this PR — the cmd change mirrors `dogfood-sol`)