### PR TITLE
docs: 2026-05-19 VLM re-bench (haiku + UI-TARS, both FIXED r1)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,18 +36,19 @@ pkf run vlm-bench -- <model1> <model2> <model3> --md
 - Cost: /call (guideline: below $0.5e-7 is cheap)
 - CHANGE detection count: number of changes following structured format (7-15 is optimal)
 
-### Current Recommendations (2026-05-18)
-- **Default**: `bytedance/ui-tars-1.5-7b` (1.16s, $0.1e-6/$0.2e-6) — UI-domain-trained, fastest of the structured outputs
-- **Stable / detailed**: `qwen/qwen3-vl-30b-a3b-instruct` (1.99s) — emits hex codes directly
-- **Baseline fallback**: `amazon/nova-lite-v1` (2.38s)
-- **High quality (agent-facing CHANGE list)**: `claude:claude-haiku-4-5-20251001` (3.51s, ~$0.002/call — only when VLM output is consumed directly, not via Stage-2 LLM)
+### Current Recommendations (2026-05-19)
+- **Default**: `bytedance/ui-tars-1.5-7b` (~1.35s, ~$0/call) — UI-domain-trained, fastest of the structured outputs. Verified FIXED in round 1 on seed 11 (.readme-body pre, 4.1% diff).
+- **Stable / detailed**: `qwen/qwen3-vl-30b-a3b-instruct` (~2.0s) — emits hex codes directly.
+- **Baseline fallback**: `amazon/nova-lite-v1` (~2.4s).
+- **High coverage + prose root-cause**: `claude:claude-haiku-4-5-20251001` (~4.2s, ~$2e-6/call). Also FIXED in round 1 on seed 11 — works as Stage-1 VLM in the 2-stage pipeline despite format divergence; Stage-2 LLM handles it. The earlier "only when VLM is consumed directly" caveat was too conservative.
 
 #### Avoid / re-evaluate
 - `meta-llama/llama-4-scout` — regressed since 2026-04-04 (was 1.0s, now ~7s with conversational output)
 - `meta-llama/llama-4-maverick` — claims "image not available" and returns methodology only
 - `google/gemini-2.5-flash-lite` — hallucinates uniform `red → red` deltas
 
-See `docs/reports/2026-05-18-vlm-claude-vs-openrouter-vs-newcomers.md` for the 8-way bench evidence.
+See `docs/reports/2026-05-19-vlm-haiku-vs-uitars.md` for today's 2-way re-bench (haiku + UI-TARS, both FIXED r1);
+`docs/reports/2026-05-18-vlm-claude-vs-openrouter-vs-newcomers.md` for the 8-way bench from the prior week.
 
 ## Running CSS Challenge Benchmarks
 

--- a/.claude/skills/vrt-css-fix-loop/SKILL.md
+++ b/.claude/skills/vrt-css-fix-loop/SKILL.md
@@ -111,18 +111,26 @@ The harness honours `VRT_VLM_MODEL`. Prefix selects the provider:
 
 Current recommendations (from `.claude/CLAUDE.md`):
 
-- **Default**: `bytedance/ui-tars-1.5-7b` (UI-domain-trained, ~1.2s).
-- **Stable / detailed**: `qwen/qwen3-vl-30b-a3b-instruct`.
+- **Default**: `bytedance/ui-tars-1.5-7b` (UI-domain-trained, ~1.4s
+  single-call, $0/call). Verified FIXED in round 1 on the canonical
+  hard case (seed 11, .readme-body pre {6 props}, 4.1% diff →
+  0.0%).
+- **Stable / detailed**: `qwen/qwen3-vl-30b-a3b-instruct` (emits hex
+  codes directly).
 - **Baseline fallback**: `amazon/nova-lite-v1`.
-- **High quality** (only when VLM output isn't consumed by Stage-2
-  LLM): `claude:claude-haiku-4-5-20251001`.
+- **High coverage + prose root-cause**:
+  `claude:claude-haiku-4-5-20251001` (~4.2s single-call, ~$2e-6/call;
+  also FIXED in round 1 on seed 11 — works as Stage-1 VLM despite
+  format divergence, Stage-2 LLM handles it).
 
 Avoid: `meta-llama/llama-4-scout` (regressed; verbose),
 `meta-llama/llama-4-maverick` (returns "image not available"),
 `google/gemini-2.5-flash-lite` (hallucinates uniform deltas).
 
-See `docs/reports/2026-05-18-vlm-claude-vs-openrouter-vs-newcomers.md`
-for the 8-way bench.
+See `docs/reports/2026-05-19-vlm-haiku-vs-uitars.md` for the latest
+2-way re-bench;
+`docs/reports/2026-05-18-vlm-claude-vs-openrouter-vs-newcomers.md`
+for the 8-way bench from the prior week.
 
 ## Flags
 

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -632,7 +632,31 @@ By fixture:
 - `width` 50% — dead-code when natural size equals CSS width
 - `background` 82% — same as parent color, `pre code` override, etc.
 
-## VLM Model Comparison (2026-05-18 — current)
+## VLM Model Comparison
+
+### 2026-05-19 — haiku vs UI-TARS re-bench (post-0.5.0 release)
+
+Single-pair re-bench against the canonical hard case after the 0.5.0
+release. Both models **FIXED in round 1** on `seed 11 (.readme-body pre
+{6 props})`.
+
+| Model | bench latency | bench CHANGEs | fix-loop VLM | fix-loop CHANGEs | LLM | Fixes | Round to FIXED |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `bytedance/ui-tars-1.5-7b` | 1352ms | 3 | 2765ms | 5 | 5002ms | 6/6 | **1** |
+| `claude:claude-haiku-4-5-20251001` | 4180ms | 10 | 2562ms | 11 | 5772ms | 6/6 | **1** |
+
+Stage-2 LLM (fixed): `claude-sonnet-4-20250514`. Initial diff 4.1% →
+0.0% in both runs.
+
+**Insight**: Haiku works fine **as a Stage-1 VLM** even though its
+format diverges from the canonical CHANGE shape. The previous "use
+only when VLM output isn't consumed by Stage-2 LLM" caveat (from
+2026-04-04) was too conservative. UI-TARS-with-5-CHANGEs also passes,
+below the 7-15 guideline.
+
+Full report: `docs/reports/2026-05-19-vlm-haiku-vs-uitars.md`.
+
+### 2026-05-18 — 8-way bench (prior baseline)
 
 ### Single-call latency / output bench (`pkf run vlm-bench`, generated heatmap 1.7% diff, n=1)
 

--- a/docs/reports/2026-05-19-vlm-haiku-vs-uitars.md
+++ b/docs/reports/2026-05-19-vlm-haiku-vs-uitars.md
@@ -1,0 +1,105 @@
+# VLM bench 2026-05-19 — claude-haiku-4.5 vs UI-TARS 1.5-7b
+
+Single-pair re-bench to verify both models still pass the canonical
+hard case after the 0.5.0 release. Both models converge in **round
+1** on `seed 11 (.readme-body pre {6 props})` (selector mode, page
+fixture, --max-rounds 2).
+
+## Setup
+
+```bash
+# Single-call latency (generated heatmap 1.7% diff)
+node src/experiments/benchmark/vlm-bench.ts \
+  claude:claude-haiku-4-5-20251001 bytedance/ui-tars-1.5-7b --md
+
+# Fix-loop hard case
+VRT_VLM_MODEL="<model>" node --experimental-strip-types \
+  src/experiments/css-challenge/fix-loop.ts \
+  --fixture page --seed 11 --mode selector --max-rounds 2
+```
+
+Stage-2 LLM (fixed): `claude-sonnet-4-20250514`.
+
+## vlm-bench (single call, 1.7% heatmap)
+
+| Model | Latency | Cost | Tokens | Chars | CHANGEs | Format |
+|---|---:|---:|---:|---:|---:|---|
+| `bytedance/ui-tars-1.5-7b` | **1352ms** | ~$0 | 788 | 174 | 3 | Canonical `- [Selector] property: X → Y (severity: …)` |
+| `claude:claude-haiku-4-5-20251001` | 4180ms | $2e-6 | 1108 | 1382 | 10 | `- **Selector** - property: X → Y (severity: …)` + "Overall Assessment" prose |
+
+**Observations**:
+- UI-TARS is **3.1× faster** at single-call.
+- Cost difference is ~2000×; ui-tars is near-zero per call.
+- Haiku produces a higher CHANGE count (10 vs 3 on the synthetic
+  heatmap), plus a root-cause-inferring prose paragraph at the end
+  ("font encoding issue / CSS text property corruption / color
+  filter").
+- Haiku's format adds `**bold**` selector wrappers — slightly
+  divergent from the canonical leading-`[Selector]` shape, but the
+  downstream Stage-2 LLM still parses it.
+
+## fix-loop seed 11 (hard case)
+
+```
+Removed: .readme-body pre { 6 props }
+Initial pixel diff: 4.1%
+```
+
+| Model | Round | VLM latency | CHANGEs | LLM latency | Fixes applied | Final diff |
+|---|---:|---:|---:|---:|---:|---:|
+| `claude:claude-haiku-4-5-20251001` | 1 | 2562ms | 11 | 5772ms | 6/6 | **0.0%** |
+| `bytedance/ui-tars-1.5-7b` | 1 | 2765ms | 5 | 5002ms | 6/6 | **0.0%** |
+
+Both **FIXED in round 1**. End-to-end (VLM + LLM + verify) totals:
+- Haiku run: ~10.5 s (incl. verification).
+- UI-TARS run: ~9.5 s.
+
+**Notable**: UI-TARS reported 5 CHANGEs (below the 7-15 guideline in
+CLAUDE.md), yet the Stage-2 LLM still proposed 6 fixes and all
+applied cleanly. The "structured fewer-but-correct" signal carried
+enough information for the downstream model to recover the missing
+properties without needing the full CSS-diff trace.
+
+Haiku reported 11 CHANGEs across more selectors (.main, .sidebar,
+.header-nav, etc.), some of which were beyond the actually-removed
+`.readme-body pre` block — yet Stage-2 still distilled to the right
+6 fixes. This is the LLM-as-de-noiser pattern: VLM over-coverage is
+fine as long as the LLM is good.
+
+## Updated recommendations
+
+The 2026-04-04 hardline ("Haiku is **high-quality**, only use when
+VLM output isn't consumed by Stage-2 LLM") is too conservative.
+Haiku works fine as a Stage-1 VLM in the 2-stage pipeline; the
+Stage-2 LLM handles the format divergence and the over-coverage.
+
+Choose by:
+
+| Constraint | Pick |
+|---|---|
+| Cost / latency-sensitive (sub-2s budget, $0/call) | `bytedance/ui-tars-1.5-7b` |
+| Want explicit hex-code deltas | `qwen/qwen3-vl-30b-a3b-instruct` |
+| Stable baseline | `amazon/nova-lite-v1` |
+| High coverage + prose-style root cause analysis | `claude:claude-haiku-4-5-20251001` |
+
+Default remains `bytedance/ui-tars-1.5-7b` — 3.1× faster on bench,
+parity on hard case.
+
+## Avoid (no change from 2026-05-18)
+
+- `meta-llama/llama-4-scout` — regressed since 2026-04-04 (was 1.0s,
+  now ~7s conversational).
+- `meta-llama/llama-4-maverick` — "image not available."
+- `google/gemini-2.5-flash-lite` — hallucinates uniform `red → red`.
+
+## Stop-sign / convergence
+
+n=1 per model. The earlier 2026-05-18 bench used n=1 too, so this is
+not a regression in evaluation rigor — it's a delta check. If a
+production decision hinges on the ranking, repeat at n≥5 with random
+seeds 1 through 5 from the css-challenge fixture set.
+
+## Artifacts
+
+- Raw bench markdown: `test-results/vlm-bench/vlm-bench-report.md`
+- Raw bench JSON: `test-results/vlm-bench/vlm-bench-report.json`


### PR DESCRIPTION
## Summary

Re-bench of the two main VLM candidates against the canonical hard case after the 0.5.0 release. **Both `claude:claude-haiku-4-5-20251001` and `bytedance/ui-tars-1.5-7b` FIXED in round 1** on seed 11 (`.readme-body pre {6 props}`, 4.1% diff → 0.0%).

## Single-call bench (heatmap 1.7% diff)

| Model | Latency | Cost | Tokens | Chars | CHANGEs | Format |
|---|---:|---:|---:|---:|---:|---|
| `bytedance/ui-tars-1.5-7b` | **1352ms** | ~$0 | 788 | 174 | 3 | canonical `- [Selector] property: X → Y (severity)` |
| `claude:claude-haiku-4-5-20251001` | 4180ms | $2e-6 | 1108 | 1382 | 10 | `- **Selector** - property: …` + prose Overall Assessment |

## Fix-loop seed 11

| Model | VLM | CHANGEs | LLM | Fixes | Round to FIXED |
|---|---:|---:|---:|---:|---:|
| `bytedance/ui-tars-1.5-7b` | 2765ms | 5 | 5002ms | 6/6 | **1** |
| `claude:claude-haiku-4-5-20251001` | 2562ms | 11 | 5772ms | 6/6 | **1** |

## Findings revising prior caveats

- **Haiku works fine as a Stage-1 VLM** despite the `**bold**`-wrapped format. Stage-2 LLM (claude-sonnet-4) parses it and produces correct fixes. The 2026-04-04 hardline ("only when VLM is consumed directly, not via Stage-2") is now too conservative.
- **UI-TARS at 5 CHANGEs** (below the 7-15 "optimal" guideline) still drove Stage-2 to a complete 6/6 fix. The "fewer-but-structured" signal carries enough information.

## Files

- `docs/reports/2026-05-19-vlm-haiku-vs-uitars.md` — full report.
- `docs/knowledge.md` — 2026-05-19 section added at top of VLM Model Comparison; 2026-05-18 preserved as the prior baseline.
- `.claude/CLAUDE.md` — "Current Recommendations" date bumped; Haiku caveat softened; pointer to today's report.
- `.claude/skills/vrt-css-fix-loop/SKILL.md` — same Haiku revision; report pointer added.

## Test plan

- [x] `vlm-bench` against both models: report written to `test-results/vlm-bench/`
- [x] Fix-loop seed 11 for both models: both FIXED in round 1, 0.0% final diff
- [x] All references to the 2026-04-04 "haiku Stage-2 caveat" updated or softened