### PR TITLE
feat(heal): auto-detect Playwright outputDir (test-results / e2e-results)

### DIFF
--- a/packages/vlmkit-heal/src/capture.test.ts
+++ b/packages/vlmkit-heal/src/capture.test.ts
@@ -24,4 +24,22 @@ describe("capture", () => {
     assert.equal(findActualScreenshot(empty), undefined);
     assert.equal(findErrorContext(empty), undefined);
   });
+
+  it("auto-detects a non-default outputDir (e.g. Playwright's e2e-results)", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "heal-cap-e2e-"));
+    const out = join(cwd, "e2e-results", "t-chromium");
+    mkdirSync(out, { recursive: true });
+    writeFileSync(join(out, "error-context.md"), '# Page snapshot\n- navigation "Map controls"');
+    // No outputDir arg: should still find it by trying common names.
+    assert.ok(findErrorContext(cwd)?.includes('"Map controls"'));
+  });
+
+  it("honors an explicit outputDir name", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "heal-cap-custom-"));
+    const out = join(cwd, "pw-out", "t-chromium");
+    mkdirSync(out, { recursive: true });
+    writeFileSync(join(out, "error-context.md"), "# Page snapshot\n- button");
+    assert.equal(findErrorContext(cwd), undefined); // not a known name
+    assert.ok(findErrorContext(cwd, "pw-out")?.includes("Page snapshot"));
+  });
 });

--- a/packages/vlmkit-heal/src/capture.ts
+++ b/packages/vlmkit-heal/src/capture.ts
@@ -1,15 +1,21 @@
 import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-// Playwright writes artifacts to an outputDir ("test-results") that is NOT
-// always <cwd>/test-results — depending on rootDir it can land in a parent.
-// So we search cwd and a couple of ancestors for a test-results dir.
-function testResultsRoots(cwd: string): string[] {
+// Playwright writes artifacts to an outputDir that is NOT always
+// <cwd>/test-results: the name is configurable (e.g. bacuri uses `e2e-results`)
+// and, depending on rootDir, it can land in a parent. So we search cwd and a few
+// ancestors for any of the common outputDir names (plus an explicit override).
+const DEFAULT_OUTPUT_DIRS = ["test-results", "e2e-results"];
+
+function resultRoots(cwd: string, outputDir?: string): string[] {
+  const names = outputDir ? [outputDir, ...DEFAULT_OUTPUT_DIRS] : DEFAULT_OUTPUT_DIRS;
   const roots: string[] = [];
   let dir = cwd;
   for (let i = 0; i < 3; i++) {
-    const candidate = join(dir, "test-results");
-    if (existsSync(candidate)) roots.push(candidate);
+    for (const name of names) {
+      const candidate = join(dir, name);
+      if (existsSync(candidate) && !roots.includes(candidate)) roots.push(candidate);
+    }
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -17,7 +23,7 @@ function testResultsRoots(cwd: string): string[] {
   return roots;
 }
 
-function newestMatching(cwd: string, endsWith: string): string | undefined {
+function newestMatching(cwd: string, endsWith: string, outputDir?: string): string | undefined {
   let best: { path: string; mtimeMs: number } | undefined;
   const walk = (dir: string): void => {
     let entries: string[];
@@ -35,22 +41,23 @@ function newestMatching(cwd: string, endsWith: string): string | undefined {
       }
     }
   };
-  for (const root of testResultsRoots(cwd)) walk(root);
+  for (const root of resultRoots(cwd, outputDir)) walk(root);
   return best?.path;
 }
 
 /** Newest Playwright `*-actual.png` (the screenshot from a failed toHaveScreenshot). */
-export function findActualScreenshot(cwd: string): Buffer | undefined {
-  const path = newestMatching(cwd, "-actual.png");
+export function findActualScreenshot(cwd: string, outputDir?: string): Buffer | undefined {
+  const path = newestMatching(cwd, "-actual.png", outputDir);
   return path ? readFileSync(path) : undefined;
 }
 
 /**
  * Newest Playwright `error-context.md` — contains a `# Page snapshot` aria tree
  * with the real accessible names/roles on the page. This is what lets codegen
- * fix a broken locator (it can see e.g. `button "Submit"`).
+ * fix a broken locator (it can see e.g. `button "Submit"`). Pass `outputDir` to
+ * target a custom Playwright outputDir name; otherwise common names are tried.
  */
-export function findErrorContext(cwd: string): string | undefined {
-  const path = newestMatching(cwd, "error-context.md");
+export function findErrorContext(cwd: string, outputDir?: string): string | undefined {
+  const path = newestMatching(cwd, "error-context.md", outputDir);
   return path ? readFileSync(path, "utf8") : undefined;
 }

--- a/packages/vlmkit-heal/src/heal.ts
+++ b/packages/vlmkit-heal/src/heal.ts
@@ -33,8 +33,8 @@ export async function heal(opts: HealOptions, deps?: Partial<HealDeps>): Promise
     codegen: deps?.codegen ?? createRealCodegenClient(),
     baselineAllow: deps?.baselineAllow,
     updateSnapshotsCommand: deps?.updateSnapshotsCommand,
-    captureActual: deps?.captureActual ?? (async (cwd) => findActualScreenshot(cwd)),
-    captureContext: deps?.captureContext ?? (async (cwd) => findErrorContext(cwd)),
+    captureActual: deps?.captureActual ?? (async (cwd) => findActualScreenshot(cwd, opts.outputDir)),
+    captureContext: deps?.captureContext ?? (async (cwd) => findErrorContext(cwd, opts.outputDir)),
   };
 
   let spent = 0;

--- a/packages/vlmkit-heal/src/types.ts
+++ b/packages/vlmkit-heal/src/types.ts
@@ -46,6 +46,8 @@ export interface HealOptions {
   /** Shared cap across BOTH routers; the summed cost exceeding it stops the loop. */
   budgetUsd: number;
   maxAttempts: number;
+  /** Playwright outputDir name to read artifacts from (default: auto — test-results / e2e-results). */
+  outputDir?: string;
   /** Consecutive "gate green but verify red" observations before reporting flaky. Default 2. */
   flakyThreshold?: number;
   /** Default false: the final green patch needs human approval before commit. */


### PR DESCRIPTION
The artifact finder assumed `test-results`, so heal missed projects with a custom Playwright `outputDir` (e.g. bacuri's `e2e-results`) and the observe/codegen tiers got no page snapshot. Now `resultRoots()` tries common outputDir names across cwd + ancestors, and `HealOptions.outputDir` overrides.

Verified end-to-end: `heal()` fixes a broken locator in a real repo (arkedge/bacuri, which uses `e2e-results`) with **no captureContext injection** — $0.000084, cheapest tier. 34 unit tests (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)