### PR TITLE
fix: repair pnpm-lock after #65 + #66 merge (frozen install broken on main)

### DIFF
--- a/packages/vlmkit-heal/package.json
+++ b/packages/vlmkit-heal/package.json
@@ -32,6 +32,6 @@
     "@mizchi/vlmkit-ai": "workspace:*",
     "@mizchi/vlmkit-capture": "workspace:*",
     "@mizchi/vlmkit-core": "workspace:*",
-    "playwright": "^1.58.2"
+    "playwright": "^1.61.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: workspace:*
         version: link:../vlmkit-core
       playwright:
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.61.1
+        version: 1.61.1
 
   packages/vlmkit-markup:
     dependencies:


### PR DESCRIPTION
Merging #65 (vlmkit-heal, playwright `^1.58.2`) and #66 (Node 24.16 hang fix, playwright `1.61.1`) in sequence left `pnpm-lock.yaml` referencing a removed `playwright@1.58.2` entry, so `pnpm install --frozen-lockfile` fails on `main` (breaks every CI job).

Fix: bump `packages/vlmkit-heal` to `playwright ^1.61.1` and regenerate the lockfile. `--frozen-lockfile` passes again; 0 references to 1.58.x remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)