### PR TITLE
feat(heal): publishable package + baseURL tiers + healAll batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ for the full old → new mapping.
 - **Markup-assistance toolkit** (10+ commands): build from screenshot, theme-parity,
   i18n stress, a11y contrast / touch / focus-order, media-variant adaptations,
   cross-browser parity, design-token conformance, interaction sequences.
+- **Self-healing Playwright tests** (`@mizchi/vlmkit-heal`) — a cost-optimized
+  loop that runs a test, observes the failure, and patches the test (or updates
+  a VRT baseline), escalating cheap → strong models under a shared budget cap.
+  See [`packages/vlmkit-heal`](packages/vlmkit-heal/README.md).
 
 ## Quick Start
 
@@ -625,6 +629,11 @@ src/
 packages/vlmkit-capture/src/
   crater-client.ts          # Crater BiDi WebSocket client
   crater-wasm.ts            # Crater layout-only JS/WASM adapter
+packages/vlmkit-heal/src/
+  router.ts                 # Cost-escalation model router (shared budget)
+  heal.ts                   # Self-healing loop state machine
+  clients.ts                # Observe (VLM) / codegen (LLM) tiers
+  cost.ts                   # Token×price billing so the budget cap works
 fixtures/
   css-challenge/            # 9 HTML fixtures for CSS bench
   migration/                # Migration comparison fixtures

--- a/packages/vlmkit-heal/README.md
+++ b/packages/vlmkit-heal/README.md
@@ -29,6 +29,24 @@ const result = await heal({
 // result.verdict: "fixed" | "regression" | "intentional-change" | "give-up"
 ```
 
+Heal a whole failing suite with one cross-file budget:
+
+```ts
+import { healAll } from "@mizchi/vlmkit-heal";
+
+const { entries, fixed, totalCostUsd } = await healAll(
+  [optsA, optsB, optsC],          // one HealOptions per file
+  { totalBudgetUsd: 2.0 },        // outer cap; remaining files skip once reached
+);
+```
+
+Self-hosted observe model (e.g. ui-tars) via an OpenAI-compatible endpoint —
+set `baseURL` on the tier (auth via `VLMKIT_HEAL_BASEURL_KEY` if needed):
+
+```ts
+observe: { tiers: [{ provider: "openrouter", model: "ui-tars", vision: true, baseURL: "http://localhost:8000/v1" }] }
+```
+
 Inject mocks for deterministic tests:
 
 ```ts

--- a/packages/vlmkit-heal/package.json
+++ b/packages/vlmkit-heal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-heal",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Cost-optimized self-healing loop for Playwright tests — escalates from cheap to strong models, edits tests/baselines, re-verifies.",
   "license": "MIT",
   "author": "mizchi",
@@ -14,7 +14,6 @@
     "url": "https://github.com/mizchi/vlmkit/issues"
   },
   "type": "module",
-  "private": true,
   "files": [
     "src/**/*.ts",
     "!src/**/*.test.ts",

--- a/packages/vlmkit-heal/src/clients.ts
+++ b/packages/vlmkit-heal/src/clients.ts
@@ -1,6 +1,7 @@
 import { createUnifiedLLMClient } from "@mizchi/vlmkit-ai";
 import type { ModelTier } from "./types.ts";
 import { billedCost } from "./cost.ts";
+import { openAICompatComplete } from "./openai-compat.ts";
 
 /** Observe phase: a vision model (tier0 = ui-tars) judges a vrt-diff failure. */
 export interface ObserveClient {
@@ -36,29 +37,51 @@ function clientFor(tier: ModelTier, vision: boolean) {
   return client;
 }
 
+// One entry point for both axes: a self-hosted baseURL tier hits an
+// OpenAI-compatible endpoint directly (ui-tars etc.), otherwise route through
+// the vlmkit-ai unified client. Cost is billed from the tier's per-token price
+// whenever the provider doesn't report one.
+async function completeForTier(
+  tier: ModelTier,
+  prompt: string,
+  vision: boolean,
+  screenshotPng?: Buffer,
+): Promise<{ content: string; costUsd: number }> {
+  if (tier.baseURL) {
+    const res = await openAICompatComplete({
+      tier,
+      text: prompt,
+      screenshotPng,
+      apiKey: process.env.VLMKIT_HEAL_BASEURL_KEY,
+    });
+    return { content: res.content, costUsd: billedCost(tier, 0, res) };
+  }
+  const client = clientFor(tier, vision);
+  const content = screenshotPng
+    ? [
+        { type: "text" as const, text: prompt },
+        { type: "image" as const, base64: screenshotPng.toString("base64"), mimeType: "image/png" },
+      ]
+    : prompt;
+  const res = await client.completeWithImages(content);
+  return { content: res.content, costUsd: billedCost(tier, res.costUsd, res) };
+}
+
 export function createRealObserveClient(): ObserveClient {
   return {
     async observe({ tier, screenshotPng, textReport }) {
-      const client = clientFor(tier, true);
       const prompt =
         "A visual regression test failed. Decide if the change looks like an " +
         "INTENTIONAL UI change or a REGRESSION. Answer with exactly one word: " +
         "intentional-change OR regression.\n\nReport:\n" + textReport;
-      const content = screenshotPng
-        ? [
-            { type: "text" as const, text: prompt },
-            { type: "image" as const, base64: screenshotPng.toString("base64"), mimeType: "image/png" },
-          ]
-        : prompt;
-      const res = await client.completeWithImages(content);
+      const res = await completeForTier(tier, prompt, true, screenshotPng);
       const word = res.content.toLowerCase();
       const verdict = word.includes("intentional")
         ? "intentional-change"
         : word.includes("regression")
           ? "regression"
           : "unknown";
-      const costUsd = billedCost(tier, res.costUsd, res);
-      return { verdict, costUsd };
+      return { verdict, costUsd: res.costUsd };
     },
   };
 }
@@ -66,16 +89,14 @@ export function createRealObserveClient(): ObserveClient {
 export function createRealCodegenClient(): CodegenClient {
   return {
     async propose({ tier, errorKind, testSource, context }) {
-      const client = clientFor(tier, false);
       const prompt =
         `A Playwright test is failing (errorKind: ${errorKind}). Rewrite the ` +
         `WHOLE test file so it passes against the current UI. Output ONLY the ` +
         `full updated TypeScript file inside a single \`\`\`ts code block.\n\n` +
         `Context:\n${context}\n\nCurrent file:\n\`\`\`ts\n${testSource}\n\`\`\``;
-      const res = await client.completeWithImages(prompt);
+      const res = await completeForTier(tier, prompt, false);
       const newTestSource = extractCodeBlock(res.content) ?? undefined;
-      const costUsd = billedCost(tier, res.costUsd, res);
-      return { newTestSource, costUsd };
+      return { newTestSource, costUsd: res.costUsd };
     },
   };
 }

--- a/packages/vlmkit-heal/src/heal-all.test.ts
+++ b/packages/vlmkit-heal/src/heal-all.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { healAll } from "./heal-all.ts";
+import type { HealOptions } from "./types.ts";
+import type { HealDeps } from "./heal.ts";
+
+function tmpFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), "heal-all-"));
+  const f = join(dir, "x.spec.ts");
+  writeFileSync(f, "// original\n");
+  return f;
+}
+
+function opts(testCommand: string, testFile: string): HealOptions {
+  return {
+    testCommand,
+    testFile,
+    cwd: process.cwd(),
+    observe: { tiers: [{ provider: "openrouter", model: "o", vision: true }] },
+    codegen: { tiers: [{ provider: "openrouter", model: "c", vision: false }] },
+    budgetUsd: 5,
+    maxAttempts: 4,
+  };
+}
+
+// Each distinct testCommand: first run fails, then passes -> heal patches once.
+function deps(): Partial<HealDeps> {
+  const calls = new Map<string, number>();
+  return {
+    runTest: async (cmd) => {
+      const n = calls.get(cmd) ?? 0;
+      calls.set(cmd, n + 1);
+      return n === 0
+        ? { ok: false, stdout: "", stderr: "locator resolved to 0 elements" }
+        : { ok: true, stdout: "", stderr: "" };
+    },
+    observe: { observe: async () => ({ verdict: "unknown", costUsd: 0 }) },
+    codegen: { propose: async () => ({ newTestSource: "// fixed\n", costUsd: 0.3 }) },
+  };
+}
+
+describe("healAll", () => {
+  it("heals every file when there is no cross-file budget", async () => {
+    const items = [opts("test a", tmpFile()), opts("test b", tmpFile())];
+    const r = await healAll(items, undefined, deps());
+    assert.equal(r.fixed, 2);
+    assert.equal(r.entries.every((e) => !e.skipped), true);
+    assert.ok(Math.abs(r.totalCostUsd - 0.6) < 1e-9);
+  });
+
+  it("skips remaining files once the cross-file budget is reached", async () => {
+    const items = [opts("test a", tmpFile()), opts("test b", tmpFile())];
+    const r = await healAll(items, { totalBudgetUsd: 0.2 }, deps());
+    assert.equal(r.entries[0].skipped, false);
+    assert.equal(r.entries[0].result?.verdict, "fixed");
+    assert.equal(r.entries[1].skipped, true);
+    assert.equal(r.entries[1].result, null);
+    assert.equal(r.fixed, 1);
+  });
+});

--- a/packages/vlmkit-heal/src/heal-all.ts
+++ b/packages/vlmkit-heal/src/heal-all.ts
@@ -1,0 +1,50 @@
+import { heal, type HealDeps } from "./heal.ts";
+import type { HealOptions, HealResult } from "./types.ts";
+
+export interface HealAllEntry {
+  testFile: string;
+  /** null when skipped because the cross-file budget was exhausted. */
+  result: HealResult | null;
+  skipped: boolean;
+}
+
+export interface HealAllResult {
+  entries: HealAllEntry[];
+  totalCostUsd: number;
+  fixed: number;
+}
+
+export interface HealAllOptions {
+  /** Optional cap across ALL files; once cumulative spend reaches it, remaining files are skipped. */
+  totalBudgetUsd?: number;
+}
+
+/**
+ * Heal several test files sequentially (e.g. a whole failing suite). Each file
+ * keeps its own per-run `budgetUsd`; `totalBudgetUsd` is an outer cap across the
+ * batch so a runaway suite can't overspend.
+ */
+export async function healAll(
+  items: HealOptions[],
+  opts?: HealAllOptions,
+  deps?: Partial<HealDeps>,
+): Promise<HealAllResult> {
+  const entries: HealAllEntry[] = [];
+  let totalCostUsd = 0;
+
+  for (const item of items) {
+    if (opts?.totalBudgetUsd != null && totalCostUsd >= opts.totalBudgetUsd) {
+      entries.push({ testFile: item.testFile, result: null, skipped: true });
+      continue;
+    }
+    const result = await heal(item, deps);
+    totalCostUsd += result.totalCostUsd;
+    entries.push({ testFile: item.testFile, result, skipped: false });
+  }
+
+  return {
+    entries,
+    totalCostUsd,
+    fixed: entries.filter((e) => e.result?.verdict === "fixed").length,
+  };
+}

--- a/packages/vlmkit-heal/src/index.ts
+++ b/packages/vlmkit-heal/src/index.ts
@@ -14,3 +14,7 @@ export type {
 export { createRealObserveClient, createRealCodegenClient } from "./clients.ts";
 export { heal } from "./heal.ts";
 export type { HealDeps } from "./heal.ts";
+export { healAll } from "./heal-all.ts";
+export type { HealAllResult, HealAllEntry, HealAllOptions } from "./heal-all.ts";
+export { openAICompatComplete, buildUserContent, parseChatCompletion } from "./openai-compat.ts";
+export type { ChatUsage } from "./openai-compat.ts";

--- a/packages/vlmkit-heal/src/openai-compat.test.ts
+++ b/packages/vlmkit-heal/src/openai-compat.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildUserContent, parseChatCompletion } from "./openai-compat.ts";
+
+describe("buildUserContent", () => {
+  it("returns a plain string when there is no screenshot", () => {
+    assert.equal(buildUserContent("hello"), "hello");
+  });
+  it("returns a text+image_url array with a data URL when given a screenshot", () => {
+    const out = buildUserContent("look", Buffer.from("PNGBYTES"));
+    assert.ok(Array.isArray(out));
+    const arr = out as Array<{ type: string; image_url?: { url: string } }>;
+    assert.equal(arr[0].type, "text");
+    assert.equal(arr[1].type, "image_url");
+    assert.match(arr[1].image_url!.url, /^data:image\/png;base64,/);
+  });
+});
+
+describe("parseChatCompletion", () => {
+  it("extracts content and token usage", () => {
+    const r = parseChatCompletion({
+      choices: [{ message: { content: "intentional-change" } }],
+      usage: { prompt_tokens: 12, completion_tokens: 3 },
+    });
+    assert.equal(r.content, "intentional-change");
+    assert.equal(r.promptTokens, 12);
+    assert.equal(r.completionTokens, 3);
+  });
+  it("is defensive about missing fields", () => {
+    const r = parseChatCompletion({});
+    assert.equal(r.content, "");
+    assert.equal(r.promptTokens, 0);
+    assert.equal(r.completionTokens, 0);
+  });
+});

--- a/packages/vlmkit-heal/src/openai-compat.ts
+++ b/packages/vlmkit-heal/src/openai-compat.ts
@@ -1,0 +1,65 @@
+import type { ModelTier } from "./types.ts";
+
+// Minimal OpenAI-compatible chat-completions client, used when a ModelTier sets
+// `baseURL` (e.g. a self-hosted ui-tars endpoint) — createUnifiedLLMClient in
+// @mizchi/vlmkit-ai does not take a baseURL, so we call the endpoint directly.
+
+export interface ChatUsage {
+  content: string;
+  promptTokens: number;
+  completionTokens: number;
+}
+
+type Block =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+/** Build an OpenAI `content` array from a text prompt + optional PNG screenshot. */
+export function buildUserContent(text: string, screenshotPng?: Buffer): string | Block[] {
+  if (!screenshotPng) return text;
+  return [
+    { type: "text", text },
+    { type: "image_url", image_url: { url: `data:image/png;base64,${screenshotPng.toString("base64")}` } },
+  ];
+}
+
+/** Parse an OpenAI chat-completions response into content + token usage. */
+export function parseChatCompletion(json: unknown): ChatUsage {
+  const j = json as {
+    choices?: Array<{ message?: { content?: string } }>;
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
+  };
+  return {
+    content: j.choices?.[0]?.message?.content ?? "",
+    promptTokens: j.usage?.prompt_tokens ?? 0,
+    completionTokens: j.usage?.completion_tokens ?? 0,
+  };
+}
+
+/** Call a tier's self-hosted OpenAI-compatible endpoint. `baseURL` is the API
+ * base (e.g. http://localhost:8000/v1); `/chat/completions` is appended. */
+export async function openAICompatComplete(opts: {
+  tier: ModelTier;
+  text: string;
+  screenshotPng?: Buffer;
+  maxTokens?: number;
+  apiKey?: string;
+}): Promise<ChatUsage> {
+  const { tier, text, screenshotPng, maxTokens = 1024, apiKey } = opts;
+  if (!tier.baseURL) throw new Error("openAICompatComplete requires tier.baseURL");
+  const url = `${tier.baseURL.replace(/\/$/, "")}/chat/completions`;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model: tier.model,
+      max_tokens: maxTokens,
+      messages: [{ role: "user", content: buildUserContent(text, screenshotPng) }],
+    }),
+  });
+  if (!res.ok) throw new Error(`${tier.baseURL} error: ${res.status} ${(await res.text()).slice(0, 200)}`);
+  return parseChatCompletion(await res.json());
+}


### PR DESCRIPTION
Follow-ups to #65.

## 1. Publishable
- Drop `private: true`, set `version: 0.1.0` so `@mizchi/vlmkit-heal` ships like its sibling packages.
- Add it to the root README (Features + Project Structure).

## 2. Self-hosted baseURL tiers
- `ModelTier.baseURL` is now honored: a tier with `baseURL` is called via a minimal OpenAI-compatible client (`openai-compat.ts`), so ui-tars / self-hosted models work in either axis. Auth via `VLMKIT_HEAL_BASEURL_KEY`. Resolves the clients.ts TODO.

## 3. `healAll` batch
- Heal a whole failing suite sequentially with an optional `totalBudgetUsd` cap across files (per-file budgets still apply); returns per-file results + `fixed` count.

## Tests
32 unit tests (6 new: openai-compat message/parse, healAll budget skip + aggregation). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)