### PR TITLE
feat(heal): confirm VRT accept with strongest tier + CI review example

### DIFF
--- a/.claude/skills/spec-to-playwright/SKILL.md
+++ b/.claude/skills/spec-to-playwright/SKILL.md
@@ -143,7 +143,7 @@ const r = await heal({
   // expectedChange: "the badge turns red"  // declare for a VRT change; omit and a
   //                                          regression is reported, NOT baked into the baseline
 });
-// r.verdict: "fixed" | "regression" | "intentional-change" | "flaky" | "give-up"
+// r.verdict: "fixed" | "regression" | "needs-review" | "flaky" | "give-up"
 ```
 
 Needs `OPENROUTER_API_KEY`. Heal only edits the test file + baselines (never app
@@ -158,6 +158,40 @@ mislabels intentional changes as regressions. Use a cheap reasoning VLM.
 `qwen/qwen3-coder-30b-a3b-instruct`, etc. — all on one `OPENROUTER_API_KEY`.
 `provider: "anthropic"` / `"gemini"` hit those APIs directly (need their own key).
 `baseURL` on a tier points at any OpenAI-compatible endpoint (e.g. self-hosted).
+
+## VRT review in CI (accept / reject / needs-review)
+
+When a `toHaveScreenshot()` VRT fails in CI, a model can decide whether the change
+is **intended** (accept → refresh the baseline) or a **regression** (reject). Two
+assets wire this up:
+
+- `assets/vrt-review.mjs` → repo root. Reads the failing VRT artifacts
+  (`findVrtArtifacts`), infers intent from the commit + diff (`collectGitContext`)
+  or `EXPECTED_CHANGE`, and calls `reviewVrtDiff`. accept (≥0.8) → runs
+  `--update-snapshots` and exits 0; reject / unsure → exits 1.
+- `assets/vrt-review-ci.yml` → `.github/workflows/vrt-review.yml`. Runs the VRT
+  with `continue-on-error`, then `node vrt-review.mjs` on failure, then commits the
+  refreshed baselines back to the PR branch on accept (`permissions: contents: write`).
+  Needs an `OPENROUTER_API_KEY` secret.
+
+```js
+import { findVrtArtifacts, reviewVrtDiff, collectGitContext } from "@mizchi/vlmkit-heal";
+const { baseline, actual, diff } = findVrtArtifacts(process.cwd());
+const review = await reviewVrtDiff({
+  baselinePng: baseline, actualPng: actual, diffPng: diff,
+  gitContext: collectGitContext(process.cwd(), { base: "origin/main" }),
+  tier: { provider: "openrouter", model: "openai/gpt-5-mini", vision: true },
+});
+// review.verdict: "accept" | "reject" | "unsure"
+```
+
+**Use a CAPABLE reasoning VLM for the review tier** (e.g. `gpt-5-mini`, not a tiny
+VLM). Cheap VLMs accept a diff with high confidence while missing *collateral*
+breakage elsewhere on the page. Inside the heal loop the same risk is guarded by
+`confirmAccept` (default `true`): an accept is re-checked by the **strongest**
+`observe` tier before the baseline is touched; if it disagrees the verdict becomes
+`needs-review` instead of silently updating. Set `confirmAccept: false` to skip the
+second opinion (single-tier ladders skip it automatically).
 
 ## Pitfalls (lived in the reference repo)
 

--- a/.claude/skills/spec-to-playwright/assets/vrt-review-ci.yml
+++ b/.claude/skills/spec-to-playwright/assets/vrt-review-ci.yml
@@ -1,0 +1,54 @@
+# CI that runs VRT and, on failure, has a model decide accept/reject/needs-review.
+# accept  -> baselines updated in the CI env and committed back to the PR branch
+# reject  -> job fails (regression)
+# needs-review -> job fails with a warning (a human decides)
+#
+# Requires: `@mizchi/vlmkit-heal` as a devDep, `assets/vrt-review.mjs` in the repo,
+# and an OPENROUTER_API_KEY repo secret.
+name: vrt-review
+on: [pull_request]
+
+jobs:
+  vrt:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # to commit accepted baselines back to the PR branch
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - id: vrt
+        run: pnpm exec playwright test
+        continue-on-error: true   # let the review step interpret a VRT failure
+
+      - name: Review VRT failure with a model
+        if: steps.vrt.outcome == 'failure'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node vrt-review.mjs   # exits 0 on accept (snapshots updated), 1 on reject/needs-review
+
+      - name: Commit accepted baselines
+        # only reached when the review step exited 0 (accept) and changed snapshots
+        if: steps.vrt.outcome == 'failure'
+        run: |
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "test: update VRT baselines (model-reviewed) [skip ci]"
+            git push
+          fi
+
+      - name: Pass through a real VRT pass
+        if: steps.vrt.outcome == 'success'
+        run: echo "VRT green"

--- a/.claude/skills/spec-to-playwright/assets/vrt-review.mjs
+++ b/.claude/skills/spec-to-playwright/assets/vrt-review.mjs
@@ -1,0 +1,42 @@
+// CI: when a Playwright VRT (toHaveScreenshot) fails, let a model decide whether
+// the change is intended (accept -> update baselines) or a regression (reject).
+// Requires `@mizchi/vlmkit-heal` (devDep) and an OPENROUTER_API_KEY secret.
+//   node vrt-review.mjs
+import { execSync } from "node:child_process";
+import { findVrtArtifacts, reviewVrtDiff, collectGitContext } from "@mizchi/vlmkit-heal";
+
+const cwd = process.cwd();
+const { baseline, actual, diff } = findVrtArtifacts(cwd);
+if (!baseline || !actual) {
+  console.log("no VRT artifacts found; nothing to review");
+  process.exit(0);
+}
+
+const review = await reviewVrtDiff({
+  baselinePng: baseline,
+  actualPng: actual,
+  diffPng: diff,
+  // optional explicit intent (e.g. from the PR description); else inferred from git
+  expectedChange: process.env.EXPECTED_CHANGE,
+  gitContext: collectGitContext(cwd, {
+    base: process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : undefined,
+  }),
+  // Use a CAPABLE reasoning VLM — small VLMs miss collateral breakage.
+  tier: { provider: "openrouter", model: "openai/gpt-5-mini", vision: true },
+});
+
+console.log(`VRT review: ${review.verdict} (confidence ${review.confidence}, via ${review.intentSource})`);
+console.log(`reason: ${review.reason}`);
+
+if (review.verdict === "accept" && review.confidence >= 0.8) {
+  // Intended change: refresh the baselines here; a later workflow step commits them.
+  execSync("pnpm exec playwright test --update-snapshots", { stdio: "inherit" });
+  console.log("::notice::Intended change accepted — baselines updated.");
+  process.exit(0);
+}
+if (review.verdict === "reject") {
+  console.log("::error::VRT regression — the model rejected the change.");
+  process.exit(1);
+}
+console.log("::warning::VRT change needs human review (unsure / low confidence).");
+process.exit(1);

--- a/packages/vlmkit-heal/src/heal.test.ts
+++ b/packages/vlmkit-heal/src/heal.test.ts
@@ -122,6 +122,71 @@ describe("heal", () => {
     assert.equal(result.verdict, "needs-review");
   });
 
+  it("downgrades an accept to needs-review when the strong observe tier disagrees (confirmAccept)", async () => {
+    const testFile = tmpTestFile();
+    const opts: HealOptions = {
+      ...baseOpts(testFile),
+      observe: { tiers: [
+        { provider: "openrouter", model: "cheap", vision: true },
+        { provider: "openrouter", model: "strong", vision: true },
+      ]},
+    };
+    let strongCalled = false;
+    const result = await heal(opts, {
+      runTest: async () => ({ ok: false, stdout: "", stderr: "Error: Screenshot comparison failed" }),
+      captureVrt: async () => ({ baseline: Buffer.from("B"), actual: Buffer.from("A") }),
+      reviewVrt: async ({ tier }) => {
+        if (tier.model === "strong") {
+          strongCalled = true;
+          return { verdict: "reject", confidence: 0.9, reason: "collateral breakage", intentSource: "expectedChange", costUsd: 0.001 };
+        }
+        return { verdict: "accept", confidence: 0.99, reason: "looks intended", intentSource: "expectedChange", costUsd: 0.0001 };
+      },
+      codegen: { propose: async () => { throw new Error("codegen must NOT run on the VRT path"); } },
+    });
+    assert.equal(result.verdict, "needs-review");
+    assert.equal(strongCalled, true, "the strong tier must confirm an accept");
+  });
+
+  it("accepts and updates the baseline when both tiers accept (verdict=fixed)", async () => {
+    const testFile = tmpTestFile();
+    const opts: HealOptions = {
+      ...baseOpts(testFile),
+      observe: { tiers: [
+        { provider: "openrouter", model: "cheap", vision: true },
+        { provider: "openrouter", model: "strong", vision: true },
+      ]},
+    };
+    const m = failThenOk("Error: Screenshot comparison failed");
+    const result = await heal(opts, {
+      runTest: m.runTest,
+      updateSnapshotsCommand: "noop --update-snapshots",
+      captureVrt: async () => ({ baseline: Buffer.from("B"), actual: Buffer.from("A") }),
+      reviewVrt: async () => ({ verdict: "accept", confidence: 0.95, reason: "intended", intentSource: "expectedChange", costUsd: 0.0001 }),
+      codegen: { propose: async () => { throw new Error("codegen must NOT run on the accept path"); } },
+    });
+    assert.equal(result.verdict, "fixed");
+    assert.equal(result.finalPatch, "baseline-update");
+  });
+
+  it("skips confirmation when confirmAccept is false (single review accepts -> fixed)", async () => {
+    const testFile = tmpTestFile();
+    const m = failThenOk("Error: Screenshot comparison failed");
+    let reviewCalls = 0;
+    const result = await heal(
+      { ...baseOpts(testFile), confirmAccept: false },
+      {
+        runTest: m.runTest,
+        updateSnapshotsCommand: "noop --update-snapshots",
+        captureVrt: async () => ({ baseline: Buffer.from("B"), actual: Buffer.from("A") }),
+        reviewVrt: async () => { reviewCalls++; return { verdict: "accept", confidence: 0.95, reason: "ok", intentSource: "expectedChange", costUsd: 0.0001 }; },
+        codegen: { propose: async () => { throw new Error("codegen must NOT run"); } },
+      },
+    );
+    assert.equal(result.verdict, "fixed");
+    assert.equal(reviewCalls, 1, "no confirmation review when confirmAccept is false");
+  });
+
   it("reports flaky (not fixed, no patch) when verify intermittently fails", async () => {
     const testFile = tmpTestFile("// ORIGINAL\n");
     // pattern per iteration: gate=ok, v1=ok, v2=FAIL -> flaky signal each round

--- a/packages/vlmkit-heal/src/heal.ts
+++ b/packages/vlmkit-heal/src/heal.ts
@@ -39,6 +39,7 @@ export async function heal(opts: HealOptions, deps?: Partial<HealDeps>): Promise
     captureContext: deps?.captureContext ?? (async (cwd) => findErrorContext(cwd, opts.outputDir)),
   };
   const acceptThreshold = opts.acceptThreshold ?? 0.8;
+  const confirmAccept = opts.confirmAccept ?? true;
 
   let spent = 0;
   const budget: Budget = { budgetUsd: opts.budgetUsd, add: (n) => (spent += n), total: () => spent };
@@ -109,8 +110,30 @@ export async function heal(opts: HealOptions, deps?: Partial<HealDeps>): Promise
         attempts.push({ tier, phase: "observe", costUsd: review.costUsd, errorKind });
 
         if (review.verdict === "reject") return done("regression");
-        if (review.verdict === "accept" && review.confidence >= acceptThreshold) {
-          // Intended change with enough confidence -> refresh the baseline, then verify.
+
+        const accepted = review.verdict === "accept" && review.confidence >= acceptThreshold;
+        if (accepted) {
+          // An accept auto-updates the baseline, so a confidently-wrong accept (cheap
+          // VLMs miss collateral breakage) is the dangerous case. Asymmetrically
+          // confirm it with the STRONGEST observe tier before trusting it.
+          const strong = opts.observe.tiers[opts.observe.tiers.length - 1];
+          if (confirmAccept && strong && strong.model !== tier.model) {
+            const confirm = await d.reviewVrt({
+              baselinePng: art.baseline,
+              actualPng: art.actual,
+              diffPng: art.diff,
+              expectedChange: opts.expectedChange,
+              gitContext: opts.gitContext,
+              tier: strong,
+            });
+            observeRouter.record({ costUsd: confirm.costUsd });
+            attempts.push({ tier: strong, phase: "observe", costUsd: confirm.costUsd, errorKind });
+            if (!(confirm.verdict === "accept" && confirm.confidence >= acceptThreshold)) {
+              // The strong model disagrees -> don't bake it in; a human decides.
+              return done("needs-review");
+            }
+          }
+          // Intended change, confirmed -> refresh the baseline, then verify.
           const cmd = d.updateSnapshotsCommand ?? `${opts.testCommand} --update-snapshots`;
           await d.runTest(cmd, opts.cwd);
           finalPatch = "baseline-update";

--- a/packages/vlmkit-heal/src/types.ts
+++ b/packages/vlmkit-heal/src/types.ts
@@ -50,6 +50,8 @@ export interface HealOptions {
   outputDir?: string;
   /** Min confidence to auto-accept a VRT change (update the baseline). Below it -> needs-review. Default 0.8. */
   acceptThreshold?: number;
+  /** Confirm a VRT accept with the strongest observe tier before updating the baseline. Default true. */
+  confirmAccept?: boolean;
   /** Optional intent signal for VRT review (commit msg + code diff). See collectGitContext. */
   gitContext?: string;
   /** Consecutive "gate green but verify red" observations before reporting flaky. Default 2. */


### PR DESCRIPTION
## What

Strengthens the VRT accept gate and adds a working CI integration for the `spec-to-playwright` skill.

### Accept gate (`confirmAccept`, default `true`)
An accept auto-updates the baseline, so a *confidently-wrong* accept is the dangerous case — cheap VLMs accept a diff with high confidence while missing collateral breakage elsewhere on the page. The loop now asymmetrically re-checks an accept with the **strongest** `observe` tier before touching the baseline. If the strong tier doesn't also accept (≥ `acceptThreshold`), the verdict becomes `needs-review` instead of silently updating. Single-tier ladders skip the second opinion automatically; `confirmAccept: false` opts out.

### CI review example
- `assets/vrt-review.mjs` — `findVrtArtifacts` + `reviewVrtDiff` + `collectGitContext`; accept (≥0.8) → `--update-snapshots` + exit 0, reject/unsure → exit 1.
- `assets/vrt-review-ci.yml` — runs VRT with `continue-on-error`, reviews on failure, commits accepted baselines back to the PR branch (`permissions: contents: write`, needs `OPENROUTER_API_KEY`).

## Tests
`node --test` green (3 new `confirmAccept` cases: downgrade-to-needs-review when the strong tier disagrees; both-accept → fixed; `confirmAccept:false` skips confirmation). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)