### PR TITLE
fix: calibrate selector-heal reporting tiers

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -864,3 +864,11 @@ tokens 列を必ず含め、この節のベースライン表に 1 行追記す�
 `vlmkit verify markup`(verdict + 校正フロア + 全残差キックバック)に
 一本化 — 検証者ツーリングの詳細と S6 の結果は
 `docs/reports/2026-07-28-verifier-tooling-and-s6.md`。
+
+### Selector-heal calibration (2026-07-30)
+
+`vrt interact --heal-all` labels **strong** suggestions at confidence `>= 0.40`
+and **weak** ones at `>= 0.15`. These are precision-first thresholds: a
+fixture-derived corpus found that the former 0.30 strong cutoff promoted a
+wrong sibling. The corpus, exact scores, and reproduction command are in
+[`docs/reports/2026-07-30-selector-heal-calibration.md`](reports/2026-07-30-selector-heal-calibration.md).

--- a/docs/reports/2026-07-30-selector-heal-calibration.md
+++ b/docs/reports/2026-07-30-selector-heal-calibration.md
@@ -1,0 +1,46 @@
+# Selector-heal tier calibration (2026-07-30)
+
+Issue #14 calibrates the report labels used by `vrt interact --heal-all`; it
+does not change the selector-healing algorithm.
+
+## Corpus
+
+[`data/2026-07-30-selector-heal-calibration.json`](data/2026-07-30-selector-heal-calibration.json)
+contains 23 labeled, deterministic selector failures exercised against the
+repository's real `fixtures/interact/{heal-all-demo,dropdown-form,form-validation}`
+pages. Each record retains the intended repair, the actual top candidate, and
+its measured confidence. The executable regression test re-runs every case.
+
+| confidence band | cases | result |
+|---|---:|---|
+| >= 0.40 | 6 | 6/6 true positives |
+| 0.15–0.40 | 12 | mixed; informational only |
+| < 0.15 | 5 | suppress; includes low-signal true repairs and noise |
+
+Notably, the old 0.30 strong cutoff would have promoted a 0.325 false positive:
+`button.btn-seconday` incorrectly suggested `button.btn-primary` rather than
+`button.btn-secondary`. The lower weak cutoff of 0.10 also showed 0.10–0.13
+noise, so it is raised to 0.15.
+
+## Decision
+
+| tier | old | calibrated | meaning |
+|---|---:|---:|---|
+| strong | >= 0.30 | **>= 0.40** | actionable `did you mean` |
+| weak | >= 0.10 | **>= 0.15 and < 0.40** | informational `weak match` |
+| none | < 0.10 | **< 0.15** | suppressed |
+
+The strong tier is precision-first: it must not make a wrong-sibling suggestion
+look actionable. This corpus is fixture-derived rather than a production
+telemetry sample, so new real interaction failures should be appended before
+relaxing the cutoff.
+
+## Validation
+
+```bash
+pnpm --filter @mizchi/vlmkit-markup test
+```
+
+The calibration test loads all corpus fixtures in Chromium and checks both the
+recorded top candidate and the exact confidence, making score changes visible
+in CI.

--- a/docs/reports/data/2026-07-30-selector-heal-calibration.json
+++ b/docs/reports/data/2026-07-30-selector-heal-calibration.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "collectedAt": "2026-07-30",
+  "description": "Labeled selector-healer failures measured against repository interact fixtures. expectedSelector is the intended repair; actualSelector is the top result returned by healSelector.",
+  "cases": [
+    {"fixture":"heal-all-demo/page.html","brokenSelector":"button.btn-prmary","expectedSelector":"button.btn-primary","actualSelector":"button.btn-primary","confidence":0.325,"label":"true-positive"},
+    {"fixture":"heal-all-demo/page.html","brokenSelector":"button.btn-primar","expectedSelector":"button.btn-primary","actualSelector":"button.btn-primary","confidence":0.475,"label":"true-positive"},
+    {"fixture":"heal-all-demo/page.html","brokenSelector":"button.btn-seconday","expectedSelector":"button.btn-secondary","actualSelector":"button.btn-primary","confidence":0.325,"label":"false-positive"},
+    {"fixture":"heal-all-demo/page.html","brokenSelector":"button.btn-secondar","expectedSelector":"button.btn-secondary","actualSelector":"button.btn-secondary","confidence":0.475,"label":"true-positive"},
+    {"fixture":"heal-all-demo/page.html","brokenSelector":".btn-prmary","expectedSelector":"button.btn-primary","actualSelector":"button.btn-primary","confidence":0.125,"label":"true-positive"},
+    {"fixture":"heal-all-demo/page.html","brokenSelector":".btn-seconday","expectedSelector":"button.btn-secondary","actualSelector":"button.btn-primary","confidence":0.125,"label":"false-positive"},
+    {"fixture":"heal-all-demo/page.html","brokenSelector":"button:has-text(\"Savee\")","expectedSelector":"button.btn-primary","actualSelector":"button.btn-primary","confidence":0.2,"label":"true-positive"},
+    {"fixture":"heal-all-demo/page.html","brokenSelector":"button:has-text(\"Cance\")","expectedSelector":"button.btn-secondary","actualSelector":"button.btn-secondary","confidence":0.5,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":"button.dropdown-triger","expectedSelector":"button.dropdown-trigger","actualSelector":"button.dropdown-trigger","confidence":0.2833333333333333,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":".dropdown-triger","expectedSelector":"button.dropdown-trigger","actualSelector":"button.dropdown-trigger","confidence":0.08333333333333333,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":"button:has-text(\"Region: United State\")","expectedSelector":"button.dropdown-trigger","actualSelector":"button.dropdown-trigger","confidence":0.6666666666666667,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":"input#emali","expectedSelector":"#email","actualSelector":"#email","confidence":0.2,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":"input#emal","expectedSelector":"#email","actualSelector":"#email","confidence":0.2,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":".submit-bt","expectedSelector":"button.submit-btn","actualSelector":"button.submit-btn","confidence":0.275,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":"button.submit-bt","expectedSelector":"button.submit-btn","actualSelector":"button.submit-btn","confidence":0.475,"label":"true-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":"button:has-text(\"Svae\")","expectedSelector":"button.submit-btn","actualSelector":"button.dropdown-trigger","confidence":0.2,"label":"false-positive"},
+    {"fixture":"dropdown-form/page.html","brokenSelector":".dropdown-trig","expectedSelector":"button.dropdown-trigger","actualSelector":"button.dropdown-trigger","confidence":0.23333333333333334,"label":"true-positive"},
+    {"fixture":"form-validation/page.html","brokenSelector":"input#emali","expectedSelector":"#email","actualSelector":"#email","confidence":0.2,"label":"true-positive"},
+    {"fixture":"form-validation/page.html","brokenSelector":"input#passwrod","expectedSelector":"#password","actualSelector":"#email","confidence":0.2,"label":"false-positive"},
+    {"fixture":"form-validation/page.html","brokenSelector":"button.submit-bt","expectedSelector":"#submit","actualSelector":"#submit","confidence":0.45000000000000007,"label":"true-positive"},
+    {"fixture":"form-validation/page.html","brokenSelector":"button:has-text(\"Create acount\")","expectedSelector":"#submit","actualSelector":"#submit","confidence":0.30000000000000004,"label":"true-positive"},
+    {"fixture":"form-validation/page.html","brokenSelector":".error-ms","expectedSelector":null,"actualSelector":null,"confidence":0,"label":"true-negative"},
+    {"fixture":"form-validation/page.html","brokenSelector":"#email-fiel","expectedSelector":"#email","actualSelector":"#email","confidence":0.1,"label":"true-positive"}
+  ]
+}

--- a/packages/vlmkit-markup/src/inspect/interact.ts
+++ b/packages/vlmkit-markup/src/inspect/interact.ts
@@ -43,6 +43,7 @@ import { healSelector } from "../heal/selector-heal.ts";
 import type { VrtSnapshot } from "@mizchi/vlmkit-core/types.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
+import { classifyHealTier } from "./selector-heal-calibration.ts";
 
 export type SequenceAction =
   | { action: "snapshot"; name: string }
@@ -291,16 +292,13 @@ export async function runInteract(options: InteractOptions): Promise<InteractRep
               maxCandidates: 1,
               exclude: successSelector,
             });
-            // Tiering: 0.3+ is "did you mean" (strong, actionable);
-            // 0.1-0.3 is "weak match" (sibling-button-style overlap
-            // that's worth eyeballing but not an obvious typo).
-            // Dogfood (2026-05-15) flagged 13% as noise when labelled
-            // "did you mean", hence the split. Healer's internal
-            // floor stays at 0.05; we ignore the 0.05-0.1 band here.
+            // The corpus-calibrated strong tier is deliberately conservative:
+            // a 30% suggestion selected the wrong sibling. See docs/knowledge.md.
             const top = candidates[0];
-            if (top && top.confidence >= 0.1) {
-              const tier: "strong" | "weak" = top.confidence >= 0.3 ? "strong" : "weak";
-              healAllFindings.push({
+            if (top) {
+              const tier = classifyHealTier(top.confidence);
+              if (tier !== "none") {
+                healAllFindings.push({
                 stepIndex,
                 action: step,
                 originalSelector: successSelector,
@@ -308,7 +306,8 @@ export async function runInteract(options: InteractOptions): Promise<InteractRep
                 suggestion: { selector: top.selector, confidence: top.confidence, text: top.text },
               });
               const label = tier === "strong" ? `${YELLOW}did you mean${RESET}` : `${DIM}weak match${RESET}`;
-              console.log(`    ${label} ${DIM}\`${top.selector}\`${RESET} ${DIM}(${(top.confidence * 100).toFixed(0)}% confidence${top.text ? `, "${top.text}"` : ""})${RESET}`);
+                console.log(`    ${label} ${DIM}\`${top.selector}\`${RESET} ${DIM}(${(top.confidence * 100).toFixed(0)}% confidence${top.text ? `, "${top.text}"` : ""})${RESET}`);
+              }
             }
           } catch { /* healer failure is non-fatal */ }
         }

--- a/packages/vlmkit-markup/src/inspect/selector-heal-calibration.test.ts
+++ b/packages/vlmkit-markup/src/inspect/selector-heal-calibration.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { test } from "node:test";
+import { chromium } from "playwright";
+import { healSelector } from "../heal/selector-heal.ts";
+import {
+  classifyHealTier,
+  STRONG_HEAL_THRESHOLD,
+  WEAK_HEAL_THRESHOLD,
+} from "./selector-heal-calibration.ts";
+
+type CalibrationCase = {
+  fixture: string;
+  brokenSelector: string;
+  expectedSelector: string | null;
+  actualSelector: string | null;
+  confidence: number;
+  label: "true-positive" | "false-positive" | "true-negative";
+};
+
+const root = resolve(process.cwd(), "../..");
+const corpusPath = resolve(root, "docs/reports/data/2026-07-30-selector-heal-calibration.json");
+
+test("selector-heal calibration corpus has 20+ labeled real fixture cases", async () => {
+  const corpus = JSON.parse(await readFile(corpusPath, "utf8")) as { cases: CalibrationCase[] };
+  assert.ok(corpus.cases.length >= 20);
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    for (const entry of corpus.cases) {
+      await page.goto(`file://${resolve(root, "fixtures/interact", entry.fixture)}`);
+      const actual = (await healSelector(page, entry.brokenSelector, { maxCandidates: 1 }))[0];
+      assert.equal(actual?.selector ?? null, entry.actualSelector, entry.brokenSelector);
+      assert.ok(Math.abs((actual?.confidence ?? 0) - entry.confidence) < 1e-9, entry.brokenSelector);
+      assert.equal(entry.actualSelector === entry.expectedSelector, entry.label !== "false-positive", entry.brokenSelector);
+    }
+    await page.close();
+  } finally {
+    await browser.close();
+  }
+});
+
+test("calibrated tiers suppress the measured 10-13% noise and keep strong precision", () => {
+  assert.equal(STRONG_HEAL_THRESHOLD, 0.4);
+  assert.equal(WEAK_HEAL_THRESHOLD, 0.15);
+  assert.equal(classifyHealTier(0.4), "strong");
+  assert.equal(classifyHealTier(0.325), "weak"); // wrong sibling in corpus
+  assert.equal(classifyHealTier(0.125), "none");
+});

--- a/packages/vlmkit-markup/src/inspect/selector-heal-calibration.ts
+++ b/packages/vlmkit-markup/src/inspect/selector-heal-calibration.ts
@@ -1,0 +1,16 @@
+/** Empirically calibrated reporting thresholds for `vrt interact --heal-all`.
+ *
+ * See docs/reports/data/2026-07-30-selector-heal-calibration.json.
+ * The strong cutoff intentionally favours precision: the corpus has no false
+ * positives at >= 0.40, while 0.30 admitted an incorrect sibling suggestion.
+ */
+export const STRONG_HEAL_THRESHOLD = 0.4;
+export const WEAK_HEAL_THRESHOLD = 0.15;
+
+export type HealTier = "strong" | "weak" | "none";
+
+export function classifyHealTier(confidence: number): HealTier {
+  if (confidence >= STRONG_HEAL_THRESHOLD) return "strong";
+  if (confidence >= WEAK_HEAL_THRESHOLD) return "weak";
+  return "none";
+}


### PR DESCRIPTION
## Summary
- add a reproducible 23-case selector-heal calibration corpus from `fixtures/interact`
- raise strong threshold from 0.30 to 0.40 and weak threshold from 0.10 to 0.15 to avoid measured wrong-sibling suggestions
- document the calibration and make every recorded score a Chromium regression test

## Validation
- `pnpm --filter @mizchi/vlmkit-markup test` (424 passed)

Closes #14