### PR TITLE
fix(heal): catch collateral breakage in VRT review + recommend a capable review VLM

### DIFF
--- a/.claude/skills/spec-to-playwright/SKILL.md
+++ b/.claude/skills/spec-to-playwright/SKILL.md
@@ -132,7 +132,7 @@ const r = await heal({
   testFile: "tests/<topic>.spec.ts",
   cwd: process.cwd(),
   // observe = a cheap REASONING VLM that judges intentional-change vs regression
-  observe: { tiers: [{ provider: "openrouter", model: "google/gemini-2.5-flash-lite", vision: true }] },
+  observe: { tiers: [{ provider: "openrouter", model: "openai/gpt-5-mini", vision: true }] },
   // codegen = cheap coder first, escalate to a stronger model on repeated failure
   codegen: { tiers: [
     { provider: "openrouter", model: "qwen/qwen3-coder-30b-a3b-instruct", vision: false },

--- a/packages/vlmkit-heal/README.md
+++ b/packages/vlmkit-heal/README.md
@@ -19,7 +19,7 @@ const result = await heal({
   testFile: "tests/login.spec.ts",     // the only source file the loop may edit
   cwd: process.cwd(),
   // observe = a cheap REASONING VLM (NOT ui-tars, which is GUI-grounding only)
-  observe: { tiers: [{ provider: "openrouter", model: "google/gemini-2.5-flash-lite", vision: true }] },
+  observe: { tiers: [{ provider: "openrouter", model: "openai/gpt-5-mini", vision: true }] },
   codegen: { tiers: [
     { provider: "openrouter", model: "qwen/qwen3-coder-30b-a3b-instruct", vision: false }, // cheap first
     { provider: "openrouter", model: "openai/gpt-5-codex", vision: false },                // strong last
@@ -79,7 +79,7 @@ const { baseline, actual, diff } = findVrtArtifacts(cwd); // *-expected/-actual/
 const r = await reviewVrtDiff({
   baselinePng: baseline!, actualPng: actual!, diffPng: diff,
   expectedChange: "the status badge turns red",       // or omit and pass gitContext, or neither
-  tier: { provider: "openrouter", model: "google/gemini-2.5-flash-lite", vision: true },
+  tier: { provider: "openrouter", model: "openai/gpt-5-mini", vision: true },
 });
 // r: { verdict: "accept" | "reject" | "unsure", confidence: 0..1, reason, intentSource, costUsd }
 ```
@@ -87,6 +87,13 @@ const r = await reviewVrtDiff({
 Inside `heal`, this drives the VRT path: `accept` with `confidence >=
 acceptThreshold` (default 0.8) updates the baseline; `reject` → `regression`;
 `unsure` or a low-confidence accept → the `needs-review` verdict (a human decides).
+
+**Use a capable reasoning VLM for the review tier.** A wrong `accept` bakes a
+regression into the baseline, so the model must catch *collateral* breakage (the
+declared change happened, but something else also broke). Empirically a small VLM
+(gemini-2.5-flash-lite) misses this — it accepts with high confidence even when an
+unrelated heading disappeared, and a diff image doesn't help. `openai/gpt-5-mini`
+and `anthropic/claude-sonnet-4.6` catch it reliably and are still cheap; prefer those.
 
 ## Design
 

--- a/packages/vlmkit-heal/src/review.ts
+++ b/packages/vlmkit-heal/src/review.ts
@@ -51,8 +51,10 @@ export function buildReviewPrompt(intent: ResolvedIntent): string {
     intent.intentSource === "vision-only"
       ? "There is no declared intent — judge from the images alone and keep CONFIDENCE modest."
       : `Declared intended change (${intent.intentSource}):\n${intent.text}\n` +
-        "If the visual change matches this intent, lean accept; if it contradicts or adds " +
-        "unrelated breakage, lean reject.";
+        "Accept ONLY if the change matches this intent AND nothing else unexpected " +
+        "changed. If there is ANY additional or unrelated visual change beyond the " +
+        "declared one (e.g. a heading disappears, layout shifts, other text changes), " +
+        "that is collateral breakage — reject. List the unexpected change in REASON.";
   return head + intentLine;
 }
 


### PR DESCRIPTION
Found by adding more real VRT scenarios. With an explicit `expectedChange`, the judge confirmed the declared change and **ignored unrelated breakage** (a heading disappearing) → a false `accept` that would bake a regression into the baseline.

- Review prompt now requires: accept ONLY if the declared change happened AND nothing else unexpected changed; list collateral changes in REASON.
- Prompt alone isn't enough on a small VLM: `gemini-2.5-flash-lite` still accepts (conf 1.0), even with a diff image. `openai/gpt-5-mini` (conf 0.86) and `anthropic/claude-sonnet-4.6` (conf 0.95) reject correctly. So the observe/review model recommendation (SKILL.md + README) switches to `gpt-5-mini`, with the rationale documented.

42 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)