### PR TITLE
release: 0.5.0 — first public npm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,100 @@
 # Changelog
 
-## Unreleased — design-md scenario branch (2026-05-15)
+All notable changes to this project will be documented in this file.
+Dates are YYYY-MM-DD.
+
+## 0.5.0 — 2026-05-19 (first public release)
+
+The internal 0.4.x history is preserved in commits; npm publication
+starts here. Two work streams since `0.4.0` rolled up under this
+release: the **0.5.0 CLI restructure + dispatcher rewrite** (this
+section) and the prior **design-md / markup-assistance** sections
+below.
+
+### CLI restructure — verb groups
+
+Every command now lives under a verb group. Single-token names from
+0.4.x remain as deprecation shims that print a one-line hint and
+forward.
+
+| Old | New |
+|---|---|
+| `vrt compare` | `vrt diff html` |
+| `vrt png-diff` | `vrt diff png` |
+| `vrt elements` | `vrt diff elements` |
+| `vrt cross-browser` | `vrt diff browsers` |
+| `vrt diff-for-agent` | `vrt diff agent` |
+| `vrt compare-runs` | `vrt diff runs` |
+| `vrt a11y-{contrast,touch,focus-order}` | `vrt check a11y {contrast,touch,focus}` |
+| `vrt design-tokens` | `vrt check tokens` |
+| `vrt theme-parity` | `vrt check theme` |
+| `vrt perf` | `vrt check perf` |
+| `vrt {component,multi-page}-consistency` | `vrt check drift {component,pages}` |
+| `vrt interact` / `vrt explore` / `vrt smoke` | `vrt inspect {interact,explore,smoke}` |
+| `vrt i18n-stress` / `vrt media-variants` | `vrt stress {i18n,media}` |
+| `vrt component-extract` | `vrt scan component` |
+| `vrt component-from-image` | `vrt build component` |
+| `vrt flipbook` | `vrt snapshot flipbook` |
+| `vrt migration {compare,blind,subagent}` | unchanged (already grouped) |
+| `vrt snapshot`, `vrt workflow`, `vrt manifest`, `vrt watch`, `vrt diff-pr`, `vrt baseline` | unchanged |
+
+### Dispatcher rewrite for bundled `dist/vrt.mjs`
+
+`src/cli/cli.ts` previously routed leaves via
+`import.meta.resolve(<source-relative-path>)`, which only worked from
+the source tree. The bundled binary failed with
+`ERR_MODULE_NOT_FOUND` on every leaf. Rewritten in this release:
+
+- SPECS is a `{ name, loader }` map where `loader` is a
+  `() => import("literal-path")` closure. tsdown statically discovers
+  the import and code-splits each leaf into a chunk under `dist/`.
+- A per-leaf signal (`__VRT_DISPATCHER_LEAF__=<name>`) replaces the
+  earlier `process.argv` swap. Each leaf's CLI-entry guard checks the
+  env var against its *own* name, so cross-leaf static imports
+  (e.g. `diff-pr.ts` ↔ `media-variants.ts` for shared types) don't
+  accidentally fire a sibling's `main()`.
+- `scripts/smoke-dist.sh` runs strict by default and gates every
+  documented subcommand.
+
+### Workspace packages published
+
+`@mizchi/vrt-core`, `@mizchi/vrt-capture`, `@mizchi/vrt-ai`, and
+`@mizchi/vrt-markup` all 0.5.0. Each ships raw `.ts` via the `exports`
+map — consumers need Node 24+ with `--experimental-strip-types`, or a
+bundler that resolves `.ts` extensions. The packages expose both a
+curated barrel and deep per-module exports (e.g.
+`@mizchi/vrt-core/png-diff.ts`).
+
+### Agent skills (APM-distributable)
+
+Five skill packs at `.claude/skills/`:
+
+- `vrt-visual-diff` — `vrt diff html` → `vrt diff agent` workflow.
+- `vrt-migration-eval` — `vrt migration compare|blind|subagent`.
+- `vrt-markup-synth` — five DOM/pixel-based signal tools (no VLM).
+- `vrt-regression-watch` — stateful `--previous` / `--persist-summary`.
+- `vrt-css-fix-loop` — VLM + LLM 2-stage repair loop.
+
+Install via `apm install mizchi/vrt/.claude/skills/<name>` (or pin to
+`@v0.5.0`).
+
+### Diff-report filename
+
+`vrt diff html` / `vrt migration compare` now write both
+`diff-report.json` (canonical, prefer this) and
+`migration-report.json` (legacy alias, byte-identical). Pinning the
+canonical name lets the legacy alias be removed in a future major.
+
+### Repo / task-runner
+
+Migrated from `justfile` to `Taskfile.pkl` (pkfire). Doc snippets
+across the repo and CLAUDE.md now read `pkf run <task>`. Tasks that
+take positional flags carry `acceptsArgs = true`; tasks with named
+params use the `--<param> <value>` syntax.
+
+---
+
+## 0.5.0 — design-md scenario branch (2026-05-15)
 
 A single branch of work — `claude/design-md-scenario-2026-05-15` —
 turning vrt from a single-shot diff tool into a complete UI-regression
@@ -136,7 +230,7 @@ Detailed analysis of each validation run is under
 report quotes the agent's friction verbatim and records what was
 fixed in response.
 
-## Unreleased — Markup-assistance toolkit
+## 0.5.0 — Markup-assistance toolkit (2026-05-13)
 
 A new suite of commands focused on the LLM-agent markup-authoring loop:
 build from screenshot, verify a11y / theme / i18n / cross-browser

--- a/README.md
+++ b/README.md
@@ -1,23 +1,37 @@
 # vrt
 
-Visual Regression Testing toolkit — pixel diff, computed style diff, a11y tree diff, and AI-powered CSS fix generation.
+Visual Regression Testing toolkit — pixel diff, computed-style diff,
+a11y tree diff, agent-readable Markdown reports, and AI-powered CSS
+fix generation.
 
 Requires Node 24+.
 
-The public surface is organized into:
+```bash
+npm install -g @mizchi/vrt
+# or, from this repo:
+pnpm install && pnpm build
+```
 
-- **Dev inner loop**: `vrt compare` (rich signal output), `vrt watch`
-  (file-watcher + round-vs-round delta), `vrt manifest` (approval
-  authoring).
-- **CI gate**: `vrt diff-pr {pin,verify,post}` — visual diff +
-  optional a11y / media-variants / cross-browser gates per route.
-  `vrt baseline` is the canonical alias.
-- **One-shot analysis**: `vrt compare`, `vrt png-diff`, `vrt snapshot`,
-  the 10+ markup-assistance commands.
-- **Legacy / internal**: `vrt workflow <command>` — vrt's own
-  dogfood harness; external projects should prefer `vrt baseline` /
-  `vrt diff-pr`.
-- **API**: `vrt api {serve,status}` for HTTP integrations.
+The CLI is organized into verb groups. Run `vrt <group> --help` for
+options.
+
+| Group | Subcommands |
+|---|---|
+| `vrt diff` | `html`, `png`, `elements`, `browsers`, `agent`, `runs` |
+| `vrt check` | `a11y {contrast,touch,focus}`, `tokens`, `theme`, `perf`, `drift {component,pages}` |
+| `vrt inspect` | `interact`, `explore`, `smoke` |
+| `vrt stress` | `i18n`, `media` |
+| `vrt scan` | `component`, `breakpoints` |
+| `vrt build` | `component` |
+| `vrt snapshot` | `[<url>...]`, `approve`, `fix-prompt`, `stability`, `flipbook`, `report` |
+| `vrt migration` | `compare`, `blind`, `subagent` |
+| `vrt workflow` | `init`, `capture`, `verify`, `approve`, `graph`, `affected`, `introspect`, `spec-verify`, `expect` |
+| Standalone | `vrt watch`, `vrt manifest`, `vrt diff-pr`, `vrt baseline`, `vrt api`, `vrt bench`, `vrt report`, `vrt skill` |
+
+The single-token commands from 0.4.x (`vrt compare`, `vrt png-diff`,
+`vrt theme-parity`, …) remain as deprecation shims that forward to
+the new names and print a one-line hint. See the [CHANGELOG](./CHANGELOG.md)
+for the full old → new mapping.
 
 ## Features
 
@@ -45,13 +59,17 @@ pnpm install
 pnpm test
 
 # Compare two HTML files
-vrt compare before.html after.html
+vrt diff html before.html after.html --output reports/
+
+# Render the diff into an agent-friendly Markdown report
+vrt diff agent reports/diff-report.json > reports/diff.md
 
 # Compare two existing PNG screenshots without Playwright
-vrt png-diff baselines/home.png snapshots/home.png
+vrt diff png baselines/home.png snapshots/home.png
 
 # Compare two URLs
-vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/
+vrt diff html --url http://localhost:3000/ --current-url http://localhost:8080/ \
+  --output reports/
 
 # Snapshot URLs (creates baseline on first run, diffs on subsequent runs)
 vrt snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
@@ -69,7 +87,7 @@ vrt snapshot approve --output snapshots/
 vrt snapshot
 
 # Dev inner loop with rich signal output (token-aware + cross-round)
-vrt compare baseline.html variant.html --tokens DESIGN.md
+vrt diff html baseline.html variant.html --tokens DESIGN.md --output reports/
 vrt watch baseline.html variant.html --tokens DESIGN.md
 
 # Author approval rules (sub-pixel deviations, intentional design exceptions, etc.)
@@ -109,7 +127,7 @@ pkf run migration-blind-evaluate --scenario shadcn-to-luna -- --before-report te
 vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
 
 # Detect broken baseline renders (e.g. CDN failed to load) — on by default
-vrt compare --dir fixtures/migration/tailwind-to-vanilla \
+vrt diff html --dir fixtures/migration/tailwind-to-vanilla \
   --baseline before.html --variants after.html
 # Add --strict-baseline-sanity to exit non-zero when warnings fire,
 # or --no-baseline-sanity to skip the check entirely.
@@ -150,55 +168,61 @@ nix run git+https://github.com/mizchi/pkspec  -- check Spec.pkl Test.pkl
 
 ## CLI Surface
 
-### Core Commands
+### Diff (compare two things)
 
 ```bash
-vrt compare <before.html> <after.html>      # Migration VRT for files or URLs
-                                             # ([--strict-baseline-sanity] to fail on broken baseline renders)
-vrt diff-for-agent <migration-report.json>  # Agent-friendly Markdown summary of a compare report
-vrt png-diff <baseline.png> <current.png>   # Direct PNG pixel diff + heatmap
-vrt snapshot <url1> [url2] ...              # Multi-viewport snapshot + diff
-vrt snapshot approve                        # Promote *-current.png to *-baseline.png
+vrt diff html <baseline> <variant>          # HTML/URL pair → multi-viewport diff + report.json
+vrt diff agent <report.json>                # Render report.json as agent-friendly Markdown
+vrt diff png <baseline.png> <current.png>   # Direct PNG pixel diff + heatmap
+vrt diff elements [options]                 # Element-level diff with shift isolation
+vrt diff browsers <html|url>                # chromium / firefox / webkit parity
+vrt diff runs <dir...>                      # Aggregate multiple VRT runs into one table
+```
+
+### Snapshot (URL → baseline + diff)
+
+```bash
+vrt snapshot <url1> [url2] ...              # First run: baseline. Subsequent: baseline + diff
+vrt snapshot approve                        # Promote *-current.png → *-baseline.png
 vrt snapshot fix-prompt                     # Emit a subagent-ready prompt from snapshot-report.json
 vrt snapshot stability <url...>             # Run N iterations and report false-positive rate
 vrt snapshot flipbook                       # Diff three-frame (baseline ↔ current ↔ heatmap) HTML flipbooks
-vrt flipbook <frame1.png> ...               # Assemble arbitrary PNG sequence into a single-file HTML flipbook
-vrt smoke --record-video <dir>              # Capture a WebM video of the smoke-test session (Playwright recordVideo)
-vrt elements [options]                      # Element-level diff with shift isolation
-vrt smoke <file-or-url>                     # A11y-driven random interaction test
-vrt discover <html-file>                    # Breakpoint discovery from HTML/CSS
-vrt bench [options]                         # CSS challenge benchmark
-vrt report                                  # Detection pattern report
+vrt snapshot report                         # Render snapshot-report.json as Markdown
 ```
 
-### Markup-Assistance Commands
+### Check (gates: a11y / tokens / theme / perf / drift)
 
-Built on the same Playwright + pixel-diff foundation, these commands cover the
-LLM-agent markup-authoring loop: build from a screenshot, verify the result,
-catch a11y / theme / i18n / cross-browser regressions before they ship.
+```bash
+vrt check a11y contrast <html>              # WCAG AA contrast scan
+vrt check a11y touch    <html|url>          # Touch target size (WCAG 2.5.5 / 2.5.8)
+vrt check a11y focus    <html|url>          # Tab order vs visual order
+vrt check tokens        <html>              # radius/spacing/z-index/shadow scale conformance
+vrt check theme         <html>              # prefers-color-scheme dark / unthemed components
+vrt check perf          <html|url>          # Web Vitals (CLS / LCP / FCP)
+vrt check drift component <html> --selector .card
+vrt check drift pages     --selector .footer --files A.html B.html C.html
+```
+
+### Build / Scan / Inspect / Stress (markup-assistance)
 
 ```bash
 # Build component from a target screenshot, iterate until close.
-vrt component-from-image <target.png> <current.html>
+vrt build component <target.png> <current.html>
   # signals: bbox + heatmap regions + dominant fill + typography hints
   # + spacing-fix table + palette diff + multi-state suspect flags.
 
-# Verify a fully-built page.
-vrt theme-parity      <html>            # prefers-color-scheme dark / unthemed components
-vrt media-variants    <html>            # forced-colors, reduced-motion, print, RTL, 200% zoom
-vrt cross-browser     <html|url>        # chromium / firefox / webkit parity
-vrt i18n-stress       <html>            # text-node inflation overflow detection
-vrt design-tokens     <html>            # radius/spacing/z-index/shadow scale conformance
-vrt a11y-contrast     <html>            # WCAG AA contrast scan
-vrt a11y-touch        <html|url>        # touch target size (WCAG 2.5.5 / 2.5.8)
-vrt a11y-focus-order  <html|url>        # Tab order vs visual order
+# Detect components in a screenshot.
+vrt scan component <screenshot.png>         # Crop to standalone PNGs
+vrt scan breakpoints <html-file>            # Discover responsive breakpoints
 
-# Drift checks.
-vrt multi-page-consistency --selector .footer --files A.html B.html C.html
-vrt component-consistency  <html> --selector .card
+# Scripted / exploratory interaction.
+vrt inspect interact <html|url> --sequence <path.json>
+vrt inspect explore  <html|url>             # Auto-discover declared actions and diff each
+vrt inspect smoke    <html|url>             # A11y-driven exploratory smoke test
 
-# Scripted UI interactions (dropdowns, forms, scroll, multi-step flows).
-vrt interact <html|url> --sequence <path.json>
+# Stress tests.
+vrt stress i18n  <html>                     # Text-node inflation overflow detection
+vrt stress media <html>                     # forced-colors, reduced-motion, print, RTL, 200% zoom
 ```
 
 All emit a self-contained Markdown report under `--output-dir`. Each
@@ -312,7 +336,7 @@ PRs:
 
 ```bash
 # 1. Fix-loop convergence (or any ordered PNG sequence)
-vrt flipbook round-0.png round-1.png round-2.png \
+vrt snapshot flipbook round-0.png round-1.png round-2.png \
   --label "round 0" --label "round 1" --label "round 2" \
   --title "Fix-loop convergence" --out fix-loop.html
 
@@ -326,7 +350,7 @@ vrt snapshot stability http://localhost:3000/ \
 # → test-results/stability/flipbooks/<label>-<viewport>-stability.html
 
 # 4. WebM recording of a smoke-test session (Playwright recordVideo)
-vrt smoke --url http://localhost:3000/ --max-actions 20 --record-video videos/
+vrt inspect smoke --url http://localhost:3000/ --max-actions 20 --record-video videos/
 # → videos/<hash>.webm
 ```
 
@@ -335,17 +359,17 @@ Common flags: `--delay <ms>` controls per-frame duration (default 700),
 
 #### Agent-friendly diff summary
 
-When a coding agent is iterating with `vrt compare`, the natural workflow
+When a coding agent is iterating with `vrt diff html`, the natural workflow
 (see [`docs/reports/2026-05-12-dogfood-shadcn-luna.md`](docs/reports/2026-05-12-dogfood-shadcn-luna.md))
 is: read the worst-viewport PNGs side-by-side, then write a CSS patch.
-`vrt diff-for-agent` collapses the inputs the agent needs into a single
+`vrt diff agent` collapses the inputs the agent needs into a single
 Markdown blob:
 
 ```bash
-vrt compare --dir fixtures/migration/shadcn-to-luna \
+vrt diff html --dir fixtures/migration/shadcn-to-luna \
   --baseline before.html --variants working.html \
-  --output-dir test-results/iter1
-vrt diff-for-agent test-results/iter1/migration-report.json --max-viewports 2
+  --output test-results/iter1
+vrt diff agent test-results/iter1/diff-report.json --max-viewports 2
 ```
 
 The output contains: a worst-first diff table, category totals across

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vrt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Visual Regression Testing harness: multi-viewport snapshot + diff + workflow CLI driven by VLM/LLM analysis.",
   "license": "MIT",
   "author": "mizchi",
@@ -33,9 +33,11 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/**",
+    "!dist/e2e/**",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsdown",

--- a/packages/vrt-ai/package.json
+++ b/packages/vrt-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vrt-ai",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "VLM / LLM clients, reasoning pipeline, and NLP helpers used by VRT to interpret diff images and natural-language intent.",
   "license": "MIT",
   "author": "mizchi",
@@ -15,7 +15,8 @@
   },
   "type": "module",
   "files": [
-    "src",
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
     "README.md",
     "LICENSE"
   ],

--- a/packages/vrt-capture/package.json
+++ b/packages/vrt-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vrt-capture",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Playwright + Crater capture infrastructure for VRT — viewport discovery, multi-route capture, prescanner.",
   "license": "MIT",
   "author": "mizchi",
@@ -15,7 +15,8 @@
   },
   "type": "module",
   "files": [
-    "src",
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
     "README.md",
     "LICENSE"
   ],

--- a/packages/vrt-core/package.json
+++ b/packages/vrt-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vrt-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "VRT diff engine + shared types — pure image / DOM / a11y / visual comparison primitives.",
   "license": "MIT",
   "author": "mizchi",
@@ -15,7 +15,8 @@
   },
   "type": "module",
   "files": [
-    "src",
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
     "README.md",
     "LICENSE"
   ],

--- a/packages/vrt-markup/README.md
+++ b/packages/vrt-markup/README.md
@@ -4,8 +4,8 @@ VLM-driven markup-assistance tooling — component extraction, design-token
 conformance, theme parity, i18n stress, palette diff, dep-graph, selector heal.
 
 Part of the [`vrt`](https://github.com/mizchi/vrt) monorepo. Most modules
-double as CLI commands routed by the `vrt` CLI (`vrt component-extract`,
-`vrt theme-parity`, …).
+double as CLI commands routed by the `vrt` CLI (`vrt scan component`,
+`vrt check theme`, `vrt check tokens`, `vrt stress i18n|media`, …).
 
 ## Install
 

--- a/packages/vrt-markup/package.json
+++ b/packages/vrt-markup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vrt-markup",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "VLM-driven markup tooling for VRT: component extract, design-token / theme-parity / i18n-stress / palette checks, dep-graph, selector heal, smoke runner.",
   "license": "MIT",
   "author": "mizchi",
@@ -15,7 +15,8 @@
   },
   "type": "module",
   "files": [
-    "src",
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
     "README.md",
     "LICENSE"
   ],

--- a/src/util/package-manifest.test.ts
+++ b/src/util/package-manifest.test.ts
@@ -66,7 +66,10 @@ describe("package manifest for publishable CLI", () => {
     const files = pkg.files as string[] | undefined;
 
     assert.ok(files, "package.json should define files");
-    assert.ok(files.includes("dist"), "dist should be published");
+    assert.ok(
+      files.some((f) => f === "dist" || f.startsWith("dist/")),
+      "dist should be published (either 'dist' or 'dist/**' patterns)",
+    );
     assert.ok(files.includes("README.md"), "README should be published");
   });
 });


### PR DESCRIPTION
## Summary

Prepares `@mizchi/vrt` + 4 workspace packages for their first npm publication. No code-behavior changes — version bumps, README rewrite for the 0.5.0 verb-group CLI, CHANGELOG entry, and `files` patterns to keep test / e2e files out of the published tarballs.

## Packages bumped to 0.5.0

| Package | Tarball size |
|---|---:|
| `@mizchi/vrt` | 158k |
| `@mizchi/vrt-core` | 65k |
| `@mizchi/vrt-markup` | 83k |
| `@mizchi/vrt-ai` | 19k |
| `@mizchi/vrt-capture` | 15k |

## Changes

- **`package.json` files field** — switched to glob + negation
  (`["src/**/*.ts", "!src/**/*.test.ts", ...]` on workspaces;
  `["dist/**", "!dist/e2e/**", ...]` on root) so `pnpm pack` ships
  zero `.test.ts` / `dist/e2e/*` junk. `pnpm pack --dry-run` across
  all 5: **0 leaks**.
- **README.md** — reorganized around the verb groups: `vrt diff
  html|png|elements|browsers|agent|runs`, `vrt check a11y|tokens|theme
  |perf|drift`, `vrt inspect|stress|scan|build|snapshot|migration`.
  Quickstart snippets updated. Legacy single-token names noted as
  deprecation shims forwarding to the new groups.
- **CHANGELOG.md** — promoted the prior "Unreleased" sections to
  0.5.0, added a top-of-file 0.5.0 entry covering: CLI restructure,
  dispatcher rewrite (closes #48), workspace publish, agent skills
  (APM), `diff-report.json` rename + `migration-report.json` legacy
  alias, just → pkf migration.
- **`packages/vrt-markup/README.md`** — legacy CLI mentions updated to
  verb-group form.
- **`src/util/package-manifest.test.ts`** — assertion relaxed to
  accept either bare `"dist"` or `"dist/**"` patterns.

## Out of scope

`npm publish` is not run from this PR — the maintainer should run it
from a clean checkout after CI approves the bumps.

## Test plan

- [x] `pnpm test` — 776 pass / 0 fail
- [x] `bash scripts/smoke-dist.sh` (strict) — 11 pass / 0 fail
- [x] `pnpm pack` × 5 — zero `.test.ts` / `dist/e2e/*` in any tarball
- [x] `node dist/vrt.mjs --version` prints `vrt/0.5.0`