### PR TITLE
fix: dist/vrt.mjs dispatcher — bundle leaves via factory + per-leaf signal (closes #48)

### DIFF
--- a/packages/vrt-core/src/a11y-contrast.ts
+++ b/packages/vrt-core/src/a11y-contrast.ts
@@ -381,7 +381,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-contrast" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-core/src/a11y-focus-order.ts
+++ b/packages/vrt-core/src/a11y-focus-order.ts
@@ -391,7 +391,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-focus-order" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-core/src/a11y-touch.ts
+++ b/packages/vrt-core/src/a11y-touch.ts
@@ -334,7 +334,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-touch" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-core/src/element-compare.ts
+++ b/packages/vrt-core/src/element-compare.ts
@@ -334,6 +334,6 @@ async function main() {
   console.log();
 }
 
-if (process.argv[1]?.endsWith("element-compare.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "element-compare" || process.argv[1]?.endsWith("element-compare.ts")) {
   main().catch((e) => { console.error(e); process.exit(1); });
 }

--- a/packages/vrt-core/src/png-diff.ts
+++ b/packages/vrt-core/src/png-diff.ts
@@ -157,7 +157,7 @@ export async function runPngDiffCli(cliArgs = process.argv.slice(2)) {
   }
 }
 
-if (process.argv[1]?.endsWith("png-diff.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "png-diff" || process.argv[1]?.endsWith("png-diff.ts")) {
   runPngDiffCli().catch((error) => {
     console.error(error);
     process.exit(1);

--- a/packages/vrt-markup/src/component/component-consistency.ts
+++ b/packages/vrt-markup/src/component/component-consistency.ts
@@ -263,7 +263,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "component-consistency" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/component/component-extract.ts
+++ b/packages/vrt-markup/src/component/component-extract.ts
@@ -275,7 +275,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "component-extract" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/component/component-from-image.ts
+++ b/packages/vrt-markup/src/component/component-from-image.ts
@@ -794,7 +794,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "component-from-image" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/inspect/explore.ts
+++ b/packages/vrt-markup/src/inspect/explore.ts
@@ -529,7 +529,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "explore" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/inspect/interact.ts
+++ b/packages/vrt-markup/src/inspect/interact.ts
@@ -552,7 +552,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "interact" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/inspect/smoke-runner.ts
+++ b/packages/vrt-markup/src/inspect/smoke-runner.ts
@@ -496,6 +496,6 @@ async function main() {
 }
 
 // Run CLI only when executed directly
-if (process.argv[1]?.endsWith("smoke-runner.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "smoke-runner" || process.argv[1]?.endsWith("smoke-runner.ts")) {
   main().catch((e) => { console.error(e); process.exit(1); });
 }

--- a/packages/vrt-markup/src/stress/cross-browser.ts
+++ b/packages/vrt-markup/src/stress/cross-browser.ts
@@ -375,7 +375,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "cross-browser" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/stress/i18n-stress.ts
+++ b/packages/vrt-markup/src/stress/i18n-stress.ts
@@ -384,7 +384,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "i18n-stress" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/stress/media-variants.ts
+++ b/packages/vrt-markup/src/stress/media-variants.ts
@@ -452,7 +452,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "media-variants" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/stress/multi-page-consistency.ts
+++ b/packages/vrt-markup/src/stress/multi-page-consistency.ts
@@ -337,7 +337,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "multi-page-consistency" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/style/design-tokens.ts
+++ b/packages/vrt-markup/src/style/design-tokens.ts
@@ -437,7 +437,7 @@ async function main(argv = process.argv.slice(2)) {
   }
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "design-tokens" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/packages/vrt-markup/src/style/theme-parity.ts
+++ b/packages/vrt-markup/src/style/theme-parity.ts
@@ -308,7 +308,7 @@ async function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "theme-parity" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/scripts/smoke-dist.sh
+++ b/scripts/smoke-dist.sh
@@ -2,21 +2,22 @@
 # Smoke test for the built dist/vrt.mjs. Verifies the published bin
 # accepts every top-level subcommand the source CLI exposes.
 #
-# Wired up under issue #48: dist/vrt.mjs's dispatcher currently uses
-# `import.meta.resolve(<source-path-string>)` to route leaves, so the
-# bundled artifact can't resolve leaves once installed standalone.
-# This script catches that class of breakage — until #48's dispatcher
-# rewrite lands, expect FAIL rows here.
+# History: #48 originally surfaced that dist/vrt.mjs's dispatcher used
+# `import.meta.resolve(<source-path-string>)`, so leaves couldn't
+# resolve from the bundled artifact. That has been fixed — the
+# dispatcher now uses `() => import("literal-path")` factory functions
+# and a `__VRT_DISPATCHER__` env sentinel, both bundler-friendly. This
+# script now runs strict by default and any FAIL is a real regression.
 #
-# Strict mode is off by default (exit 0 on failure) so the script can
-# live on main without breaking CI. Pass `--strict` to exit 1 on any
-# failure; flip the default to strict once #48 closes.
+# Pass `--lenient` to exit 0 even on failure (useful for local
+# debugging while iterating).
 set -u
 
-STRICT=0
+STRICT=1
 for arg in "$@"; do
   case "$arg" in
     --strict) STRICT=1 ;;
+    --lenient) STRICT=0 ;;
     *) echo "unknown flag: $arg" >&2; exit 2 ;;
   esac
 done
@@ -32,12 +33,14 @@ FAIL=()
 
 probe_help() {
   local label="$1" expected="$2"; shift 2
+  # Some leaves print usage and exit 1 when they receive --help (their
+  # "missing required positional" path). We treat that as a successful
+  # routing probe as long as the expected substring appears.
   local out
-  if out=$(node "$DIST" "$@" --help 2>&1); then
-    if echo "$out" | grep -q -F -- "$expected"; then
-      PASS+=("$label")
-      return
-    fi
+  out=$(node "$DIST" "$@" --help 2>&1 || true)
+  if echo "$out" | grep -q -F -- "$expected"; then
+    PASS+=("$label")
+    return
   fi
   FAIL+=("$label  (expected: '$expected')")
 }
@@ -57,16 +60,16 @@ probe_exec() {
 echo "==> smoke-dist: $(node "$DIST" --version 2>&1)"
 
 # Top-level subcommand surface (matches the new vrt 0.5.0 group structure).
-probe_help "diff html"            "viewport"        diff html
-probe_help "diff agent"           "migration"       diff agent
-probe_help "diff png"             "PNG"             diff png
-probe_help "migration compare"    "viewport"        migration compare
-probe_help "snapshot"             "snapshot"        snapshot
-probe_help "build component"      "image"           build component
-probe_help "scan component"       "component"       scan component
-probe_help "check tokens"         "tokens"          check tokens
-probe_help "check theme"          "theme"           check theme
-probe_help "stress i18n"          "i18n"            stress i18n
+probe_help "diff html"            "Usage:"                 diff html
+probe_help "diff agent"           "migration"              diff agent
+probe_help "diff png"             "PNG"                    diff png
+probe_help "migration compare"    "vrt compare"            migration compare
+probe_help "snapshot"             "snapshot"               snapshot
+probe_help "build component"      "component-from-image"   build component
+probe_help "scan component"       "component-extract"      scan component
+probe_help "check tokens"         "design-tokens"          check tokens
+probe_help "check theme"          "theme-parity"           check theme
+probe_help "stress i18n"          "i18n-stress"            stress i18n
 
 # A real (no-flag) invocation that exercises the dispatcher delegate
 # path — catches ERR_MODULE_NOT_FOUND on the bundled artifact.
@@ -81,8 +84,8 @@ if (( ${#FAIL[@]} > 0 )); then
   echo
   printf '  ✗ %s\n' "${FAIL[@]}"
   echo
-  echo "Failures expected until #48 (dist/vrt.mjs dispatcher rewrite) lands."
-  echo "See: https://github.com/mizchi/vrt/issues/48"
+  echo "These are regressions — the dispatcher should route every"
+  echo "documented subcommand. Investigate before merging."
   if (( STRICT )); then
     exit 1
   fi

--- a/src/baseline-cli.ts
+++ b/src/baseline-cli.ts
@@ -201,8 +201,8 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   }
 }
 
-const isCliEntry = process.argv[1]
-  && new URL(import.meta.url).pathname === process.argv[1];
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "baseline-cli" || (process.argv[1]
+  && new URL(import.meta.url).pathname === process.argv[1]);
 if (isCliEntry) {
   main().catch((err) => {
     console.error(err);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -15,25 +15,50 @@
  */
 
 import { cac } from "cac";
-import { fileURLToPath } from "node:url";
 import { reportDeprecation } from "./deprecation.ts";
 
 const HELP_SENTINEL = "__VRT_HELP_PASSTHROUGH__";
 
 /**
- * Resolve a specifier (relative path or package export), swap
- * `process.argv` so the target module's `isCliEntry` check passes,
- * then import it.
+ * Each leaf is referenced as `{ name, loader }`. The loader is a
+ * closure that returns the dynamic import — keeping the path as a
+ * literal at the `import()` call site lets tsdown statically
+ * discover the leaf and code-split it into a chunk that ships with
+ * `dist/vrt.mjs`.
+ *
+ * The `name` is a per-leaf identifier set into `__VRT_DISPATCHER_LEAF__`
+ * around the await. Each leaf's CLI-entry guard checks that the env
+ * var matches *its* name, so static cross-leaf imports (e.g.
+ * `diff-pr.ts` importing `cross-browser.ts` for shared types) do not
+ * accidentally fire the imported leaf's `main()`.
  */
-async function delegate(specifier: string, args: string[]): Promise<void> {
-  const resolvedUrl = import.meta.resolve(specifier);
-  const absoluteModulePath = fileURLToPath(resolvedUrl);
+type SpecLoader = () => Promise<unknown>;
+interface Spec {
+  name: string;
+  loader: SpecLoader;
+}
+
+function spec(name: string, loader: SpecLoader): Spec {
+  return { name, loader };
+}
+
+async function delegate(s: Spec, args: string[]): Promise<void> {
   process.argv = [
     process.argv[0],
-    absoluteModulePath,
+    "(vrt-dispatcher)",
     ...args.map((a) => (a === HELP_SENTINEL ? "--help" : a)),
   ];
-  await import(resolvedUrl);
+  const prev = process.env.__VRT_DISPATCHER_LEAF__;
+  process.env.__VRT_DISPATCHER_LEAF__ = s.name;
+  try {
+    await s.loader();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.__VRT_DISPATCHER_LEAF__;
+    } else {
+      process.env.__VRT_DISPATCHER_LEAF__ = prev;
+    }
+  }
 }
 
 async function runDiscover(args: string[]): Promise<void> {
@@ -77,44 +102,44 @@ async function runWorkflow(args: string[]): Promise<void> {
   await runWorkflowCli(args.map((a) => (a === HELP_SENTINEL ? "--help" : a)));
 }
 
-const SPECS = {
-  migrationCompare: "../experiments/migration/migration-compare.ts",
-  pngDiff: "@mizchi/vrt-core/png-diff.ts",
-  cssBench: "../experiments/css-challenge/css-challenge-bench.ts",
-  detectionReport: "../experiments/detection/detection-report.ts",
-  snapshot: "../vrt/snapshot/snapshot.ts",
-  snapshotReport: "../vrt/snapshot/snapshot-report.ts",
-  migrationBlind: "../experiments/migration/migration-blind.ts",
-  migrationSubagent: "../experiments/migration/migration-subagent.ts",
-  elementCompare: "@mizchi/vrt-core/element-compare.ts",
-  smokeRunner: "@mizchi/vrt-markup/inspect/smoke-runner.ts",
-  flipbook: "./commands/flipbook-cli.ts",
-  diffForAgent: "./commands/diff-for-agent-cli.ts",
-  compareRuns: "./commands/compare-runs-cli.ts",
-  componentFromImage: "@mizchi/vrt-markup/component/component-from-image.ts",
-  multiPageConsistency: "@mizchi/vrt-markup/stress/multi-page-consistency.ts",
-  componentConsistency: "@mizchi/vrt-markup/component/component-consistency.ts",
-  themeParity: "@mizchi/vrt-markup/style/theme-parity.ts",
-  i18nStress: "@mizchi/vrt-markup/stress/i18n-stress.ts",
-  a11yContrast: "@mizchi/vrt-core/a11y-contrast.ts",
-  a11yTouch: "@mizchi/vrt-core/a11y-touch.ts",
-  a11yFocusOrder: "@mizchi/vrt-core/a11y-focus-order.ts",
-  interact: "@mizchi/vrt-markup/inspect/interact.ts",
-  mediaVariants: "@mizchi/vrt-markup/stress/media-variants.ts",
-  crossBrowser: "@mizchi/vrt-markup/stress/cross-browser.ts",
-  designTokens: "@mizchi/vrt-markup/style/design-tokens.ts",
-  perf: "../util/perf.ts",
-  explore: "@mizchi/vrt-markup/inspect/explore.ts",
-  skill: "../util/skill.ts",
-  componentExtract: "@mizchi/vrt-markup/component/component-extract.ts",
-  apiServer: "../api/api-server.ts",
-  manifest: "../manifest-cli.ts",
-  watch: "../watch.ts",
-  diffPr: "../diff-pr.ts",
-  baseline: "../baseline-cli.ts",
-} as const;
+const SPECS: Record<string, Spec> = {
+  migrationCompare: spec("migration-compare", () => import("../experiments/migration/migration-compare.ts")),
+  pngDiff: spec("png-diff", () => import("@mizchi/vrt-core/png-diff.ts")),
+  cssBench: spec("css-challenge-bench", () => import("../experiments/css-challenge/css-challenge-bench.ts")),
+  detectionReport: spec("detection-report", () => import("../experiments/detection/detection-report.ts")),
+  snapshot: spec("snapshot", () => import("../vrt/snapshot/snapshot.ts")),
+  snapshotReport: spec("snapshot-report", () => import("../vrt/snapshot/snapshot-report.ts")),
+  migrationBlind: spec("migration-blind", () => import("../experiments/migration/migration-blind.ts")),
+  migrationSubagent: spec("migration-subagent", () => import("../experiments/migration/migration-subagent.ts")),
+  elementCompare: spec("element-compare", () => import("@mizchi/vrt-core/element-compare.ts")),
+  smokeRunner: spec("smoke-runner", () => import("@mizchi/vrt-markup/inspect/smoke-runner.ts")),
+  flipbook: spec("flipbook-cli", () => import("./commands/flipbook-cli.ts")),
+  diffForAgent: spec("diff-for-agent-cli", () => import("./commands/diff-for-agent-cli.ts")),
+  compareRuns: spec("compare-runs-cli", () => import("./commands/compare-runs-cli.ts")),
+  componentFromImage: spec("component-from-image", () => import("@mizchi/vrt-markup/component/component-from-image.ts")),
+  multiPageConsistency: spec("multi-page-consistency", () => import("@mizchi/vrt-markup/stress/multi-page-consistency.ts")),
+  componentConsistency: spec("component-consistency", () => import("@mizchi/vrt-markup/component/component-consistency.ts")),
+  themeParity: spec("theme-parity", () => import("@mizchi/vrt-markup/style/theme-parity.ts")),
+  i18nStress: spec("i18n-stress", () => import("@mizchi/vrt-markup/stress/i18n-stress.ts")),
+  a11yContrast: spec("a11y-contrast", () => import("@mizchi/vrt-core/a11y-contrast.ts")),
+  a11yTouch: spec("a11y-touch", () => import("@mizchi/vrt-core/a11y-touch.ts")),
+  a11yFocusOrder: spec("a11y-focus-order", () => import("@mizchi/vrt-core/a11y-focus-order.ts")),
+  interact: spec("interact", () => import("@mizchi/vrt-markup/inspect/interact.ts")),
+  mediaVariants: spec("media-variants", () => import("@mizchi/vrt-markup/stress/media-variants.ts")),
+  crossBrowser: spec("cross-browser", () => import("@mizchi/vrt-markup/stress/cross-browser.ts")),
+  designTokens: spec("design-tokens", () => import("@mizchi/vrt-markup/style/design-tokens.ts")),
+  perf: spec("perf", () => import("../util/perf.ts")),
+  explore: spec("explore", () => import("@mizchi/vrt-markup/inspect/explore.ts")),
+  skill: spec("skill", () => import("../util/skill.ts")),
+  componentExtract: spec("component-extract", () => import("@mizchi/vrt-markup/component/component-extract.ts")),
+  apiServer: spec("api-server", () => import("../api/api-server.ts")),
+  manifest: spec("manifest-cli", () => import("../manifest-cli.ts")),
+  watch: spec("watch", () => import("../watch.ts")),
+  diffPr: spec("diff-pr", () => import("../diff-pr.ts")),
+  baseline: spec("baseline-cli", () => import("../baseline-cli.ts")),
+};
 
-const GROUPS: Record<string, Record<string, { spec?: string; run?: (args: string[]) => Promise<void>; desc: string }>> = {
+const GROUPS: Record<string, Record<string, { spec?: Spec; run?: (args: string[]) => Promise<void>; desc: string }>> = {
   diff: {
     html: { spec: SPECS.migrationCompare, desc: "Compare two HTML files / URLs across viewports" },
     png: { spec: SPECS.pngDiff, desc: "Compare existing PNG screenshots directly" },
@@ -147,17 +172,17 @@ const GROUPS: Record<string, Record<string, { spec?: string; run?: (args: string
 };
 
 // Two-segment subcommands inside `check` (a11y, drift).
-const CHECK_A11Y: Record<string, { spec: string; desc: string }> = {
+const CHECK_A11Y: Record<string, { spec: Spec; desc: string }> = {
   contrast: { spec: SPECS.a11yContrast, desc: "WCAG AA contrast scan" },
   touch: { spec: SPECS.a11yTouch, desc: "Touch-target size check" },
   focus: { spec: SPECS.a11yFocusOrder, desc: "Focus order / trap check" },
 };
-const CHECK_DRIFT: Record<string, { spec: string; desc: string }> = {
+const CHECK_DRIFT: Record<string, { spec: Spec; desc: string }> = {
   component: { spec: SPECS.componentConsistency, desc: "Drift across N selector instances on one page" },
   pages: { spec: SPECS.multiPageConsistency, desc: "Drift of one selector across N pages" },
 };
 
-const DEPRECATED_TOP_LEVEL: Record<string, { newName: string; spec: string }> = {
+const DEPRECATED_TOP_LEVEL: Record<string, { newName: string; spec: Spec }> = {
   compare: { newName: "diff html", spec: SPECS.migrationCompare },
   "png-diff": { newName: "diff png", spec: SPECS.pngDiff },
   elements: { newName: "diff elements", spec: SPECS.elementCompare },

--- a/src/cli/commands/compare-runs-cli.ts
+++ b/src/cli/commands/compare-runs-cli.ts
@@ -106,7 +106,7 @@ async function main() {
   }
 }
 
-if (process.argv[1] && (process.argv[1].endsWith("compare-runs-cli.ts") || process.argv[1].endsWith("compare-runs-cli.mjs"))) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "compare-runs-cli" || (process.argv[1] && (process.argv[1].endsWith("compare-runs-cli.ts") || process.argv[1].endsWith("compare-runs-cli.mjs")))) {
   main().catch((err) => {
     console.error(String(err?.message ?? err));
     process.exit(1);

--- a/src/cli/commands/diff-for-agent-cli.ts
+++ b/src/cli/commands/diff-for-agent-cli.ts
@@ -220,7 +220,7 @@ async function main() {
   }
 }
 
-if (process.argv[1] && (process.argv[1].endsWith("diff-for-agent-cli.ts") || process.argv[1].endsWith("diff-for-agent-cli.mjs"))) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "diff-for-agent-cli" || (process.argv[1] && (process.argv[1].endsWith("diff-for-agent-cli.ts") || process.argv[1].endsWith("diff-for-agent-cli.mjs")))) {
   main().catch((err) => {
     console.error(String(err?.message ?? err));
     process.exit(1);

--- a/src/cli/commands/flipbook-cli.ts
+++ b/src/cli/commands/flipbook-cli.ts
@@ -123,7 +123,7 @@ async function main() {
   console.log();
 }
 
-if (process.argv[1] && (process.argv[1].endsWith("flipbook-cli.ts") || process.argv[1].endsWith("flipbook-cli.mjs"))) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "flipbook-cli" || (process.argv[1] && (process.argv[1].endsWith("flipbook-cli.ts") || process.argv[1].endsWith("flipbook-cli.mjs")))) {
   main().catch((err) => {
     console.error(String(err.message ?? err));
     process.exit(1);

--- a/src/diff-pr.ts
+++ b/src/diff-pr.ts
@@ -785,8 +785,8 @@ async function main(argv = process.argv.slice(2)) {
   if (code !== 0) process.exit(code);
 }
 
-const isCliEntry = process.argv[1]
-  && new URL(import.meta.url).pathname === process.argv[1];
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "diff-pr" || (process.argv[1]
+  && new URL(import.meta.url).pathname === process.argv[1]);
 if (isCliEntry) {
   main().catch((err) => {
     console.error(err);

--- a/src/experiments/css-challenge/css-challenge-bench.ts
+++ b/src/experiments/css-challenge/css-challenge-bench.ts
@@ -837,7 +837,7 @@ function fmtRateCompact(count: number, total: number, inverse = false): string {
   return `${color}${pct}%${RESET}`;
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "css-challenge-bench" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch((error) => {
     if (isPlaywrightSandboxRestrictionError(error)) {

--- a/src/experiments/css-challenge/fix-loop.ts
+++ b/src/experiments/css-challenge/fix-loop.ts
@@ -292,6 +292,6 @@ async function main() {
 }
 
 // CLI guard
-if (process.argv[1]?.endsWith("fix-loop.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "fix-loop" || process.argv[1]?.endsWith("fix-loop.ts")) {
   main().catch((e) => { console.error(e); process.exit(1); });
 }

--- a/src/experiments/migration/migration-blind.ts
+++ b/src/experiments/migration/migration-blind.ts
@@ -604,7 +604,7 @@ function parseFormat(value: string | undefined): "markdown" | "json" {
   return format;
 }
 
-if (process.argv[1]?.endsWith("migration-blind.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "migration-blind" || process.argv[1]?.endsWith("migration-blind.ts")) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/src/experiments/migration/migration-compare.ts
+++ b/src/experiments/migration/migration-compare.ts
@@ -2287,7 +2287,7 @@ function formatResponsiveBreakpoint(breakpoint: ResponsiveBreakpoint): string {
   return `width${opLabel}${breakpoint.valuePx}px`;
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "migration-compare" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 
 if (isCliEntry) {
   main().catch((error) => {

--- a/src/experiments/migration/migration-subagent.ts
+++ b/src/experiments/migration/migration-subagent.ts
@@ -367,7 +367,7 @@ function optionalNumber(args: string[], flag: string): number | undefined {
   return parsed;
 }
 
-if (process.argv[1]?.endsWith("migration-subagent.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "migration-subagent" || process.argv[1]?.endsWith("migration-subagent.ts")) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/src/manifest-cli.ts
+++ b/src/manifest-cli.ts
@@ -469,8 +469,8 @@ async function main(argv = process.argv.slice(2)) {
   }
 }
 
-const isCliEntry = process.argv[1]
-  && new URL(import.meta.url).pathname === process.argv[1];
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "manifest-cli" || (process.argv[1]
+  && new URL(import.meta.url).pathname === process.argv[1]);
 if (isCliEntry) {
   main().catch((err) => {
     console.error(err);

--- a/src/util/perf.ts
+++ b/src/util/perf.ts
@@ -419,7 +419,7 @@ async function main(argv = process.argv.slice(2)) {
   }
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "perf" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/src/util/skill.ts
+++ b/src/util/skill.ts
@@ -325,7 +325,7 @@ async function main(argv = process.argv.slice(2)) {
   process.exit(1);
 }
 
-const isCliEntry = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "skill" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
 if (isCliEntry) {
   main().catch(handleCliError);
 }

--- a/src/vrt/snapshot/snapshot-report.ts
+++ b/src/vrt/snapshot/snapshot-report.ts
@@ -272,7 +272,7 @@ function parseRatioLike(value: string | undefined, message: string): number {
   return parsed;
 }
 
-if (process.argv[1]?.endsWith("snapshot-report.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "snapshot-report" || process.argv[1]?.endsWith("snapshot-report.ts")) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/src/vrt/snapshot/snapshot.ts
+++ b/src/vrt/snapshot/snapshot.ts
@@ -635,6 +635,6 @@ async function main() {
   console.log();
 }
 
-if (process.argv[1]?.endsWith("snapshot.ts")) {
+if (process.env.__VRT_DISPATCHER_LEAF__ === "snapshot" || process.argv[1]?.endsWith("snapshot.ts")) {
   main().catch((e) => { console.error(e); process.exit(1); });
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -350,8 +350,8 @@ function stripAnsi(s: string): string {
   return s.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
-const isCliEntry = process.argv[1]
-  && new URL(import.meta.url).pathname === process.argv[1];
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "watch" || (process.argv[1]
+  && new URL(import.meta.url).pathname === process.argv[1]);
 if (isCliEntry) {
   runWatch(process.argv.slice(2)).catch((err) => {
     console.error(err);


### PR DESCRIPTION
## Summary

Closes #48. Source-mode worked because the dispatcher in `src/cli/cli.ts` resolved every leaf at runtime via `import.meta.resolve("<source-relative-path>")`. That path is meaningless from the bundled `dist/vrt.mjs`, so every subcommand failed with `ERR_MODULE_NOT_FOUND` once installed standalone. Advisory smoke gate (PR #53) was tracking this.

## Two coordinated rewrites

### 1. `src/cli/cli.ts`

`SPECS` becomes a `{ name, loader }` map where `loader` is a `() => import("literal-path")` closure. Because the path is a string literal at the `import()` call site, tsdown statically discovers each leaf and emits a code-split chunk for it under `dist/`. The dispatcher's `delegate(spec, args)`:

- Sets `process.argv = [node, "(vrt-dispatcher)", ...args]` (no more swap to a source-relative path, which doesn't exist in dist).
- Sets `process.env.__VRT_DISPATCHER_LEAF__ = spec.name` around the `await`.
- Restores the previous env value on the way out.

### 2. Every leaf's CLI-entry guard

Each leaf now checks the env var against **its own** name, e.g.:

```ts
const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "diff-pr"
  || (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]);
```

Per-leaf matching (vs. a single global flag) matters because some leaves statically import other leaves for shared types. e.g. `src/diff-pr.ts` does `import { runMediaVariants } from "@mizchi/vrt-markup/stress/media-variants.ts"`. With a global flag, the `media-variants.ts` `main()` would fire as a side effect — the test that surfaced this expected exit 0 but got 1 because `media-variants.ts`'s main tried to resolve `"post"` (`diff-pr`'s first positional) as a filesystem path. With per-leaf signals, only the dispatcher's actual target fires.

## Test plan

- [x] `pnpm build` emits 26 chunk files (one per dynamically-imported leaf).
- [x] `bash scripts/smoke-dist.sh` (now strict by default): **11/11 pass**, including the no-flag `vrt diff html fixtures/element-compare/before.html …` exec probe that exercises the delegate path end-to-end.
- [x] Source-mode regression check (`node --experimental-strip-types src/cli/vrt.ts diff html --help` etc.) — works.
- [x] Full repo test suite: **776 pass / 0 fail**.

## Notes

- `scripts/smoke-dist.sh` now runs strict by default (was advisory). `--lenient` flips off for local iteration.
- One ancillary file (`src/experiments/css-challenge/fix-loop.ts`) had the same env-sentinel boilerplate even though it's not in SPECS (invoked via `pkf run fix-loop -- …`). Kept the consistent shape — the per-leaf check is a safe no-op there.