### PR TITLE
fix: close cold-start dogfood pass

### DIFF
--- a/docs/reports/2026-07-30-cold-start-dogfood.md
+++ b/docs/reports/2026-07-30-cold-start-dogfood.md
@@ -1,0 +1,65 @@
+# Cold-start dogfood
+
+**Date:** 2026-07-30  
+**Method:** independent fresh-context pass against `main`, starting with CLI help
+and without context about recent changes.
+
+The pass used `vlmkit --help`, `--version`, `snapshot --help`, and `diff html
+--help`, then attempted a static-HTML comparison. Findings are recorded below
+rather than inferred from the recent change list.
+
+## A. CLI discovery and navigation
+
+**Finding — stale version string (minor):** `vlmkit --version` printed
+`vlmkit/0.6.0`, while the root package manifest is `0.7.0`.
+
+**Disposition — fixed in this session:** the CLI now reports `0.7.0`, with a
+CLI regression test. This is a straightforward release-metadata correction.
+
+The top-level help is long because it retains deprecated aliases. The grouped
+canonical commands appear first and are usable; no change is made in this pass.
+
+## B. First representative task
+
+The pass selected a local static HTML comparison (`vlmkit diff html`) after
+reading its help. The command shape and output-directory option were clear.
+
+The independent execution environment could not launch Playwright and printed
+a Chromium environment error. That is an environment-provisioning failure, not
+a reproducible repository defect: the markup test suite launches Chromium
+successfully in this checkout. The report does not attribute a product bug or
+source fix to that observation.
+
+**Disposition — won't fix:** browser installation/provisioning belongs to the
+consumer environment. The existing README installation and quick-start steps
+are the appropriate guidance; no unverified workaround is added.
+
+## C. First-time task guidance
+
+The initial pass looked for an example server before recognizing that `diff
+html` accepts files directly. The README already demonstrates this direct-file
+workflow and includes a runnable command. The repository also contains fixture
+HTML under `fixtures/`.
+
+**Disposition — won't fix:** this is a discovery cost, not an absence of a
+supported path. Adding a built-in development server would be unrelated scope
+for a visual-regression CLI.
+
+## D. Follow-up accounting
+
+| friction point | disposition |
+|---|---|
+| CLI/package version mismatch | fixed: `0.7.0` plus regression test |
+| Chromium launch failure in isolated dogfood environment | won't fix: not reproducible as a repository failure |
+| initially missed direct-file comparison path | won't fix: README already documents it |
+| long command list with deprecated aliases | won't fix: compatibility aliases remain intentionally visible |
+
+## Validation
+
+```bash
+node --test src/cli/cli.test.ts
+pnpm --filter @mizchi/vlmkit-markup test
+```
+
+The first validates the version output. The second independently confirms the
+checkout can launch Chromium for browser-backed tests.

--- a/packages/vlmkit-markup/src/inspect/selector-heal-calibration.test.ts
+++ b/packages/vlmkit-markup/src/inspect/selector-heal-calibration.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import { chromium } from "playwright";
 import { healSelector } from "../heal/selector-heal.ts";
@@ -19,8 +19,7 @@ type CalibrationCase = {
   label: "true-positive" | "false-positive" | "true-negative";
 };
 
-const root = resolve(process.cwd(), "../..");
-const corpusPath = resolve(root, "docs/reports/data/2026-07-30-selector-heal-calibration.json");
+const corpusPath = fileURLToPath(new URL("../../../../docs/reports/data/2026-07-30-selector-heal-calibration.json", import.meta.url));
 
 test("selector-heal calibration corpus has 20+ labeled real fixture cases", async () => {
   const corpus = JSON.parse(await readFile(corpusPath, "utf8")) as { cases: CalibrationCase[] };
@@ -30,7 +29,7 @@ test("selector-heal calibration corpus has 20+ labeled real fixture cases", asyn
   try {
     const page = await browser.newPage();
     for (const entry of corpus.cases) {
-      await page.goto(`file://${resolve(root, "fixtures/interact", entry.fixture)}`);
+      await page.goto(`file://${fileURLToPath(new URL(`../../../../fixtures/interact/${entry.fixture}`, import.meta.url))}`);
       const actual = (await healSelector(page, entry.brokenSelector, { maxCandidates: 1 }))[0];
       assert.equal(actual?.selector ?? null, entry.actualSelector, entry.brokenSelector);
       assert.ok(Math.abs((actual?.confidence ?? 0) - entry.confidence) < 1e-9, entry.brokenSelector);

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -24,6 +24,12 @@ function runVrt(args: string[]): { stdout: string; stderr: string; status: numbe
 }
 
 describe("vrt CLI tree (cac-based)", () => {
+  it("`vrt --version` matches the package release", () => {
+    const r = runVrt(["--version"]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /vlmkit\/0\.7\.0/);
+  });
+
   it("`vrt --help` prints top-level usage", () => {
     const r = runVrt(["--help"]);
     assert.equal(r.status, 0);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -343,7 +343,7 @@ async function runGroupLeaf(
 
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
   const cli = cac("vlmkit");
-  cli.version("0.6.0");
+  cli.version("0.7.0");
 
   cli.usage(`<command> [options]
 


### PR DESCRIPTION
## Summary
- record an independent fresh-context cold-start dogfood pass
- sync `vlmkit --version` with package version 0.7.0 and add regression coverage
- account for every observed friction point with a fix or explicit rationale

## Validation
- `node --test src/cli/cli.test.ts` (28 passed)

Closes #16