### PR TITLE
chore(heal): bump @mizchi/vlmkit-heal to 0.2.0

### DIFF
--- a/packages/vlmkit-heal/package.json
+++ b/packages/vlmkit-heal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-heal",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cost-optimized self-healing loop for Playwright tests — escalates from cheap to strong models, edits tests/baselines, re-verifies.",
   "license": "MIT",
   "author": "mizchi",


### PR DESCRIPTION
Records the published version bump.

`@mizchi/vlmkit-heal@0.2.0` is live on npm. Over 0.1.0 it adds:
- `reviewVrtDiff` / `findVrtArtifacts` / `collectGitContext` — VRT review building blocks (used by the `spec-to-playwright` CI example)
- `confirmAccept` gate — a VRT accept is re-checked by the strongest observe tier before the baseline is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)