### PR TITLE
docs(heal): gpt-5 codegen example + any-provider driver note

### DIFF
--- a/.claude/skills/spec-to-playwright/SKILL.md
+++ b/.claude/skills/spec-to-playwright/SKILL.md
@@ -136,7 +136,7 @@ const r = await heal({
   // codegen = cheap coder first, escalate to a stronger model on repeated failure
   codegen: { tiers: [
     { provider: "openrouter", model: "qwen/qwen3-coder-30b-a3b-instruct", vision: false },
-    { provider: "openrouter", model: "openai/gpt-4o-mini", vision: false },
+    { provider: "openrouter", model: "openai/gpt-5-codex", vision: false },
   ]},
   budgetUsd: 1,            // shared cap; estimated from tokens × price for OpenRouter
   maxAttempts: 4,
@@ -151,6 +151,13 @@ code), and only commits a patch that verified green twice.
 
 **Do NOT use ui-tars for the observe judgment** — it is a GUI-grounding model and
 mislabels intentional changes as regressions. Use a cheap reasoning VLM.
+
+**Any provider/model drives a tier** — `provider` is `"openrouter" | "anthropic" |
+"gemini"`. Via OpenRouter you can name any model: `openai/gpt-5-codex`,
+`openai/gpt-5-mini`, `anthropic/claude-sonnet-4.6` (Claude as the driver),
+`qwen/qwen3-coder-30b-a3b-instruct`, etc. — all on one `OPENROUTER_API_KEY`.
+`provider: "anthropic"` / `"gemini"` hit those APIs directly (need their own key).
+`baseURL` on a tier points at any OpenAI-compatible endpoint (e.g. self-hosted).
 
 ## Pitfalls (lived in the reference repo)
 

--- a/packages/vlmkit-heal/README.md
+++ b/packages/vlmkit-heal/README.md
@@ -18,16 +18,23 @@ const result = await heal({
   testCommand: "pnpm exec playwright test login.spec.ts",
   testFile: "tests/login.spec.ts",     // the only source file the loop may edit
   cwd: process.cwd(),
-  observe: { tiers: [{ provider: "openrouter", model: "bytedance/ui-tars-72b", vision: true }] },
+  // observe = a cheap REASONING VLM (NOT ui-tars, which is GUI-grounding only)
+  observe: { tiers: [{ provider: "openrouter", model: "google/gemini-2.5-flash-lite", vision: true }] },
   codegen: { tiers: [
-    { provider: "gemini",    model: "gemini-2.0-flash-lite",   vision: false }, // cheap first
-    { provider: "anthropic", model: "claude-sonnet-4-20250514", vision: false }, // strong last
+    { provider: "openrouter", model: "qwen/qwen3-coder-30b-a3b-instruct", vision: false }, // cheap first
+    { provider: "openrouter", model: "openai/gpt-5-codex", vision: false },                // strong last
   ]},
   budgetUsd: 1.0,        // shared cap across both tiers; loop stops when summed cost exceeds it
   maxAttempts: 4,
 });
-// result.verdict: "fixed" | "regression" | "intentional-change" | "give-up"
+// result.verdict: "fixed" | "regression" | "intentional-change" | "flaky" | "give-up"
 ```
+
+Any provider/model drives a tier. Via OpenRouter (one `OPENROUTER_API_KEY`) you
+can name any model — `openai/gpt-5-codex`, `openai/gpt-5-mini`,
+`anthropic/claude-sonnet-4.6` (Claude as the driver), `qwen/qwen3-coder-30b-a3b-instruct`.
+`provider: "anthropic"` / `"gemini"` hit those APIs directly (own key); a tier's
+`baseURL` points at any OpenAI-compatible endpoint.
 
 Heal a whole failing suite with one cross-file budget:
 


### PR DESCRIPTION
Reflects verified usage: any provider/model can drive an observe/codegen tier.

- Examples now use `openai/gpt-5-codex` for the strong codegen tier (was gpt-4o-mini).
- README's stale observe tier fixed: ui-tars (GUI-grounding) -> a cheap reasoning VLM.
- Documents driver flexibility: OpenRouter model names (`openai/gpt-5-*`, `anthropic/claude-sonnet-4.6` = Claude as driver) on one key; `provider: anthropic|gemini` direct; tier `baseURL` for OpenAI-compatible endpoints.

Verified end-to-end against the heal fixture: Claude sonnet-4.6, gpt-5-codex, and gpt-5-mini each fixed a broken locator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)