### PR TITLE
docs: rename `just <task>` -> `pkf run <task>` across live docs (closes #59)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ Periodically evaluate VLM (Vision Language Model) cost-performance for analyzing
 
 1. **Check available models** (dynamically fetched from OpenRouter API):
 ```bash
-just vlm-bench --list --max-cost 0.001 --limit 30
+pkf run vlm-bench -- --list --max-cost 0.001 --limit 30
 ```
 
 2. **Run fix-loop with candidate models** (hard case: seed 11):
@@ -20,7 +20,7 @@ VRT_VLM_MODEL="<model-id>" node --experimental-strip-types src/experiments/css-c
 
 3. **Measure VLM quality** (token count, latency, CHANGE detection count):
 ```bash
-just vlm-bench <model1> <model2> <model3> --md
+pkf run vlm-bench -- <model1> <model2> <model3> --md
 ```
 
 4. **Update results in the "VLM Model Comparison" section of `docs/knowledge.md`**
@@ -63,22 +63,22 @@ NO_IMAGES=1 node --experimental-strip-types src/experiments/css-challenge/css-ch
 cd ~/ghq/github.com/mizchi/crater && just build-bidi && just start-bidi-with-font
 
 # Run bench
-just css-bench-crater --fixture page --trials 30
+pkf run css-bench-crater -- --fixture page --trials 30
 ```
 
 ### Tracking Detection Rate
 ```bash
-just css-report  # Aggregate accumulated data
+pkf run css-report  # Aggregate accumulated data
 ```
 
 ## Running Migration VRT
 
 ```bash
 # Tailwind → vanilla CSS
-just migration-tailwind
+pkf run migration-tailwind
 
 # Reset CSS comparison
-just migration-reset
+pkf run migration-reset
 
 # File comparison
 vrt compare before.html after.html
@@ -107,23 +107,23 @@ vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
 pkf run dogfood-luna
 
 # sol.mbt (requires: npx serve ~/ghq/.../sol.mbt/website/dist-docs -p 3000)
-just dogfood-sol
+pkf run dogfood-sol
 
 # False positive test (compare same URL twice)
-just false-positive http://localhost:3000/luna/
+pkf run false-positive --url http://localhost:3000/luna/
 ```
 
 ## Running Fix Loop
 
 ```bash
 # Property mode (delete 1 CSS property)
-just fix-loop --fixture page --seed 42
+pkf run fix-loop -- --fixture page --seed 42
 
 # Selector mode (delete 1 selector block)
-just fix-loop --fixture page --seed 11 --mode selector --max-rounds 3
+pkf run fix-loop -- --fixture page --seed 11 --mode selector --max-rounds 3
 
 # Specify a VLM model
-VRT_VLM_MODEL="bytedance/ui-tars-1.5-7b" just fix-loop --fixture page --seed 11 --mode selector
+VRT_VLM_MODEL="bytedance/ui-tars-1.5-7b" pkf run fix-loop -- --fixture page --seed 11 --mode selector
 ```
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -93,17 +93,17 @@ vrt workflow init --config ./vrt.config.json
 vrt workflow capture --config ./vrt.config.json
 
 # Prepare a migration diff packet for an external fixer
-just migration-subagent-prepare --report test-results/migration/migration-report.json --output test-results/migration/subagent-task.md
+pkf run migration-subagent-prepare -- --report test-results/migration/migration-report.json --output test-results/migration/subagent-task.md
 
 # Measure success rate from before/after migration reports
-just migration-subagent-evaluate --before-report test-results/migration/migration-report.json --after-report test-results/migration/migration-report.after.json
+pkf run migration-subagent-evaluate -- --before-report test-results/migration/migration-report.json --after-report test-results/migration/migration-report.after.json
 
 # Inspect blind migration scenarios
-just migration-blind-list
-just migration-blind-show shadcn-to-luna
-just migration-blind-prepare shadcn-to-luna --packet test-results/migration/blind/shadcn-to-luna/task.md
-just migration-blind-solo shadcn-to-luna --output test-results/migration/blind/shadcn-to-luna/solo/after-blind.html --report-output-dir test-results/migration/blind/shadcn-to-luna/solo-report
-just migration-blind-evaluate shadcn-to-luna --before-report test-results/migration/blind/shadcn-to-luna/migration-report.json --after-report test-results/migration/blind/shadcn-to-luna/solo-report/migration-report.json --rounds 1
+pkf run migration-blind-list
+pkf run migration-blind-show --scenario shadcn-to-luna
+pkf run migration-blind-prepare --scenario shadcn-to-luna -- --packet test-results/migration/blind/shadcn-to-luna/task.md
+pkf run migration-blind-solo --scenario shadcn-to-luna -- --output test-results/migration/blind/shadcn-to-luna/solo/after-blind.html --report-output-dir test-results/migration/blind/shadcn-to-luna/solo-report
+pkf run migration-blind-evaluate --scenario shadcn-to-luna -- --before-report test-results/migration/blind/shadcn-to-luna/migration-report.json --after-report test-results/migration/blind/shadcn-to-luna/solo-report/migration-report.json --rounds 1
 
 # Mask dynamic content
 vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -54,11 +54,13 @@ local vrtDemoMultistep = new Task {
 
 local cssBench = new Task {
   name = "css-bench"
+  acceptsArgs = true
   cmd = "NO_IMAGES=1 node src/experiments/css-challenge/css-challenge-bench.ts"
   inputs { "src/experiments/css-challenge/css-challenge*.ts"; "fixtures/css-challenge/**" }
 }
 local cssBenchSelector = new Task {
   name = "css-bench-selector"
+  acceptsArgs = true
   cmd = "NO_IMAGES=1 node src/experiments/css-challenge/css-challenge-bench.ts --mode selector"
   inputs { "src/experiments/css-challenge/css-challenge*.ts"; "fixtures/css-challenge/**" }
 }
@@ -72,11 +74,13 @@ local cssBenchAll = new Task {
 }
 local cssBenchCrater = new Task {
   name = "css-bench-crater"
+  acceptsArgs = true
   cmd = "NO_IMAGES=1 node src/experiments/css-challenge/css-challenge-bench.ts --backend crater"
   inputs { "src/experiments/css-challenge/css-challenge*.ts"; "fixtures/css-challenge/**" }
 }
 local cssBenchPrescanner = new Task {
   name = "css-bench-prescanner"
+  acceptsArgs = true
   cmd = "NO_IMAGES=1 node src/experiments/css-challenge/css-challenge-bench.ts --backend prescanner"
   inputs { "src/experiments/css-challenge/css-challenge*.ts"; "fixtures/css-challenge/**" }
 }
@@ -139,12 +143,14 @@ local migrationShadcn = new Task {
 
 local migrationSubagentPrepare = new Task {
   name = "migration-subagent-prepare"
+  acceptsArgs = true
   cmd = "node src/experiments/migration/migration-subagent.ts prepare"
   inputs { "src/experiments/migration/migration-subagent.ts"; "src/experiments/migration/migration-fix-loop-core.ts" }
 }
 
 local migrationSubagentEvaluate = new Task {
   name = "migration-subagent-evaluate"
+  acceptsArgs = true
   cmd = "node src/experiments/migration/migration-subagent.ts evaluate"
   inputs { "src/experiments/migration/migration-subagent.ts" }
 }
@@ -166,6 +172,7 @@ local migrationBlindShow = new Task {
 
 local migrationBlindPrepare = new Task {
   name = "migration-blind-prepare"
+  acceptsArgs = true
   params {
     new { name = "scenario"; type = "string" }
   }
@@ -175,6 +182,7 @@ local migrationBlindPrepare = new Task {
 
 local migrationBlindSolo = new Task {
   name = "migration-blind-solo"
+  acceptsArgs = true
   params {
     new { name = "scenario"; type = "string" }
   }
@@ -184,6 +192,7 @@ local migrationBlindSolo = new Task {
 
 local migrationBlindEvaluate = new Task {
   name = "migration-blind-evaluate"
+  acceptsArgs = true
   params {
     new { name = "scenario"; type = "string" }
   }
@@ -201,12 +210,14 @@ local flakerVrtAdapt = new Task {
 
 local fixLoop = new Task {
   name = "fix-loop"
+  acceptsArgs = true
   cmd = "node src/experiments/css-challenge/fix-loop.ts"
   inputs { "src/experiments/css-challenge/fix-loop.ts"; "packages/vrt-ai/src/vlm-client.ts"; "packages/vrt-ai/src/llm-client.ts" }
 }
 
 local vlmBench = new Task {
   name = "vlm-bench"
+  acceptsArgs = true
   cmd = "node src/experiments/benchmark/vlm-bench.ts"
   inputs { "src/experiments/benchmark/vlm-bench.ts" }
 }

--- a/docs/introduce.ja.md
+++ b/docs/introduce.ja.md
@@ -121,16 +121,16 @@ CSS プロパティやセレクタブロックを1つ削除し、各検出手法
 
 ```bash
 # プロパティ削除モード
-just css-bench --fixture page --trials 30
+pkf run css-bench -- --fixture page --trials 30
 
 # セレクタブロック削除モード
-just css-bench --fixture page --mode selector --trials 30
+pkf run css-bench -- --fixture page --mode selector --trials 30
 
 # 全フィクスチャ横断
-just css-bench --fixture all --trials 10
+pkf run css-bench -- --fixture all --trials 10
 
 # 検出率レポート
-just css-report
+pkf run css-report
 ```
 
 現在の検出率: Chromium 96.7% (scoped)
@@ -141,10 +141,10 @@ CSS の破壊を検出し、AI が修正を生成して検証するループで�
 
 ```bash
 # Fix ループ（CSS 破壊 → VLM 分析 → LLM 修正 → 検証）
-just fix-loop --fixture page --seed 42
+pkf run fix-loop -- --fixture page --seed 42
 
 # セレクタモード + VLM 指定
-VRT_VLM_MODEL="meta-llama/llama-4-scout" just fix-loop --fixture page --seed 11 --mode selector
+VRT_VLM_MODEL="meta-llama/llama-4-scout" pkf run fix-loop -- --fixture page --seed 11 --mode selector
 ```
 
 2段階パイプライン:
@@ -186,7 +186,7 @@ TypeScript クライアント SDK (`src/api/client.ts`) も用意しています
 cd ~/ghq/github.com/mizchi/crater && just build-bidi && just start-bidi-with-font
 
 # Crater プリスキャナ付きベンチマーク
-just css-bench-crater --fixture page --trials 30
+pkf run css-bench-crater -- --fixture page --trials 30
 ```
 
 ## 環境変数

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -35,10 +35,10 @@ vrt snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapsh
 vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
 
 # CSS チャレンジベンチマーク
-just css-bench --fixture page --trials 30
+pkf run css-bench -- --fixture page --trials 30
 
 # Fix ループ (CSS 破壊 → VLM 分析 → LLM 修正 → 検証)
-just fix-loop --fixture page --seed 42
+pkf run fix-loop -- --fixture page --seed 42
 ```
 
 ## CLI

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -634,7 +634,7 @@ By fixture:
 
 ## VLM Model Comparison (2026-05-18 — current)
 
-### Single-call latency / output bench (`just vlm-bench`, generated heatmap 1.7% diff, n=1)
+### Single-call latency / output bench (`pkf run vlm-bench`, generated heatmap 1.7% diff, n=1)
 
 | Model | Latency | Tokens | Output | Notes |
 |-------|--------:|-------:|-------:|-------|


### PR DESCRIPTION
## Summary

Fixes #59. The repo migrated to pkfire (Taskfile.pkl) but five live-doc files still told agents to run `just <task>` — and there's no `justfile` in the tree, so every snippet failed outright on a fresh machine.

## Changes

### `Taskfile.pkl`

Added `acceptsArgs = true` to the 9 tasks whose docs show positional flags:

```
vlm-bench, css-bench, css-bench-selector, css-bench-crater, css-bench-prescanner,
fix-loop, migration-subagent-prepare, migration-subagent-evaluate,
migration-blind-prepare, migration-blind-solo, migration-blind-evaluate
```

`pkf list` now surfaces them as `*ARGS` so it's obvious they take trailing flags.

### Docs (5 files, ~28 snippets)

- `.claude/CLAUDE.md`, `README.md`, `docs/introduce.ja.md`, `docs/ja/README.md`, `docs/knowledge.md`
- Translation rules:
  - bare task: `pkf run <task>`
  - task + flags: `pkf run <task> -- <flags>` (uses acceptsArgs)
  - task + named param: `pkf run <task> --<param> <value>` (e.g. `false-positive`, `migration-blind-*`)
  - param + flags: `pkf run <task> --<param> <value> -- <flags>`

### Out of scope (intentionally untouched)

- `docs/reports/2026-*.md` — historical artifacts; they describe past runs.
- `.claude/CLAUDE.md` L63 (`cd ~/.../crater && just build-bidi …`) — invokes the *crater* repo's own justfile, not vrt's.

## Test plan

Empirically verified each new pattern:

- [x] `pkf run vlm-bench -- --list` — args pass through, 70ms wall
- [x] `pkf run css-bench -- --fixture page` — runs the bench end-to-end (1m9s)
- [x] `pkf run migration-blind-show --scenario shadcn-to-luna` — param resolves correctly
- [x] `pkf run migration-blind-prepare --scenario shadcn-to-luna -- --dry-run` — combined params + acceptsArgs work in one invocation
- [x] `grep -rE "^just |^[A-Z_]+=.*just " .claude/CLAUDE.md README.md docs/introduce.ja.md docs/ja/README.md docs/knowledge.md` returns no scope-relevant hits