### PR TITLE
fix(heal): republish 0.2.1 with resolved workspace deps

### DIFF
--- a/packages/vlmkit-heal/package.json
+++ b/packages/vlmkit-heal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-heal",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Cost-optimized self-healing loop for Playwright tests — escalates from cheap to strong models, edits tests/baselines, re-verifies.",
   "license": "MIT",
   "author": "mizchi",


### PR DESCRIPTION
`@mizchi/vlmkit-heal@0.2.0` was published with `pnpm --filter ... publish`, which did **not** rewrite the `workspace:*` protocol in its dependencies — so the published package was uninstallable from npm (`ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`).

0.2.1 is republished from the package directory (`cd packages/vlmkit-heal && pnpm publish`), which rewrites them to `0.6.0`. Verified on the registry. 0.2.0 is deprecated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)