### PR TITLE
0.9.0: gates that were confidently wrong, and the vrt → vlmkit rename

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -140,23 +140,23 @@ pkf run migration-tailwind
 pkf run migration-reset
 
 # File comparison
-vrt compare before.html after.html
+vlmkit diff html before.html after.html
 
 # URL comparison
-vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/
+vlmkit diff html --url http://localhost:3000/ --current-url http://localhost:8080/
 
 # With masks (exclude dynamic content)
-vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/ --mask ".marquee-container,.hero-badge"
+vlmkit diff html --url http://localhost:3000/ --current-url http://localhost:8080/ --mask ".marquee-container,.hero-badge"
 ```
 
 ## Snapshot (URL → multi-viewport capture)
 
 ```bash
 # First run: create baseline. Subsequent runs: baseline + diff
-vrt snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
+vlmkit snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
 
 # With masks (exclude animated/dynamic elements)
-vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
+vlmkit snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
 ```
 
 ## Dogfooding
@@ -203,10 +203,10 @@ This repository is a pnpm workspace.
 
 | Path | Contents |
 |------|----------|
-| `packages/vrt-core/` | Image / CSS / DOM / a11y diff engine + shared types and CLI helpers. No Playwright or AI deps required to import core types. |
-| `packages/vrt-capture/` | Playwright / Crater capture infrastructure, viewport discovery, prescanner. |
-| `packages/vrt-ai/` | VLM / LLM clients, reasoning pipeline, NLP helpers. |
-| `packages/vrt-markup/` | VLM-driven markup tooling: component extract / from-image, design tokens, theme parity, i18n stress, palette, dep-graph, selector-heal, smoke-runner. |
+| `packages/vlmkit-core/` | Image / CSS / DOM / a11y diff engine + shared types and CLI helpers. No Playwright or AI deps required to import core types. |
+| `packages/vlmkit-capture/` | Playwright / Crater capture infrastructure, viewport discovery, prescanner. |
+| `packages/vlmkit-ai/` | VLM / LLM clients, reasoning pipeline, NLP helpers. |
+| `packages/vlmkit-markup/` | VLM-driven markup tooling: component extract / from-image, design tokens, theme parity, i18n stress, palette, dep-graph, selector-heal, smoke-runner. |
 | `src/cli/` | CLI entry + router + workflow command implementations (split per-command under `cli/workflow/`). |
 | `src/api/` | HTTP API server (deep-imports vrt-markup smoke-runner + experiments/css-challenge). |
 | `src/experiments/` | migration, css-challenge, detection, benchmark, flaker. |
@@ -216,7 +216,7 @@ This repository is a pnpm workspace.
 
 Cross-package imports use `@mizchi/vrt-<pkg>/<path>.ts` or the curated barrel `@mizchi/vrt-<pkg>`. Within a package, use relative imports. The barrel excludes Playwright-bound and CLI-entry modules — deep-import those.
 
-Run tests for a single package: `pnpm --filter @mizchi/vrt-core test`. From repo root, `pnpm test` runs all.
+Run tests for a single package: `pnpm --filter @mizchi/vlmkit-core test`. From repo root, `pnpm test` runs all.
 
 The `vlmkit-markup` markup-core tests build MoonBit sources on demand and need the `moon` CLI. If tests fail with `spawnSync moon ENOENT`, add it to PATH first (it is often installed but not on PATH in sandboxes): `export PATH="$HOME/.moon/bin:$PATH"`.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# vrt — Project Skills
+# vlmkit — Project Skills
 
 ## How to Update VLM Model Benchmarks
 
@@ -14,7 +14,7 @@ pkf run vlm-bench -- --list --max-cost 0.001 --limit 30
 
 2. **Run fix-loop with candidate models** (hard case: seed 11):
 ```bash
-VRT_VLM_MODEL="<model-id>" node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
+VLMKIT_VLM_MODEL="<model-id>" node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts \
   --fixture page --seed 11 --mode selector --max-rounds 2
 ```
 
@@ -182,20 +182,20 @@ pkf run fix-loop -- --fixture page --seed 42
 pkf run fix-loop -- --fixture page --seed 11 --mode selector --max-rounds 3
 
 # Specify a VLM model
-VRT_VLM_MODEL="bytedance/ui-tars-1.5-7b" pkf run fix-loop -- --fixture page --seed 11 --mode selector
+VLMKIT_VLM_MODEL="bytedance/ui-tars-1.5-7b" pkf run fix-loop -- --fixture page --seed 11 --mode selector
 ```
 
 ## Environment Variables
 
 | Variable | Purpose | Default |
 |------|------|----------|
-| `VRT_LLM_PROVIDER` | LLM provider | gemini |
-| `VRT_LLM_MODEL` | LLM model | Provider default |
-| `VRT_VLM_MODEL` | VLM model (OpenRouter / `gemini:` / `claude:`) | bytedance/ui-tars-1.5-7b |
+| `VLMKIT_LLM_PROVIDER` | LLM provider | gemini |
+| `VLMKIT_LLM_MODEL` | LLM model | Provider default |
+| `VLMKIT_VLM_MODEL` | VLM model (OpenRouter / `gemini:` / `claude:`) | bytedance/ui-tars-1.5-7b |
 | `OPENROUTER_API_KEY` | OpenRouter API key | — |
 | `GEMINI_API_KEY` | Google AI API key | — |
 | `ANTHROPIC_API_KEY` | Anthropic API key | — |
-| `DEBUG_VRT` | Enable debug logs | — |
+| `DEBUG_VLMKIT` | Enable debug logs | — |
 
 ## Package Layout
 

--- a/.claude/skills/agent-validation-loop/SKILL.md
+++ b/.claude/skills/agent-validation-loop/SKILL.md
@@ -339,7 +339,7 @@ This skill was distilled from the
 - 9 agent runs (a → i) on a single DESIGN.md → HTML/CSS reproduction
   scenario.
 - 18 GitHub issues filed and closed (#22 – #36) + 3 drafts shipped as
-  CLIs (`vrt manifest` / `vrt watch` / `vrt diff-pr`).
+  CLIs (`vlmkit manifest` / `vlmkit watch` / `vlmkit diff-pr`).
 - Closed-loop floor moved from 10.3% → 0.2% (5-round budget) and to
   3.45% (3-round budget).
 - 38 commits, 183 tests across 32 suites.

--- a/.claude/skills/agent-validation-loop/SKILL.md
+++ b/.claude/skills/agent-validation-loop/SKILL.md
@@ -131,7 +131,7 @@ Re-running on the same scenario lets you compare apples-to-apples.
 Each agent gets the same brief and budget; what changes is the tool.
 Convergence-by-version becomes the public metric.
 
-| agent | budget | result | what changed in vrt since prior |
+| agent | budget | result | what changed in vlmkit since prior |
 |---|---|---|---|
 | a | 5 rounds | 10.3% mobile | initial |
 | d | 5 rounds | 0.2% mobile | post-#22..#29 |

--- a/.claude/skills/markup-assist/SKILL.md
+++ b/.claude/skills/markup-assist/SKILL.md
@@ -25,6 +25,7 @@ paths or URLs. All commands support `--json` and most support
 | Is the required copy present, exactly? | `vlmkit check copy page.html --manifest copy.txt` |
 | Does the structure match the brief? (widths, per-row counts, order, per-viewport visibility) | `vlmkit check layout page.html --contract layout.json` |
 | Tokens / theme / a11y / long-text survival | `check tokens` · `check theme` · `check a11y contrast\|touch\|focus` · `stress i18n` |
+| Is the page consistent with itself? (no tokens file needed — component styles reused, spacing on its own scale) | `vlmkit check design page.html` |
 
 **Behavior:**
 

--- a/.claude/skills/vrt-css-fix-loop/SKILL.md
+++ b/.claude/skills/vrt-css-fix-loop/SKILL.md
@@ -35,7 +35,7 @@ banner line `VLM=<id> | LLM=<id>` makes the two stages explicit.
 
 ## Invocation
 
-`fix-loop` is run directly from source (not via the `vrt` CLI):
+`fix-loop` is run directly from source (not via the `vlmkit` CLI):
 
 ```bash
 node --experimental-strip-types src/experiments/css-challenge/fix-loop.ts <flags>
@@ -151,7 +151,7 @@ for the 8-way bench from the prior week.
 | `OPENROUTER_API_KEY` | Unprefixed model id |
 | `GEMINI_API_KEY` | `gemini:` prefix |
 | `ANTHROPIC_API_KEY` | `claude:` prefix |
-| `DEBUG_VRT=1` | Verbose VLM round logging |
+| `DEBUG_VLMKIT=1` | Verbose VLM round logging |
 
 ## Reading the output
 
@@ -192,7 +192,7 @@ recall, property recall).
 
 A "stalled" run shows diffRatio holding steady across rounds — the
 VLM's proposals aren't parseable, or the LLM's emitted fixes aren't
-structurally valid CSS. Set `DEBUG_VRT=1` to see both stages' raw
+structurally valid CSS. Set `DEBUG_VLMKIT=1` to see both stages' raw
 output.
 
 At the end of the run, a summary table prints one row per round

--- a/.claude/skills/vrt-markup-synth/SKILL.md
+++ b/.claude/skills/vrt-markup-synth/SKILL.md
@@ -24,7 +24,7 @@ keys.
 
 ## Invocation
 
-The `vrt` CLI in this repo is invoked **from source**:
+The `vlmkit` CLI in this repo is invoked **from source**:
 
 ```bash
 node --experimental-strip-types src/cli/vrt.ts <command...>

--- a/.claude/skills/vrt-markup-synth/SKILL.md
+++ b/.claude/skills/vrt-markup-synth/SKILL.md
@@ -16,11 +16,11 @@ keys.
 
 | Command | Input | Output | What runs |
 |---|---|---|---|
-| `vrt build component <target.png> <current.html>` | Reference image + your current HTML | Markdown report at `test-results/component/report.md` (+ `component_heatmap.png` alongside): pixel diff + bbox + palette + heatmap + text-row signals | Playwright renders `current.html` at the target's viewport, pixel-diffs vs `target.png`, surfaces image-only signals. **No VLM.** Agent iterates `current.html`. Internal binary name: `vrt component-from-image` — the CLI banner uses the legacy name even when invoked as `vrt build component`. `--output` is **not** a destination path here — the report always lands at the fixed `test-results/component/` path; the flag is silently ignored. |
-| `vrt scan component <screenshot>` | Full-page PNG | `components/*.png` + `manifest.json` (bbox + role guess) | Bbox detection + clustering on the image. **No VLM.** |
-| `vrt check tokens <html-or-url>` | Page | Markdown table: violation + nearest-token | Playwright + computed-style scan; snaps to allowed scale within tolerance. **No VLM.** Internal binary name: `vrt design-tokens` — the dispatcher routes both, but **the CLI banner and the generated report still call it `vrt design-tokens`** (legacy). Both invocations work; don't get tripped up when the output names a command different from the one you typed. |
-| `vrt check theme <html>` | Page | Markdown report: "unthemed" bboxes (light/dark render same) | Playwright with `emulateMedia({ colorScheme: 'light' / 'dark' })`, per-bbox color sampling, identical-fill flag. **No VLM.** |
-| `vrt stress i18n <html>` | Page | Markdown report: selectors that overflow / wrap | Inflate every visible text node by a multiplier (synthetic `word → word + 'X'×k`), measure `scrollWidth > clientWidth` / height growth / right-edge overflow. **No VLM.** No translation dictionary. |
+| `vlmkit build component <target.png> <current.html>` | Reference image + your current HTML | Markdown report at `test-results/component/report.md` (+ `component_heatmap.png` alongside): pixel diff + bbox + palette + heatmap + text-row signals | Playwright renders `current.html` at the target's viewport, pixel-diffs vs `target.png`, surfaces image-only signals. **No VLM.** Agent iterates `current.html`. `--output` is **not** a destination path here — the report always lands at the fixed `test-results/component/` path; the flag is silently ignored. |
+| `vlmkit scan component <screenshot>` | Full-page PNG | `components/*.png` + `manifest.json` (bbox + role guess) | Bbox detection + clustering on the image. **No VLM.** |
+| `vlmkit check tokens <html-or-url>` | Page | Markdown table: violation + nearest-token | Playwright + computed-style scan; snaps to allowed scale within tolerance. **No VLM.** The banner names the command you typed, but the report still lands under the old directory name — `test-results/design-tokens/report.md`, not `check-tokens/`. |
+| `vlmkit check theme <html>` | Page | Markdown report: "unthemed" bboxes (light/dark render same) | Playwright with `emulateMedia({ colorScheme: 'light' / 'dark' })`, per-bbox color sampling, identical-fill flag. **No VLM.** |
+| `vlmkit stress i18n <html>` | Page | Markdown report: selectors that overflow / wrap | Inflate every visible text node by a multiplier (synthetic `word → word + 'X'×k`), measure `scrollWidth > clientWidth` / height growth / right-edge overflow. **No VLM.** No translation dictionary. |
 
 ## Invocation
 
@@ -62,21 +62,21 @@ dist is stale — run `pnpm build` or use the source form. All
 # pixel signal each iteration. Agent (= you) edits current.html until
 # the diff converges. The report lands at test-results/component/report.md
 # (path is fixed — `--output` is ignored for this sub-tool).
-vrt build component design.png current.html
+vlmkit build component design.png current.html
 
 # Full screenshot → per-component crops
-vrt scan component dashboard.png --output components/
+vlmkit scan component dashboard.png --output components/
 
 # Token conformance (default scales — no --tokens needed for first pass)
-vrt check tokens src/index.html
+vlmkit check tokens src/index.html
 #   ↑ uses default spacing/radius/z-index scales + 0.5px tolerance.
 #   Pass --tokens design-tokens.json to override.
 
 # Theme parity (renders light + dark, flags identical fills)
-vrt check theme src/index.html --output-dir test-results/theme/
+vlmkit check theme src/index.html --output-dir test-results/theme/
 
 # i18n / overflow stress (synthetic inflate, default factor 1.4)
-vrt stress i18n src/index.html --inflate 1.4
+vlmkit stress i18n src/index.html --inflate 1.4
 ```
 
 ## Build component — what the report contains
@@ -97,7 +97,7 @@ auto-fix — the tool is the eyes, the agent is the hands.
 
 ## Check tokens — what counts as a violation
 
-`vrt check tokens` flags computed-style values that aren't on the
+`vlmkit check tokens` flags computed-style values that aren't on the
 allowed scale within tolerance. The default scales:
 
 | Property kind | Default scale |

--- a/.claude/skills/vrt-migration-eval/SKILL.md
+++ b/.claude/skills/vrt-migration-eval/SKILL.md
@@ -16,9 +16,9 @@ boxes and computed-style deltas to surface only the deltas that matter.
 
 | Mode | Cmd | What it does | Use when |
 |---|---|---|---|
-| **compare** | `vrt migration compare` | Deterministic: capture both, pixel diff + per-section bbox + computed-style diff per viewport | Baseline + variant are both rendered, you want a numeric verdict |
-| **blind** | `vrt migration blind` | Variant agent never sees baseline pixels — only structural hints. Forces agent to converge from spec text alone | Stress-test the migration: "can the new stack reproduce the layout from scratch?" |
-| **subagent** | `vrt migration subagent` | Dispatched subagent runs `compare` + writes a structured verdict | You want a fresh, unbiased read inside a longer chain |
+| **compare** | `vlmkit migration compare` | Deterministic: capture both, pixel diff + per-section bbox + computed-style diff per viewport | Baseline + variant are both rendered, you want a numeric verdict |
+| **blind** | `vlmkit migration blind` | Variant agent never sees baseline pixels — only structural hints. Forces agent to converge from spec text alone | Stress-test the migration: "can the new stack reproduce the layout from scratch?" |
+| **subagent** | `vlmkit migration subagent` | Dispatched subagent runs `compare` + writes a structured verdict | You want a fresh, unbiased read inside a longer chain |
 
 Default to **compare**. Use blind / subagent when you're auditing the
 toolchain itself, not the migration.
@@ -29,7 +29,7 @@ toolchain itself, not the migration.
 If you cannot fill in both sides (e.g. "Tailwind → vanilla CSS",
 "reset-css `eric-meyer` → `modern-normalize`", "Vite → Rspack
 pipeline"), this is the wrong skill — stop and use `vrt-visual-diff`
-instead. The Quickstart's `vrt migration compare baseline.html
+instead. The Quickstart's `vlmkit migration compare baseline.html
 variant.html` command shape matches *any* two-file pair, so it's
 easy to fall into. The named-migration check is the gate.
 
@@ -65,24 +65,24 @@ the dist is stale — run `pnpm build` or use the source form. All
 
 `--output <dir>` is a **directory** path; the engine writes
 `<dir>/diff-report.json` (+ per-viewport PNGs) into it. Pass that
-JSON file — not the dir — to `vrt diff agent`. (`migration-report.json`
+JSON file — not the dir — to `vlmkit diff agent`. (`migration-report.json`
 is also written as a legacy alias; both files have identical
 content.)
 
 ```bash
 # Two HTML files, side by side → writes reports/diff-report.json
-vrt migration compare baseline.html variant.html \
+vlmkit migration compare baseline.html variant.html \
   --output reports/
 
 # Two URLs (different dev servers / preview deploys)
-vrt migration compare \
+vlmkit migration compare \
   --url http://localhost:3000/ \
   --current-url http://localhost:8080/ \
   --mask ".marquee-container,.hero-badge" \
   --output reports/
 
 # Then format for the agent
-vrt diff agent reports/diff-report.json
+vlmkit diff agent reports/diff-report.json
 ```
 
 ## Computed-style diff is the load-bearing signal
@@ -99,13 +99,13 @@ report surfaces:
 - **Breakpoint-gated pairs**: selectors that differ on a viewport
   subset. Almost always "missing or wrong `@media` rule."
 
-`vrt diff agent` renders these as two subtables under "Verified
+`vlmkit diff agent` renders these as two subtables under "Verified
 deltas (computed-style) × viewport" — read top-to-bottom.
 
 ## Mode: blind
 
 ```bash
-vrt migration blind <baseline-url> <variant-url> --rounds 3
+vlmkit migration blind <baseline-url> <variant-url> --rounds 3
 ```
 
 The variant builder agent gets:
@@ -122,10 +122,10 @@ ergonomics are.
 ## Mode: subagent
 
 ```bash
-vrt migration subagent baseline.html variant.html
+vlmkit migration subagent baseline.html variant.html
 ```
 
-Spawns a fresh CC subagent that runs `vrt migration compare`, reads
+Spawns a fresh CC subagent that runs `vlmkit migration compare`, reads
 the Markdown report, and writes a verdict. Useful inside a longer
 chain where you want one unbiased opinion ("is this migration done?")
 without the caller's context bleeding in.
@@ -135,7 +135,7 @@ without the caller's context bleeding in.
 Migration diffs include cosmetic differences in non-deterministic
 content (timestamps, marquee animations, generated IDs). Always pass
 `--mask <selectors>` for any selector whose content isn't
-controlled. The `vrt diff html` quickstart in `vrt-visual-diff` shows
+controlled. The `vlmkit diff html` quickstart in `vrt-visual-diff` shows
 the syntax — `migration compare` accepts the same flag.
 
 ## Environment
@@ -150,7 +150,7 @@ the syntax — `migration compare` accepts the same flag.
 
 | File | Mode | Purpose |
 |---|---|---|
-| `migration.json` | compare | machine input to `vrt diff agent` |
+| `migration.json` | compare | machine input to `vlmkit diff agent` |
 | `migration-<vp>.png` | compare | pixel diff per viewport |
 | Markdown verdict | subagent | structured agent reply |
 | `rounds/<N>/` | blind | per-round capture + diff trail |

--- a/.claude/skills/vrt-migration-eval/SKILL.md
+++ b/.claude/skills/vrt-migration-eval/SKILL.md
@@ -35,7 +35,7 @@ easy to fall into. The named-migration check is the gate.
 
 ## Invocation
 
-The `vrt` CLI in this repo is invoked **from source**:
+The `vlmkit` CLI in this repo is invoked **from source**:
 
 ```bash
 node --experimental-strip-types src/cli/vrt.ts <command...>

--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -13,7 +13,7 @@ regression.
 
 ## Invocation
 
-The `vrt` CLI in this repo is invoked **from source**:
+The `vlmkit` CLI in this repo is invoked **from source**:
 
 ```bash
 node --experimental-strip-types src/cli/vrt.ts <command...>
@@ -205,7 +205,7 @@ disappears, the original signal was noise.
   selectors.
 - `--fail-on-regression` exits 1 but the banner says "0 viewports
   got worse" → there's a JSON-vs-Markdown drift bug; re-run with
-  `DEBUG_VRT=1` and file an issue.
+  `DEBUG_VLMKIT=1` and file an issue.
 - Stale summary from months ago → manually remove
   `.vrt/last-diff-for-agent.json` (or your custom path) and re-run.
 

--- a/.claude/skills/vrt-regression-watch/SKILL.md
+++ b/.claude/skills/vrt-regression-watch/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: vrt-regression-watch
-description: Run vrt diff in a stateful loop where each run is compared against the previous run's persisted summary, surfacing a `⚠ REGRESSION` banner when the majority of viewports get worse. Designed for periodic CI gates (per-PR or scheduled) where you want "did this change make things worse" as a binary signal, not a one-shot snapshot. Stores summary at `.vrt/last-diff-for-agent.json` by default.
+description: Run vlmkit diff in a stateful loop where each run is compared against the previous run's persisted summary, surfacing a `⚠ REGRESSION` banner when the majority of viewports get worse. Designed for periodic CI gates (per-PR or scheduled) where you want "did this change make things worse" as a binary signal, not a one-shot snapshot. Stores summary at `.vrt/last-diff-for-agent.json` by default.
 ---
 
 # vrt-regression-watch
 
-The same `vrt diff agent` CLI exposes regression flags
+The same `vlmkit diff agent` CLI exposes regression flags
 (`--previous`, `--persist-summary`, `--no-history`,
 `--fail-on-regression`). This skill explains *how* to wire them into a
 recurring loop, what state lives where, and what counts as a
@@ -45,7 +45,7 @@ these two forms.
 
 ## How regression is detected
 
-After each `vrt diff agent` run, the per-viewport diffRatio is written
+After each `vlmkit diff agent` run, the per-viewport diffRatio is written
 to `.vrt/last-diff-for-agent.json`. On the next run:
 
 1. Load that file as the comparison summary.
@@ -60,13 +60,13 @@ from triggering false alarms.
 
 ## Quickstart
 
-`--output <dir>` is a **directory** path; `vrt diff html` writes
+`--output <dir>` is a **directory** path; `vlmkit diff html` writes
 `<dir>/diff-report.json` into it. Pass that JSON file path — not
-the dir — to `vrt diff agent`. (`migration-report.json` is also
+the dir — to `vlmkit diff agent`. (`migration-report.json` is also
 written as a legacy alias; both files have identical content.)
 
 The filename is `migration-report.json` even when there's no migration
-involved because the writer is shared with `vrt migration compare`.
+involved because the writer is shared with `vlmkit migration compare`.
 Legacy name; tracked for rename in #50. Treat it as "the diff
 report" regardless of how you produced it.
 
@@ -78,14 +78,14 @@ wiring the workflow into CI.
 REPORT=reports/diff-report.json
 
 # First run: establishes baseline. No banner possible (no prior summary).
-vrt diff html before.html after.html --output reports/
-vrt diff agent "$REPORT" --persist-summary .vrt/baseline.json
+vlmkit diff html before.html after.html --output reports/
+vlmkit diff agent "$REPORT" --persist-summary .vrt/baseline.json
 
 # Subsequent runs: same baseline file for read AND write
 # (local-rolling idiom — passing the same path to --previous and
 # --persist-summary means "compare against last run, then overwrite").
-vrt diff html before.html after.html --output reports/
-vrt diff agent "$REPORT" \
+vlmkit diff html before.html after.html --output reports/
+vlmkit diff agent "$REPORT" \
   --previous .vrt/baseline.json \
   --persist-summary .vrt/baseline.json \
   --fail-on-regression
@@ -100,8 +100,8 @@ PR's previous run").
 
 | File | Written by | Read by | Lifetime |
 |---|---|---|---|
-| `.vrt/last-diff-for-agent.json` | `vrt diff agent` (auto, unless `--no-history`) | next `vrt diff agent` run | persists until manually removed |
-| `report.json` | `vrt diff html` / `vrt migration compare` | `vrt diff agent` | per-run; can discard after the Markdown is produced |
+| `.vrt/last-diff-for-agent.json` | `vlmkit diff agent` (auto, unless `--no-history`) | next `vlmkit diff agent` run | persists until manually removed |
+| `report.json` | `vlmkit diff html` / `vlmkit migration compare` | `vlmkit diff agent` | per-run; can discard after the Markdown is produced |
 
 Two retention strategies:
 
@@ -125,8 +125,8 @@ Two retention strategies:
 
 - name: Render current PR + diff
   run: |
-    vrt diff html main.html pr.html --output reports/
-    vrt diff agent reports/diff-report.json \
+    vlmkit diff html main.html pr.html --output reports/
+    vlmkit diff agent reports/diff-report.json \
       --previous .vrt/baseline.json \
       --persist-summary /tmp/pr-summary.json \
       --fail-on-regression \
@@ -190,7 +190,7 @@ breakage is the most likely user-visible regression.
 
 ## Combining with masks
 
-The same `--mask` arg from `vrt diff html` applies. **A regression
+The same `--mask` arg from `vlmkit diff html` applies. **A regression
 banner appearing on a viewport you don't actually care about (e.g.
 `wide`) usually means you forgot to mask a flapping element on that
 viewport.** Add the selector to `--mask` and re-run; if the banner
@@ -211,7 +211,7 @@ disappears, the original signal was noise.
 
 ## Environment
 
-No additional env vars beyond what `vrt diff agent` needs (none for
+No additional env vars beyond what `vlmkit diff agent` needs (none for
 the pure pixel+CSD path).
 
 ## Related skills
@@ -219,4 +219,4 @@ the pure pixel+CSD path).
 - `vrt-visual-diff` — same CLI, no state. Use first to confirm the
   diff looks sensible before wiring it into a watch loop.
 - `vrt-migration-eval` — produces `report.json` files that
-  `vrt diff agent` can consume just like the html-diff path.
+  `vlmkit diff agent` can consume just like the html-diff path.

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -7,9 +7,9 @@ description: Compare two rendered pages (URL pairs or local HTML) and produce a 
 
 Two-step workflow:
 
-1. `vrt diff html <baseline> <variant>` — Playwright-driven capture +
+1. `vlmkit diff html <baseline> <variant>` — Playwright-driven capture +
    pixel diff + computed-style snapshot. Writes `report.json`.
-2. `vrt diff agent report.json` — formats the JSON into one Markdown
+2. `vlmkit diff agent report.json` — formats the JSON into one Markdown
    summary an agent can read in a single context window.
 
 The Markdown report layers signal hierarchies so a fresh agent can skim
@@ -66,36 +66,36 @@ skill assume one of these two forms.
 
 `--output <dir>` is a **directory** path; the diff writes
 `<dir>/diff-report.json` (+ per-viewport PNGs) into it. Feed that
-JSON path — not the dir — to `vrt diff agent`. (`migration-report.json`
+JSON path — not the dir — to `vlmkit diff agent`. (`migration-report.json`
 is still written alongside as a legacy alias for callers pinning
 the old name; the two files are byte-identical.)
 
 The filename is `migration-report.json` even on this non-migration
-path because the writer is shared with `vrt migration compare`. The
+path because the writer is shared with `vlmkit migration compare`. The
 name is legacy — treat it as "the diff report" regardless of whether
 you came here via `diff html` or `migration compare`. (Tracked for
 rename in #50.)
 
 ```bash
 # Local HTML pair → writes reports/diff-report.json
-vrt diff html before.html after.html --output reports/
-vrt diff agent reports/diff-report.json > reports/diff.md
+vlmkit diff html before.html after.html --output reports/
+vlmkit diff agent reports/diff-report.json > reports/diff.md
 
 # URL pair (e.g. before/after a code change on the dev server)
-vrt diff html \
+vlmkit diff html \
   --url http://localhost:3000/ \
   --current-url http://localhost:8080/ \
   --output reports/
-vrt diff agent reports/diff-report.json
+vlmkit diff agent reports/diff-report.json
 
 # Mask dynamic regions. The value is one quoted, comma-separated CSS
 # selector list — shell-quoting is required so commas don't split args.
-vrt diff html before.html after.html \
+vlmkit diff html before.html after.html \
   --mask ".marquee-container,.hero-badge,[data-testid='live-counter']" \
   --output reports/
 ```
 
-## Useful flags on `vrt diff agent`
+## Useful flags on `vlmkit diff agent`
 
 | Flag | Purpose |
 |---|---|
@@ -111,7 +111,7 @@ exposes them but the watch skill explains the persistence model.
 
 ## How to read the report
 
-The actual Markdown emitted by `vrt diff agent` opens with these
+The actual Markdown emitted by `vlmkit diff agent` opens with these
 sections, in this order (excerpt from a real run on
 `fixtures/element-compare/`):
 
@@ -167,7 +167,7 @@ ambiguous.
 
 ## Masking is load-bearing
 
-`vrt diff html` re-runs the page in headless Chromium; any animation,
+`vlmkit diff html` re-runs the page in headless Chromium; any animation,
 clock, marquee, ad slot, or hash-randomized class will flap on every
 run. Pass `--mask <css-selectors>` for everything that isn't
 deterministic. Diff% < 0.05 on a clean page with no mask is rare —
@@ -177,20 +177,20 @@ treat unexpected baseline noise as a missing mask, not a real diff.
 
 No env vars required for pixel + CSD path. The report is purely
 deterministic — no VLM / LLM is involved unless the migration-compare
-upstream invokes it (which `vrt diff html` does not by default).
+upstream invokes it (which `vlmkit diff html` does not by default).
 
 ## Outputs at a glance
 
 | File | Source | Consumer |
 |---|---|---|
-| `report.json` | `vrt diff html` | machine input to `vrt diff agent` |
-| Markdown (stdout or `--out`) | `vrt diff agent` | the calling agent |
-| `diff-<viewport>.png` | `vrt diff html` | linked in markdown for direct `Read` |
-| `.vrt/last-diff-for-agent.json` | `vrt diff agent` | next run, for regression detection (skip with `--no-history`) |
+| `report.json` | `vlmkit diff html` | machine input to `vlmkit diff agent` |
+| Markdown (stdout or `--out`) | `vlmkit diff agent` | the calling agent |
+| `diff-<viewport>.png` | `vlmkit diff html` | linked in markdown for direct `Read` |
+| `.vrt/last-diff-for-agent.json` | `vlmkit diff agent` | next run, for regression detection (skip with `--no-history`) |
 
 ## Failure modes
 
-- `vrt diff html` errors with "browser not found" → run
+- `vlmkit diff html` errors with "browser not found" → run
   `npx playwright install chromium` once.
 - Report shows 0 deltas but the agent expected changes → check the
   variant URL is actually the new build (build cache hits are common).

--- a/.claude/skills/vrt-visual-diff/SKILL.md
+++ b/.claude/skills/vrt-visual-diff/SKILL.md
@@ -34,7 +34,7 @@ top-down:
 
 ## Invocation
 
-The `vrt` CLI in this repo is invoked **from source**:
+The `vlmkit` CLI in this repo is invoked **from source**:
 
 ```bash
 node --experimental-strip-types src/cli/vrt.ts <command...>

--- a/.github/workflows/bench-report.yml
+++ b/.github/workflows/bench-report.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build workspace packages
         # 0.8.1 made src/ entrypoints resolve deep imports through dist.
-        run: pnpm build:packages
+        run: pnpm build:packages:js
 
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/bench-report.yml
+++ b/.github/workflows/bench-report.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        # 0.8.1 made src/ entrypoints resolve deep imports through dist.
+        run: pnpm build:packages
+
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
 

--- a/.github/workflows/migration-report.yml
+++ b/.github/workflows/migration-report.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        # 0.8.1 made src/ entrypoints resolve deep imports through dist.
+        run: pnpm build:packages
+
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
 

--- a/.github/workflows/migration-report.yml
+++ b/.github/workflows/migration-report.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build workspace packages
         # 0.8.1 made src/ entrypoints resolve deep imports through dist.
-        run: pnpm build:packages
+        run: pnpm build:packages:js
 
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/vrt-compare.yml
+++ b/.github/workflows/vrt-compare.yml
@@ -44,6 +44,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Run VRT Compare
@@ -86,6 +87,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Start static fixture server
@@ -143,6 +145,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Smoke test fixtures
@@ -170,6 +173,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
       - run: pnpm exec playwright install --with-deps chromium
 
       # The bench builds the MoonBit `markup-core` package, so it needs the

--- a/.github/workflows/vrt-compare.yml
+++ b/.github/workflows/vrt-compare.yml
@@ -44,7 +44,11 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
+      # 0.8.1 made src/ entrypoints resolve deep imports through dist. The
+      # `:js` variant skips `moon:build` — the MoonBit output is loaded at
+      # runtime from `_build/js/`, not needed to emit JS + declarations — so
+      # this job does not have to install the MoonBit toolchain.
+      - run: pnpm build:packages:js
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Run VRT Compare
@@ -87,7 +91,11 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
+      # 0.8.1 made src/ entrypoints resolve deep imports through dist. The
+      # `:js` variant skips `moon:build` — the MoonBit output is loaded at
+      # runtime from `_build/js/`, not needed to emit JS + declarations — so
+      # this job does not have to install the MoonBit toolchain.
+      - run: pnpm build:packages:js
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Start static fixture server
@@ -145,7 +153,11 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
+      # 0.8.1 made src/ entrypoints resolve deep imports through dist. The
+      # `:js` variant skips `moon:build` — the MoonBit output is loaded at
+      # runtime from `_build/js/`, not needed to emit JS + declarations — so
+      # this job does not have to install the MoonBit toolchain.
+      - run: pnpm build:packages:js
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Smoke test fixtures
@@ -173,7 +185,6 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
       - run: pnpm exec playwright install --with-deps chromium
 
       # The bench builds the MoonBit `markup-core` package, so it needs the
@@ -182,6 +193,9 @@ jobs:
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      # After the MoonBit install above: `build:packages` runs `moon:build`.
+      - run: pnpm build:packages
 
       - name: Run CSS benchmark
         run: |

--- a/.github/workflows/vrt-stability.yml
+++ b/.github/workflows/vrt-stability.yml
@@ -29,6 +29,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Serve fixtures

--- a/.github/workflows/vrt-stability.yml
+++ b/.github/workflows/vrt-stability.yml
@@ -29,7 +29,8 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build:packages   # 0.8.1 made src/ entrypoints need built packages
+      # `:js` skips moon:build — this job has no MoonBit toolchain.
+      - run: pnpm build:packages:js
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Serve fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Dates are YYYY-MM-DD.
 
 ## Unreleased
 
+## 0.9.0 — 2026-08-02
+
+The theme of this release is gates that were confidently wrong. Nine of
+them reported a defect in the page — or reported nothing at all — when
+the real problem was that they had measured the wrong document: an
+unstyled one, a login page, a pre-render placeholder. Each fix carries a
+differential regression test, because none of these were visible in a
+single run; every one needed two runs and a comparison.
+
 ### Breaking
 
 - **A suspect finding now fails the command by default.** `check copy`,
@@ -19,9 +28,43 @@ Dates are YYYY-MM-DD.
   `--fail-on-suspect` is still accepted as a no-op, so existing scripts
   keep working. **If you relied on a gate exiting 0 while reporting
   defects, add `--advisory`.**
+- **A malformed `verify flow` file is now a usage error.** An unknown
+  assert name used to be reported as an unmet post-condition
+  (`FAIL (unknown assert)`), and an unknown action was worse: the step
+  performed nothing, had no post-conditions to fail, and the run returned
+  `done: true`. Both are now rejected before a browser opens, naming the
+  offending step and listing the valid names. An empty `steps` array is
+  rejected too. **A flow that was silently passing on a typo'd action
+  will now error — that flow was never verifying anything.**
 
 ### Added
 
+- `check design` — coherence of the design system a page implies, with no
+  reference: spacing-scale and type-scale concentration, palette size,
+  and component-signature reuse. The `scale-outlier` rule is `info`, not
+  `warn`, because the study behind it showed spacing concentration
+  overlaps between designed and generated pages.
+- `vlmkit batch` — run gates over many pages with bounded concurrency,
+  stride sharding for CI matrices, and exit-code-as-verdict. Per-job logs
+  are named by a full-path slug plus a hash, so two pages with the same
+  basename cannot overwrite each other's output.
+- `vlmkit gates` + `vlmkit.gates.json` — one reviewed config for which
+  gates run against which pages, with `gates list | run | suppressions`.
+  A suppression must carry a reason, may carry an owner and an expiry,
+  and stops applying once expired. An empty gate list is a parse error
+  rather than a run that silently does nothing.
+- `check integrity --allow "<kind>[@<selector>][@<viewport>];<reason>"` —
+  accept an intentional pattern without editing the markup. A reason is
+  required, an unknown kind is an error listing the valid ones, exempted
+  findings stay in the report under `exempted`, and a rule that matched
+  nothing is reported so dead config gets deleted. Four kinds
+  (`js-error`, `degenerate-render`, `unstyled-page`, `redirected`) can
+  never be exempted — they mean the page is broken or unmeasurable.
+- `--json` on `check a11y contrast | touch | focus` and `stress i18n`.
+  These were the gates without it, and their console output caps its list,
+  so the full finding set had no machine-readable route out.
+- URL support on `check a11y contrast | touch | focus` and `check design`
+  — they previously accepted only local files.
 - Authenticated pages: `--storage-state <file>` on URL-capable gates, or
   `VLMKIT_STORAGE_STATE=<file>` for all of them at once, accepting the
   Playwright storage-state file that `playwright codegen --save-storage`
@@ -31,6 +74,68 @@ Dates are YYYY-MM-DD.
 
 ### Fixed
 
+- **Six gates were measuring an unstyled document.** They loaded local
+  HTML with `setContent(readFile(...))`, which gives the page an
+  `about:blank` base URL, so every relative `<link rel=stylesheet>`,
+  `<img>` and webfont silently failed to resolve. `check a11y contrast`
+  reported 0 failures where the same CSS inlined reported 1; worse,
+  `check a11y touch` *inverted* — an unstyled control keeps its intrinsic
+  size, so a CSS-shrunk tap target measured as passing. All six now
+  navigate to the file URL. (Injecting a `<base href>` was tried and does
+  not work: an opaque origin blocks `file://` subresources.)
+- **Five more gates reported success for a login page.** `check
+  breakpoints`, `check scroll` and `scan scroll` returned `status: ok`
+  for a route that 302s to `/login`, while `check layout` and
+  `verify flow` failed against the sign-in page and blamed the markup.
+  All five now report the redirect. The hint also stopped claiming
+  "vlmkit cannot inject a session", which had been false since
+  `--storage-state` landed.
+- **Six gates were reading the pre-render DOM.** `verify flow` reported
+  `count .card expected 2, measured 0` on a page where `check layout`
+  measured 2 at the same instant; `build page` screenshotted a candidate
+  at 5.3% of its settled ink, so every component came back missing; and
+  `scan contract` returned zero landmarks for a built SPA opened as a
+  file. Playwright actions auto-wait, but `page.evaluate`,
+  `page.screenshot` and `getBoundingClientRect` do not — and that is how
+  every gate measures.
+- `check integrity` findings were attributed to whichever viewport the
+  caller happened to list first, so `--allow "…@1280"` was silently
+  order-dependent and a page-wide defect could read as mobile-only. The
+  sweep is now sorted widest-first and records every width a finding was
+  seen at, which also makes "breaks at 1280/768 but not 375" expressible
+  for the first time.
+- `check a11y contrast | touch | focus` printed a headline count and then
+  five rows with no indication the list was cut — twelve findings looked
+  like five. The cap is now disclosed and `--json` carries every row.
+  `stress i18n` capped at six rows and is now disclosed too.
+- `--json` on those four gates prints **only** JSON. It was added in this
+  cycle and shipped emitting the human block first, so `JSON.parse` threw
+  on line 1 — while the truncation notice pointed the reader at exactly
+  that stream. Found by running the built CLI during release prep; the
+  original check had read `report.failures.length` from the run function,
+  which never touches stdout.
+- The four gates above no longer print `vrt` in their headers, usage
+  lines, or fix instructions. There is no `vrt` binary and the old
+  subcommand names are deprecated, so a fix instruction reading
+  "Re-run `vrt a11y-contrast`" was wrong twice over.
+- `check integrity` text-collision false positives: collisions are
+  compared on measured ink bands rather than line boxes, text inside a
+  closed `<details>` is not a collision candidate, and character-level
+  grazes are reported by ink-overlap fraction. An 8-page × 3-viewport A/B
+  against the previous revision found **0 new collisions and 16
+  disappeared** — every one a pre-existing false positive the old
+  area-ratio gate had been masking (MDN 14, from closed-`<details>`
+  content that keeps its layout boxes; APG 2, from an element paired with
+  its own inline descendant).
+- `check integrity` no longer treats an invisible overlay as an occluder —
+  found while running the gate against a real authenticated app.
+- `verify markup` scored low-contrast fills as clean instead of detecting
+  them.
+- Numeric CLI flags are validated in one place, which fixed five bugs
+  that had each been hand-rolled independently — including a `NaN`
+  concurrency that made the worker pool silently run nothing and return
+  holes, and `--min-reuse 2` printing `drift` next to a `COHERENT`
+  verdict. `--gate "check a11y contrast"` no longer splits on the space.
 - Gates no longer report on a page they did not measure: a redirect away
   from the requested URL (typically a login wall) is reported instead of
   silently measured, which previously produced `verdict: CLEAN` for a
@@ -51,6 +156,19 @@ Dates are YYYY-MM-DD.
 - `snapshot` and `scan breakpoints` now append to the run ledger.
 - `unprobed-handler-types` counts only element-specific handlers, so a
   framework delegation root no longer lists ~80 event types as findings.
+
+### Known issues
+
+- **Other commands still print `vrt` in their output.** The four gates
+  above were fixed because they were already in the release diff; a full
+  sweep found roughly 250 occurrences across ~80 distinct phrases in
+  user-facing strings (`vrt snapshot`, `vrt workflow`, `vrt diff-pr`,
+  `vrt baseline` …). Most need only the binary name changed, but some
+  refer to commands that no longer exist at all (`vrt compare`,
+  `vrt elements`, `vrt smoke`) and some are prose. Deliberately left for
+  its own change rather than folded into a release commit — a fix
+  instruction you cannot paste is a real defect, and it deserves a diff
+  someone can review.
 
 ## 0.8.0 — 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ Dates are YYYY-MM-DD.
 
 ## Unreleased
 
+### Breaking
+
+- **A suspect finding now fails the command by default.** `check copy`,
+  `check asset`, `scan scroll`, `check scroll`, and `check breakpoints`
+  previously printed their suspects and exited 0 unless you passed
+  `--fail-on-suspect`, while `check integrity`, `check layout`,
+  `verify flow`, `verify markup`, `check interactions`, and
+  `scan handlers` already exited non-zero — two commands in the same
+  `scan` group disagreed. Every gate now shares one contract: a suspect
+  exits 1, a warn never affects the exit code, and `--advisory` opts back
+  into print-and-succeed for gates being piloted before they gate CI.
+  `--fail-on-suspect` is still accepted as a no-op, so existing scripts
+  keep working. **If you relied on a gate exiting 0 while reporting
+  defects, add `--advisory`.**
+
+### Added
+
+- Authenticated pages: `--storage-state <file>` on URL-capable gates, or
+  `VLMKIT_STORAGE_STATE=<file>` for all of them at once, accepting the
+  Playwright storage-state file that `playwright codegen --save-storage`
+  and `context.storageState()` produce. Validated eagerly — a missing,
+  malformed, or empty state throws with a capture hint rather than
+  silently measuring an unauthenticated page.
+
+### Fixed
+
+- Gates no longer report on a page they did not measure: a redirect away
+  from the requested URL (typically a login wall) is reported instead of
+  silently measured, which previously produced `verdict: CLEAN` for a
+  protected page that never rendered.
+- `check interactions` and `scan handlers` waited only for `load`, so on
+  client-rendered apps they inventoried the pre-render DOM — reporting
+  `interactive elements: 0` and `status: ok` on a page with real controls
+  and a pointer-only `<div>`. Both now settle before measuring.
+- Horizontal-overflow kickbacks name the element actually at fault. The
+  culprit is measured (neutralize its width, re-read `scrollWidth`)
+  rather than ranked by right edge, which in grid/flex shells promoted
+  stretched ancestors over the rigid child causing the overflow.
+- `check copy` sees text inside open shadow roots, so component-library
+  copy is no longer reported missing; hidden shadow copy is still
+  classified by reason (e.g. `zero-size`).
+- `check integrity` waits for `document.fonts.ready`, and detects text
+  occluded by `pointer-events: none` overlays.
+- `snapshot` and `scan breakpoints` now append to the run ledger.
+- `unprobed-handler-types` counts only element-specific handlers, so a
+  framework delegation root no longer lists ~80 event types as findings.
+
 ## 0.8.0 — 2026-08-01
 
 ### Verified markup workflow

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Task-routing recipes and done-condition sets:
 
 | Doc | Contents |
 |---|---|
+| [`docs/introduce.md`](./docs/introduce.md) | What is vlmkit? — narrative introduction assuming zero context |
 | [`docs/markup-assist.md`](./docs/markup-assist.md) | Task-routing guide: which gate for which job, done-condition recipes, anti-gaming rules |
 | [`docs/cli-reference.md`](./docs/cli-reference.md) | Complete command reference: all groups, examples, workflow/API/HTTP, architecture, project structure |
 | [`docs/configuration.md`](./docs/configuration.md) | Install, MCP/skill setup, environment variables, snapshot/CI config, agent skills catalog |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ marked `[key]`.
 | Match a target design | `verify markup --target` (done verdict + fix list) · `build page` / `build component` · `scan mock` (normalize @2x exports) |
 | Track changes over time (VRT) | `snapshot` (baseline → per-viewport diff → `snapshot approve`) · `watch` · `diff-pr` · `baseline` |
 | Compare two versions | `diff html\|png\|elements` · `migration compare` · `check equivalence --region` |
-| Audit design quality | `check tokens\|theme\|palette` · `check a11y contrast\|touch\|focus` · `check perf` · `check drift` · `stress i18n\|media` |
+| Audit design quality | `check tokens\|theme\|palette` · `check design` (is the page consistent with itself — one button style or six) · `check a11y contrast\|touch\|focus` · `check perf` · `check drift` · `stress i18n\|media` |
 | Vet an image asset before it enters a slot | `check asset --slot --expect-transparent --against-bg --page-palette` |
 | Repair | `heal selector` (dead selector) · `heal markup` `[key]` (LLM auto-fix from a kickback) |
 | Wire into agents / pipelines | `mcp` (gate tools over stdio) · `contract` · `workflow` · `markup-loop` · `api` · `bench` · `skill` |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ marked `[key]`.
 | Audit design quality | `check tokens\|theme\|palette` · `check design` (is the page consistent with itself — one button style or six) · `check a11y contrast\|touch\|focus` · `check perf` · `check drift` · `stress i18n\|media` |
 | Vet an image asset before it enters a slot | `check asset --slot --expect-transparent --against-bg --page-palette` |
 | Repair | `heal selector` (dead selector) · `heal markup` `[key]` (LLM auto-fix from a kickback) |
-| Run gates over a whole site | `batch --gate "check integrity" "routes/**/*.html"` (parallel, `--shard i/n`, per-job timing) |
+| Run gates over a whole site | `batch --gate "check integrity" "routes/**/*.html"` (parallel, `--shard i/n`, per-job timing) · `gates run` (same, from one reviewed config) |
+| Audit what has been silenced | `gates suppressions` — every suppression with reason, owner, expiry; expired ones stop applying |
 | Wire into agents / pipelines | `mcp` (gate tools over stdio) · `contract` · `workflow` · `markup-loop` · `api` · `bench` · `skill` |
 
 Task-routing recipes and done-condition sets:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ marked `[key]`.
 | Audit design quality | `check tokens\|theme\|palette` · `check design` (is the page consistent with itself — one button style or six) · `check a11y contrast\|touch\|focus` · `check perf` · `check drift` · `stress i18n\|media` |
 | Vet an image asset before it enters a slot | `check asset --slot --expect-transparent --against-bg --page-palette` |
 | Repair | `heal selector` (dead selector) · `heal markup` `[key]` (LLM auto-fix from a kickback) |
+| Run gates over a whole site | `batch --gate "check integrity" "routes/**/*.html"` (parallel, `--shard i/n`, per-job timing) |
 | Wire into agents / pipelines | `mcp` (gate tools over stdio) · `contract` · `workflow` · `markup-loop` · `api` · `bench` · `skill` |
 
 Task-routing recipes and done-condition sets:

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: vrt
-description: 'Reference for the `vrt` CLI — Visual Regression Testing combined with accessibility (a11y) semantic verification. Use when running `vrt-test` / `vrt` (Playwright VRT) / `vrt-update` / `vlmkit diff html` / `vlmkit snapshot`, configuring the fix-loop CSS challenge benchmark, or picking a VLM model for diff analysis.'
+name: vlmkit
+description: 'Reference for the `vlmkit` CLI — Visual Regression Testing combined with accessibility (a11y) semantic verification. Use when running `vrt-test` / `vlmkit` (Playwright VRT) / `vrt-update` / `vlmkit diff html` / `vlmkit snapshot`, configuring the fix-loop CSS challenge benchmark, or picking a VLM model for diff analysis.'
 ---
 
 # VRT + Semantic Verification — Agent Skill Guide
@@ -93,7 +93,7 @@ pkf run vrt-demo-multistep     # Multi-step
           │
           ▼
 ┌─────────────────────────────────────────────┐
-│ 3. pkf run vrt                              │
+│ 3. pkf run vlmkit                              │
 └─────────┬───────────────────────────────────┘
           │
      ┌────┴────────────────┐

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vrt
-description: 'Reference for the `vrt` CLI — Visual Regression Testing combined with accessibility (a11y) semantic verification. Use when running `vrt-test` / `vrt` (Playwright VRT) / `vrt-update` / `vrt compare` / `vrt snapshot`, configuring the fix-loop CSS challenge benchmark, or picking a VLM model for diff analysis.'
+description: 'Reference for the `vrt` CLI — Visual Regression Testing combined with accessibility (a11y) semantic verification. Use when running `vrt-test` / `vrt` (Playwright VRT) / `vrt-update` / `vlmkit diff html` / `vlmkit snapshot`, configuring the fix-loop CSS challenge benchmark, or picking a VLM model for diff analysis.'
 ---
 
 # VRT + Semantic Verification — Agent Skill Guide

--- a/TODO.md
+++ b/TODO.md
@@ -565,6 +565,31 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   ドキュメントは「ゲートは --json を取る」と書いていたので一貫性の穴でもあった。
   回帰テスト: `packages/vlmkit-markup/src/output-consistency.test.ts`(6 件)。
 
+### ドキュメント刷新(2026-08-02)
+- [x] **`docs/introduce.ja.md` が 7/27 の `vrt` 時代のまま(248 行)だった** —
+  リネーム前のコマンド名で、**すでに削除されたコマンド**(`vrt compare` /
+  `elements` / `smoke` / `serve` / `discover`)を手順として書いており、
+  ディレクトリ構成もフラットな `src/` のまま。読者が写して実行すると必ず失敗する
+  状態だったので、`introduce.md` と同じ構成の**独立した日本語版**として全面改稿。
+  同日追加分(`check design`、`batch` / `gates`、`--allow`、`--json`、
+  マルチ viewport 帰属、`file://` ナビゲーション、リダイレクト検知)を反映し、
+  Honest limits には同日の自己監査 3 レポートを引用。
+- [x] **`introduce.md` 側にも同日の作業で偽になった記述が 2 件あった** —
+  日本語版を書く前に英語版を先に修正した:
+  (a)「integrity にユーザー定義免除リストはまだ無い」→ `--allow
+  "<kind>[@<selector>][@<viewport>];<reason>"` の契約と免除不可 4 kind を明記、
+  (b) ゲート設定は npm script のみ → `vlmkit.gates.json` の例と
+  `gates list|run|suppressions`、reason 必須 / expiry 失効ルールを明記。
+  併せて `check design` の段落を追加。
+- [x] **文中の実行可能な主張を実測で検証** — 文章を信じずに走らせた:
+  `--allow` の構文が実際に `user exemption (...)` 行を出すこと、帰属が
+  `@1280,768,375` と印字されること、免除不可 4 kind が全てエラーになること、
+  `gates suppressions` が存在すること、`--json` が `failures` を持つこと、
+  JSON ブロック 3 つが全てパースでき gates.json ブロックが 3 ページ /
+  7 ゲート実行 / 1 suppression に解決すること、layout-contract と flow の
+  ブロックが各ゲートに受理されること、相対リンク 29 本(ja 17 / en 12)が
+  全て解決すること。
+
 ### Ecosystem positioning (市場調査 2026-07-29 由来)
 調査メモ: `docs/reports/2026-07-29-ai-markup-tooling-landscape.md` /
 設計: `docs/design/mcp-and-agent-expansion.md`

--- a/TODO.md
+++ b/TODO.md
@@ -276,6 +276,21 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 - [ ] **クロス OS フォント決定論の実測レポート** — 2px/6px floor が
   macOS vs Linux 描画で維持されるかの検証(要 macOS 実機)。フォント
   同梱/未同梱の両条件。
+- [ ] **exit code コントラクトの統一(round-10 実測)** — 現状は不統一:
+  verdict 系(integrity DEFECTS / layout VIOLATED / flow FAILED /
+  markup NOT DONE)はフラグ無しで非ゼロ、finding-list 系のうち
+  copy / asset / scroll はゼロ、interactions / handlers は非ゼロ。
+  同じ `scan` グループ内でも scroll と handlers が食い違う。
+  fail-closed 統一(+ `--advisory` オプトアウト)が正しいが、既存 CI の
+  挙動を反転させる破壊的変更なので CHANGELOG + minor bump 必須。
+  docs/introduce.md には実測どおりの分岐を明記済み。
+- [ ] **verify markup: 低コントラスト塗りの取りこぼし(round-10 実測)** —
+  `#f4f4f4` カードを `#ffffff` ページから 2 枚削除(実差分 2.12% px)
+  しても `pixel diff 0.01%` / `DONE`。青に変えれば `missing 2` を正しく
+  検出するので、セグメンテーションの量子化閾値が背景に近い塗りを
+  落としている。`diff png` も同じ閾値を共有(0.01% と報告)。
+  量子化を色差ベースにするか、ΔRGB が小さい領域を別経路で拾う。
+  Honest limits に既知の穴として明記済み。
 - [ ] **text-collision の ink extents 化(round-10 staff engineer 指摘)** —
   現行は text-block の bounding box 重なり(両軸 6px AND + 小さい側の面積
   25%)。細片重なり(縦 18px × 横 3px = 実際に壊れて見える)が床下で無報告。

--- a/TODO.md
+++ b/TODO.md
@@ -299,9 +299,27 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 - [ ] **integrity のユーザー定義免除リスト** — 新規の意図的パターンが
   誤検知されたとき、マークアップ改変か issue 報告しか選択肢がない。
   copy ゲートの `--allow-invisible` に相当する承認可能な仕組み。
-- [ ] **クロス OS フォント決定論の実測レポート** — 2px/6px floor が
-  macOS vs Linux 描画で維持されるかの検証(要 macOS 実機)。フォント
-  同梱/未同梱の両条件。
+- [~] **クロス OS フォント決定論の実測レポート** — 2026-08-02 計測器 +
+  Linux 側実測完了、macOS 実機は未実施(1 コマンドで比較可能な状態にした)。
+  `src/util/font-determinism-probe.ts`(12 テスト)は本番の
+  `COLLECT_INTEGRITY_TEXT` + `findTextCollisions` をそのまま駆動し、
+  ゲートが出さない「各候補ペアの床までの距離」を記録する。
+  ベースラインは `fixtures/collision-fp-corpus/fingerprints/linux-default.json`。
+  実測(20 ページ / 2154 テキストブロック / 121 候補ペア、
+  `docs/reports/2026-08-02-font-determinism-collision-floors.md`):
+  **6 条件すべてで threshold flip 0 件**。
+  同梱条件(同一フェイス・ラスタライザ差 = hinting/subpixel/LCD off)は
+  inkInset 差 max 0.51px / p95 0.00px、dpr2 でも max 1.00px。
+  未同梱条件(フォント置換 = DejaVu Serif / Liberation Sans / WenQuanYi /
+  Noto 同梱)は max 3.00px / p95 ≤1.5px で、それでも床を跨いだペアは 0。
+  差が出た 3 件は「重なり自体が消えた」geometry flip
+  (等幅→プロポーショナルで文字列幅が縮み、絶対配置ラベルが接触しなくなる)
+  であり、両方の描画でそれぞれ正しい判定。第一版はこれを instability と
+  誤報告していたため、tool 側で threshold flip と geometry flip を分離した。
+  **残る穴**: 床から ±2px 以内にいるペアが 121 中 **1 件**しかないため、
+  「摂動しても静か」と「そもそも床付近に何も無い」を分離できていない。
+  強い主張には(a) macOS 実機での `measure` + `compare`、
+  (b) margin ±0.5px に意図的に置いたフィクスチャが必要。
 - [x] **exit code コントラクトの統一(round-10 実測)** — 2026-08-01 完了:
   `packages/vlmkit-core/src/gate-exit.ts` に統一。suspect は既定で
   非ゼロ終了、warn は常に終了コードに影響しない、`--advisory` で

--- a/TODO.md
+++ b/TODO.md
@@ -487,6 +487,17 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   両辺 undefined になる**空アサーション**(tsc が検出、テスト実行では通る)、
   (b) cwd 相対のフィクスチャパスで `pnpm --filter` 実行時にスイート全体が
   ENOENT で落ちるのに**サマリは `0 fail` と表示**していた。
+- [x] **file:// と http:// の verdict 一致確認 + URL 対応の穴埋め** —
+  同一ページをローカル HTTP で配信して 10 ゲートを A/B、**全ゲート一致**
+  (このクラスは元からクリーンだった)。ただし副産物として
+  `check a11y contrast` / `check theme` / `check tokens`(＋`stress i18n`)が
+  URL を渡すと `resolve()` でパスに変形し
+  `<cwd>/http:/host/page.html` として「file not found」になる穴を発見。
+  `openSource` 移行で読み込みは既に URL 対応済みだったので、
+  `resolveSource()`(URL はそのまま / パスだけ resolve)を core に追加し、
+  移行で**デッドコードになっていた** `readFile` を削除して 4 ゲートを
+  URL 対応にした。`check a11y contrast http://localhost:.../page.html` が
+  1.92:1 を正しく報告することを確認。
 - [ ] **ページオープン統一の残り半分** — `chromium.launch` は 44 箇所、
   `waitUntil` は networkidle 72 / load 8 / domcontentloaded 1 のまま。
   今回は「ロード方式が verdict を変えるゲート」だけを移行した。

--- a/TODO.md
+++ b/TODO.md
@@ -266,7 +266,11 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   `--allow-invisible` 承認を集約する reviewed config(現状は npm scripts
   慣行、~20 ページで破綻とドキュメントに明記済み)。suppression 棚卸しが
   grep 頼みなのが tech lead ペルソナの一貫した不満。
-- [ ] **cookie / storage-state 注入** — 認証付きページのゲート実行。
+- [x] **cookie / storage-state 注入** — 2026-08-01 完了:
+  `--storage-state <file>` + `VLMKIT_STORAGE_STATE`、URL 対応 9 ゲート
+  全部に配線。検証は事前に厳格(不在/不正 JSON/形状違い/空 state は
+  ヒント付きで throw)。実際の cookie セッションで E2E 検証済み。
+  旧記述(参考): 認証付きページのゲート実行。
   Playwright の storageState をそのまま受ける `--storage-state <json>`
   が最小案。現状の回避策(no-auth route / ローカルファイル)は checkout
   等の高価値ページで非答。
@@ -276,7 +280,11 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 - [ ] **クロス OS フォント決定論の実測レポート** — 2px/6px floor が
   macOS vs Linux 描画で維持されるかの検証(要 macOS 実機)。フォント
   同梱/未同梱の両条件。
-- [ ] **exit code コントラクトの統一(round-10 実測)** — 現状は不統一:
+- [x] **exit code コントラクトの統一(round-10 実測)** — 2026-08-01 完了:
+  `packages/vlmkit-core/src/gate-exit.ts` に統一。suspect は既定で
+  非ゼロ終了、warn は常に終了コードに影響しない、`--advisory` で
+  print-and-succeed にオプトアウト、`--fail-on-suspect` は受理される
+  no-op として後方互換。旧記述(参考): 現状は不統一:
   verdict 系(integrity DEFECTS / layout VIOLATED / flow FAILED /
   markup NOT DONE)はフラグ無しで非ゼロ、finding-list 系のうち
   copy / asset / scroll はゼロ、interactions / handlers は非ゼロ。

--- a/TODO.md
+++ b/TODO.md
@@ -362,9 +362,19 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   できない。必要な corpus を特定済み: `line-height < 1` のディスプレイ
   書体、見出しの負 margin-bottom、ascent+descent > 1em のフォント、
   `writing-mode: vertical-rl`、回転テキスト。A/B ハーネス自体は再利用可。
-- [ ] **マルチページランナー** — glob 指定で全ページのゲートを並列
-  実行(`vlmkit check integrity "routes/**.html"` 相当)。CI 時間予算
-  の質問に答える sharding / 並列度の実測値も。
+- [x] **マルチページランナー** — 2026-08-02 実装: `vlmkit batch`
+  (`src/cli/commands/batch-cli.ts`、20 テスト)。
+  `--gate "<gate>"` を複数指定 x glob 展開したページで子プロセスを並列実行。
+  判定は**終了コード**のみ(gate-exit 契約の統一が前提)なので runner は
+  レポート形状を一切知らず、新規ゲートは追加当日から batch 可能
+  (`check design` は runner 側変更ゼロで動いた)。
+  `--shard i/n` は stride 分割(同一ディレクトリのページはコストが揃うため
+  連続分割は高コスト部分木を1シャードに寄せる)。
+  実測(4 コア / 9 ページ / check integrity、`docs/reports/2026-08-02-batch-runner-ci-budget.md`):
+  並列 1→34.9s、2→20.0s(1.75x)、4→13.1s(2.66x)、8→11.0s(3.17x)。
+  ジョブ単体時間は並列で膨らむ(合計 34.9s→64.9s)ため、
+  出力は速度向上ではなく「平均同時実行数」を表示する
+  (第一版は 5.9x と誤表示していた)。3 シャード x 並列2 は 7.8/7.8/7.6s。
 
 ### Ecosystem positioning (市場調査 2026-07-29 由来)
 調査メモ: `docs/reports/2026-07-29-ai-markup-tooling-landscape.md` /

--- a/TODO.md
+++ b/TODO.md
@@ -87,7 +87,7 @@ Runs on Cloudflare Workers with Crater. WebUI is in a separate repo.
 - [x] `vlmkit snapshot` command (URL → multi-viewport capture + baseline diff)
 - [x] `vlmkit diff html --url / --current-url` URL mode (page.goto based)
 - [x] `--mask` selector masking (visibility: hidden to exclude dynamic content)
-- [x] Project rename: vrt-harness → vrt
+- [x] Project rename: vrt-harness → vlmkit
 
 ---
 
@@ -95,7 +95,7 @@ Runs on Cloudflare Workers with Crater. WebUI is in a separate repo.
 
 ### E1. Dogfooding on external projects
 
-Use vrt on real projects to verify practicality.
+Use vlmkit on real projects to verify practicality.
 
 - [x] Add `vlmkit snapshot` command (URL → multi-viewport capture + baseline diff)
 - [x] Add `vlmkit diff html --url` URL mode (page.goto based)
@@ -565,7 +565,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   ドキュメントは「ゲートは --json を取る」と書いていたので一貫性の穴でもあった。
   回帰テスト: `packages/vlmkit-markup/src/output-consistency.test.ts`(6 件)。
 
-### `vrt` → `vlmkit` リネーム(2026-08-02)
+### `vlmkit` → `vlmkit` リネーム(2026-08-02)
 - [x] **正解表は CLI 自身** — `vlmkit --help` が出す 33 件の deprecated エイリアス表
   (`a11y-contrast → check a11y contrast` など)を機械的に抽出して写像に使った。
   ソースの正規表現では 15 件しか拾えなかったので、推測ではなく実出力を使うのが正解。
@@ -595,7 +595,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   \`vlmkit check tokens\`」という自己言及になるので、**真の部分**
   (出力先が今も `test-results/design-tokens/`)に書き換えた。
 - [x] **回帰ゲート**: `src/cli/binary-name.test.ts`(28 件)。
-  全 24 コマンドの `--help` を実行して `vrt` を含まないことを検査し、
+  全 24 コマンドの `--help` を実行して `vlmkit` を含まないことを検査し、
   **例外リストも検査する**(許可した綴りが実際にソースに存在するか — 消えたら
   例外を削除すべきで、次の掃除が通り抜ける穴にしてはいけない)。
   アブレーション済み: `vrt design-tokens` を1つ戻すと落ちる。
@@ -604,17 +604,61 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 - [x] **以前の自分の主張の訂正** — introduce.ja.md のコミットで
   「`vrt compare` / `elements` / `smoke` / `serve` / `discover` は削除済み」と書いたが、
   実際は **deprecated エイリアスとして今も動く**(1.0.0 で削除予定)。
-  消えたのは `vrt` バイナリだけ。ドキュメント刷新自体は正しかったが理由が不正確だった。
-- [ ] **残り: 判断が必要(ユーザー確認待ち)**
+  消えたのは `vlmkit` バイナリだけ。ドキュメント刷新自体は正しかったが理由が不正確だった。
+- [x] **挙動に影響する 3 種を後方互換付きで改名(2026-08-02、ユーザー承認)** —
+  `packages/vlmkit-core/src/legacy-names.ts` に集約。旧名は動き続け、使うと
+  **1 行だけ**通知が出る(ループで連呼しないよう名前ごとに 1 回)。
+  - `.vrt/` → `.vlmkit/`。**サブパス単位**で判定する必要があった: `.vlmkit/` は
+    ゲートを 1 回でも走らせた repo には既に存在する(run-ledger / gates /
+    markup-loop / copy-review)ので、「`.vlmkit/` が無ければ `.vrt/`」だと
+    即座に新パスへ解決して `baselines` を取り落とす。判定は
+    `.vlmkit/baselines` vs `.vrt/baselines` の粒度。
+  - `vrt.config.json` / `.toml` → `vlmkit.config.*`。候補リストをデータとして
+    公開したのは、not-found メッセージで**全候補を名指し**する必要があるため
+    (新名だけ挙げると、動いている `vrt.config.json` を持つ repo に
+    「設定が無い」と言うことになる)。
+  - `VRT_*` → `VLMKIT_*`(8 種)。接尾辞だけ渡す API にして呼び出し側が
+    前後半を食い違わせられないようにした。空文字は未設定扱い(従来の `||` と同じ)。
+  - `DEBUG_VRT` → `DEBUG_VLMKIT` は接頭辞なので別関数。
+  - deprecation ログのパスも統一。**コメントは `vlmkit`、コードは `vrt`** と
+    元から食い違っていた。
+  - テスト: `packages/vlmkit-core/src/legacy-names.test.ts`(12 件)。
+    「`.vrt/baselines` がある repo では旧パスに解決する」= 失敗すると
+    全ルートが「新規ベースライン」に見える無音の事故なので、そこを固定。
+- [x] **素の製品名 128 行を機械的に置換(ユーザー選択)** — 業界一般語との衝突は
+  実測で自然に分離できた: **一般用法はすべて大文字 `VRT`**(`commercial VRT
+  vendors`)、製品は小文字 `vrt`。case-sensitive な置換で無害だった。
+  1 件だけ自分の TODO の説明文が置換されたので復元。
+- [x] **識別子の影響調査(ユーザー指示)— 安全に改名できたのは 1 つだけ**
+  - `data-vrt-state-marker` → `data-vlmkit-state-marker`: 設定・照会・削除が
+    `multi-state.ts` 1 モジュールに閉じているので改名済み。
+  - `data-vrt-action`: **公開 API**。ユーザーが自分の HTML に書く属性で
+    `inspect explore` が読む。改名は利用者のページを壊す → 据え置き。
+  - `vrt-page.html` / `vrt.spec.ts`(vlmkit-heal fixture): Playwright の
+    **コミット済みスクリーンショットベースラインのファイル名がスペック名から
+    導出される**。改名するとベースラインが無効化 → 据え置き。
+  - `apm.yml` の `name: vrt`: APM パッケージ識別子。消費者が固定しうる → 据え置き。
+  - GitHub Actions の `jobs: vrt:` / `- id: vrt`: 必須チェック名として参照され得る。
+    据え置き。**ここで自分が壊した**: `- id: vlmkit` にしたが参照側
+    `steps.vrt.outcome` は `vrt.` の形で置換パターンに合わず、`if:` 条件が
+    存在しない step を指す状態になった(テンプレートはパースできるので無音で
+    レビューステップが走らなくなる)。回帰ゲート追加:
+    `binary-name.test.ts` が全 yml の `steps.<id>` 参照に対応する `id:` 定義の
+    存在を検査。アブレーション済み。
+  - `markup-vrt-eval`: example ディレクトリ + package.json スクリプト名 +
+    ワークフローパス `.vrt/markup-vrt-eval/` の 3 箇所にまたがる → 据え置き。
+- [ ] **残り: 据え置き分(上記の理由により)**
   - **挙動に影響 128 箇所**: `.vrt/`(baselines / runs / last-diff-for-agent)、
     `.vrt-skills/`、`vrt.config.json` / `.toml`、`VRT_*` 環境変数(12 種以上)、
     `projectName: "vrt"`(Playwright プロジェクト名 = スナップショットパスに出る)、
     plan スキーマの `vrt?:` **フィールド名**(既存 plan ファイルが壊れる)、
     `"X-Title": "vrt"`(OpenRouter へ送る HTTP ヘッダ)、
-    `title: "vrt HTTP API"`(公開 OpenAPI)、
+    `title: "vlmkit HTTP API"`(公開 OpenAPI)、
     `~/.../vrt/deprecated.log`。改名は既存ユーザーの state / config / CI を孤児化する。
   - **素の製品名 404 箇所**: ただし **VRT は業界一般の略語**(Visual Regression
-    Testing)でもあり、「vrt vendors」「VRT service」は技術一般を指す。
+    Testing)でもあり、大文字の「VRT vendors」「VRT service」は技術一般を指す。
+    実測: 業界一般の用法はすべて大文字 `VRT`、製品を指すものは小文字 `vrt` だったので、
+    case-sensitive な置換で両者は自然に分離できた。
     機械的に置換すると意味が変わるので個別判断が必要。
   - **その他の識別子**: `vrt-eval`(53)、`vrt-diff`(27)、`vrt-action`(16)、
     `vrt-runner.ts`、`vrt-capture.spec.ts` — CI ジョブ名 / fixture 名 /
@@ -644,11 +688,11 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
     修正前 14/14 fail、修正後 14/14 pass を確認。
 - [x] **自分のテストが空回りしていたのを検出して修正** — `\bvrt\s` は正しく見えて
   無意味だった: ヘッダは `\x1b[36mvrt a11y-contrast` で、エスケープが `m`
-  (単語文字)で終わるため `vrt` の前に単語境界が無く、**拒否するために書いた出力に
+  (単語文字)で終わるため `vlmkit` の前に単語境界が無く、**拒否するために書いた出力に
   対して pass** していた。ANSI を除去してから照合するよう修正。
-- [ ] **`vrt` 名の残存 ~250 箇所 / ~80 フレーズ(次の作業)** — 実測: 4 ゲートは
+- [ ] **`vlmkit` 名の残存 ~250 箇所 / ~80 フレーズ(次の作業)** — 実測: 4 ゲートは
   リリース diff に既に入っていたので直したが、全体は `vlmkit snapshot` /
-  `vlmkit workflow` / `vlmkit diff-pr` / `vlmkit baseline` など。`vrt` バイナリは存在せず
+  `vlmkit workflow` / `vlmkit diff-pr` / `vlmkit baseline` など。`vlmkit` バイナリは存在せず
   (`bin` は `vlmkit` のみ)、旧サブコマンド名は deprecated なので
   `Re-run \`vlmkit check a11y contrast\`` は**二重に誤り**。大半はバイナリ名の置換だけで
   済むが、`vlmkit diff html` / `vlmkit diff elements` / `vlmkit inspect smoke` は**すでに削除された
@@ -734,7 +778,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   (乖離すると**有効な**フローを弾き始める)。
 
 ### ドキュメント刷新(2026-08-02)
-- [x] **`docs/introduce.ja.md` が 7/27 の `vrt` 時代のまま(248 行)だった** —
+- [x] **`docs/introduce.ja.md` が 7/27 の `vlmkit` 時代のまま(248 行)だった** —
   リネーム前のコマンド名で、**すでに削除されたコマンド**(`vlmkit diff html` /
   `elements` / `smoke` / `serve` / `discover`)を手順として書いており、
   ディレクトリ構成もフラットな `src/` のまま。読者が写して実行すると必ず失敗する
@@ -1181,7 +1225,7 @@ evaluated incrementally.
   `:focus-visible` / `:active` via CDP `CSS.forcePseudoState`,
   diff per state. `packages/vlmkit-markup/src/stress/multi-state.ts` marks all interactive
   elements (`button`, `a[href]`, `[role=button]`, form controls)
-  with a `data-vrt-state-marker` attribute, opens a CDP session,
+  with a `data-vlmkit-state-marker` attribute, opens a CDP session,
   and calls `forcePseudoState` for each matched node. Pixelmatch
   threshold lowered to 0.03 for state diffs (the default 0.1
   filters hover's typical Δ10-30/channel color shifts). Opt-in
@@ -1281,7 +1325,7 @@ Two remaining single-item gaps from the scenario matrix:
   in Figma / Chrome devtools, then run with `--dpr 2` to verify
   the live render holds up.
 
-Both registered in the unified `vrt` dispatcher. Smoke 15/15 PASS.
+Both registered in the unified `vlmkit` dispatcher. Smoke 15/15 PASS.
 
 Scenario-matrix progress (HEAD → after this commit):
   ✅ 42 → 44 (+2: F3, D4)
@@ -1331,7 +1375,7 @@ In-scope full coverage now **44 / 85 = 52%**; full + partial =
   distinct shadows (allowed 5). Conformant elements (.ok-card,
   .btn-ok) pass cleanly.
 
-Both registered in `vrt` dispatcher. Smoke script updated to
+Both registered in `vlmkit` dispatcher. Smoke script updated to
 14/14 PASS.
 
 Per scenario matrix, this drops missing-scenario count further:
@@ -1380,7 +1424,7 @@ md`): forced-colors, reduced-motion, print, RTL, 200%-zoom.
       despite animation, no print rule, physical props) → **3 ✗ +
       1 ⚠ + 1 ✓** (zoom-200 still reflows fine)
 
-  Registered under `vrt` dispatcher; added to
+  Registered under `vlmkit` dispatcher; added to
   scripts/smoke-all-clis.sh (12/12 PASS).
 
 ### Survey Tier D — real-interaction sequences (2026-05-13)
@@ -1411,7 +1455,7 @@ md`): forced-colors, reduced-motion, print, RTL, 200%-zoom.
   surfaced, including the subtle 0.07% border-color shift on email
   validation.
 
-  Registered under the unified `vrt` dispatcher.
+  Registered under the unified `vlmkit` dispatcher.
 
 ### Survey Tier B / C / F follow-ups (2026-05-13)
 
@@ -1564,7 +1608,7 @@ Three concerns left open after the re-dogfood, all addressed:
 
 - [x] **CLI unification.** All six markup-assistance CLIs +
   `diff-for-agent` + `flipbook` + `compare-runs` now registered
-  under the unified `vrt` dispatcher
+  under the unified `vlmkit` dispatcher
   (src/cli/router.ts + src/cli/vrt.ts). Fixed a
   long-standing bug in the dispatcher: `process.argv[1]` was
   being set to a *relative* module path

--- a/TODO.md
+++ b/TODO.md
@@ -259,6 +259,27 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 
 ## Backlog (prioritize after evaluation)
 
+### introduce.md 評価ループ残渣(2026-08-01 rounds 4-9 由来)
+9 ラウンドのブラインドペルソナ評価で「ドキュメントでは解決できない」
+と分類された機能要求。レポート: `docs/reports/2026-08-01-introduce-doc-eval-loop.md`
+- [ ] **中央ゲート設定ファイル** — ページごとのゲートセット +
+  `--allow-invisible` 承認を集約する reviewed config(現状は npm scripts
+  慣行、~20 ページで破綻とドキュメントに明記済み)。suppression 棚卸しが
+  grep 頼みなのが tech lead ペルソナの一貫した不満。
+- [ ] **cookie / storage-state 注入** — 認証付きページのゲート実行。
+  Playwright の storageState をそのまま受ける `--storage-state <json>`
+  が最小案。現状の回避策(no-auth route / ローカルファイル)は checkout
+  等の高価値ページで非答。
+- [ ] **integrity のユーザー定義免除リスト** — 新規の意図的パターンが
+  誤検知されたとき、マークアップ改変か issue 報告しか選択肢がない。
+  copy ゲートの `--allow-invisible` に相当する承認可能な仕組み。
+- [ ] **クロス OS フォント決定論の実測レポート** — 2px/6px floor が
+  macOS vs Linux 描画で維持されるかの検証(要 macOS 実機)。フォント
+  同梱/未同梱の両条件。
+- [ ] **マルチページランナー** — glob 指定で全ページのゲートを並列
+  実行(`vlmkit check integrity "routes/**.html"` 相当)。CI 時間予算
+  の質問に答える sharding / 並列度の実測値も。
+
 ### Ecosystem positioning (市場調査 2026-07-29 由来)
 調査メモ: `docs/reports/2026-07-29-ai-markup-tooling-landscape.md` /
 設計: `docs/design/mcp-and-agent-expansion.md`

--- a/TODO.md
+++ b/TODO.md
@@ -410,6 +410,32 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   出力は速度向上ではなく「平均同時実行数」を表示する
   (第一版は 5.9x と誤表示していた)。3 シャード x 並列2 は 7.8/7.8/7.6s。
 
+### セッション内リファクタ(2026-08-02)
+- [x] **共有 argv リーダー + 発見した実バグ 4 件の修正** —
+  `packages/vlmkit-core/src/arg-reader.ts`(21 テスト)。
+  `cli-args.ts` は import 時に `process.argv` を束縛しておりテスト不能・
+  ディスパッチャ経由のリーフから使えないため、argv を明示的に受ける
+  `readFlag` / `readAll` / `readNumber` / `readInt` / `readPositionals` /
+  `tokenizeCommand` を追加し、batch / gates / check design / font probe の
+  自前パーサ(4 箇所)を置換。値の欠落・次のフラグの誤食い・非数値は
+  読んだ場所で `UsageError` として失敗し、`handleCliError` が 1 行で表示する。
+  修正した実バグ:
+  (1) **NaN 並列度で何も実行せず成功扱い** — `Array.from({length: NaN})` が
+  0 レーンになり `runPool` が全ジョブを未実行のまま穴の配列を返していた。
+  `runPool` 自体でも限界値を検証。
+  (2) **`--output` のログ衝突** — basename 由来のファイル名だったため
+  `routes/a/index.html` と `routes/b/index.html` が同名になり、並行書き込みで
+  失敗レポートが片方消えていた。フルパス slug + ハッシュに変更(`jobLogName`)。
+  (3) **ゲートフラグの引用符無視** — `--manifest "copy/press kit.txt"` を
+  空白分割していたため複数引数に割れていた。`tokenizeCommand` で解決。
+  (4) **`--min-reuse` 指定時にロール表と verdict が矛盾** — 表がモジュール
+  既定値を見ていたため `COHERENT` の隣に `drift` と表示されていた。
+  実効しきい値を `report.thresholds` に載せた。
+  (5) **`defaults: {gates: []}` が検証を通り全ページ 0 ジョブ** — 空配列を
+  パースエラーにし、解決後 0 ゲートのページも例外にした。
+  `readInt("--concurrency")` が `2.5` を黙って 2 に切り捨てていた
+  parseInt バグも同時に修正(常に parseFloat で読み、整数性を別途検査)。
+
 ### Ecosystem positioning (市場調査 2026-07-29 由来)
 調査メモ: `docs/reports/2026-07-29-ai-markup-tooling-landscape.md` /
 設計: `docs/design/mcp-and-agent-expansion.md`

--- a/TODO.md
+++ b/TODO.md
@@ -259,6 +259,21 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 
 ## Backlog (prioritize after evaluation)
 
+### 美的/デザインポリシー指標(2026-08-01 feasibility study)
+検討記録: `docs/design/design-policy-metrics.md`、計測スクリプト:
+`src/util/design-policy-probe.mjs`
+- [ ] **`check design` — 推論したデザインシステムへの適合検査** —
+  実測で判明した唯一の強い判別軸は **component-signature uniformity**。
+  設計済みページは MDN 1署名/8ボタン、web.dev 1/5 に対し、
+  エージェント生成は s19 6/7、s15 3/6、s16 3/8。
+  逆に **4px グリッド適合は判別に使えない**(エージェントは 0.86-1.00 で
+  MDN 0.857 / web.dev 0.716 を上回る — LLM は丸い数字を必ず使うため)。
+  所見: 生成マークアップは「局所的には整っているが全体として不統一」。
+  findings 案: component-drift / scale-outlier / rail-drift /
+  type-scale-sprawl。既定は warn(taste を fail にしない)。
+  未解決: role 推論の範囲、signature の粒度(height を含めるか)、
+  最小インスタンス数の床、状態(disabled/pressed)の除外方法。
+
 ### introduce.md 評価ループ残渣(2026-08-01 rounds 4-9 由来)
 9 ラウンドのブラインドペルソナ評価で「ドキュメントでは解決できない」
 と分類された機能要求。レポート: `docs/reports/2026-08-01-introduce-doc-eval-loop.md`

--- a/TODO.md
+++ b/TODO.md
@@ -307,7 +307,17 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   落としている。`diff png` も同じ閾値を共有(0.01% と報告)。
   量子化を色差ベースにするか、ΔRGB が小さい領域を別経路で拾う。
   Honest limits に既知の穴として明記済み。
-- [ ] **text-collision の ink extents 化(round-10 staff engineer 指摘)** —
+- [~] **text-collision の ink extents 化(round-10 staff engineer 指摘)** —
+  **2026-08-01: 半分完了。** 提案を独立な2つに分解した。(a) ink band への
+  縮小を既存 finding の *フィルタ* として使う = 指摘を減らすだけなので
+  cry-wolf リスクなし → **実装済み**。corpus 構築時に発覚した実在の偽陽性
+  (kicker + 見出しの負 margin 引き上げ、行ボックス 7px 重なり/実インク
+  2px 空き — ピクセル実測)を解消し、実衝突 133x8.8px は従来どおり検出。
+  副産物のバグも修正: 重なりを ink band で測りつつ面積比を *box* 面積で
+  割っていたため、実衝突が 0.32→0.19 に落ちて消えていた(単位の不一致)。
+  (b) 床自体を下げて細片を拾う方は **未着手・gate 継続**
+  (`fixtures/collision-fp-corpus/sliver-true-positive.html` が判定基準)。
+  旧記述:
   現行は text-block の bounding box 重なり(両軸 6px AND + 小さい側の面積
   25%)。細片重なり(縦 18px × 横 3px = 実際に壊れて見える)が床下で無報告。
   `Range.getClientRects()` / `measureText().actualBoundingBox*` による

--- a/TODO.md
+++ b/TODO.md
@@ -647,6 +647,19 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
     存在を検査。アブレーション済み。
   - `markup-vrt-eval`: example ディレクトリ + package.json スクリプト名 +
     ワークフローパス `.vrt/markup-vrt-eval/` の 3 箇所にまたがる → 据え置き。
+- [x] **同じ失敗の4回目を自分でやっていた(2026-08-02)** — 製品名の掃除が
+  `binary-name.test.ts`(**リネームそのものを説明するファイル**)を裏返していた:
+  「There is no \`vrt\` binary」→「There is no \`vlmkit\` binary」、
+  「~1670 occurrences of \`vrt\`」→「…of \`vlmkit\`」、
+  `json-contract.test.ts` の「no word boundary before \`vrt\`」→「…before \`vlmkit\`」。
+  tsc も他のテストも通り、**自信のあるドキュメントとして読めるまま真逆のことを言う**。
+  最初の3回は差分を読んで気づいたが、4回目は commit・push 後に気づいた。
+  汎用の検出ゲートを追加: **出荷しているバイナリが存在しないと主張するファイルは無い**
+  (`no \`vlmkit\` binary` を全 .ts/.md で検査)。除外は狭く定義した —
+  引用符付きの旧→新の図示形のみ。「矢印を含む行を全部除外」は、
+  このゲートが対象にしている失敗そのものの繰り返しになる。
+  アブレーション済み。加えて `binary-name.test.ts` 自身が旧名の引用を
+  保持していることも検査(消えると例外リストの根拠が失われる)。
 - [ ] **残り: 据え置き分(上記の理由により)**
   - **挙動に影響 128 箇所**: `.vrt/`(baselines / runs / last-diff-for-agent)、
     `.vrt-skills/`、`vrt.config.json` / `.toml`、`VRT_*` 環境変数(12 種以上)、

--- a/TODO.md
+++ b/TODO.md
@@ -565,6 +565,75 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   ドキュメントは「ゲートは --json を取る」と書いていたので一貫性の穴でもあった。
   回帰テスト: `packages/vlmkit-markup/src/output-consistency.test.ts`(6 件)。
 
+### settle 監査 — 「waitUntil 水準合わせは装飾」が誤りだった(2026-08-02)
+レポート: `docs/reports/2026-08-02-settle-not-waituntil.md`
+- [x] **軸が `waitUntil` ではなく settle だった** — `goto(load)` の後に settle すれば
+  networkidle は結局待たれるので、`load` 8 箇所 / `domcontentloaded` 2 箇所は
+  **settle していれば** `networkidle` 71 箇所と等価。水準合わせは何も変えなかった。
+  本当の分かれ目は**アクションと読み取り**: `click`/`fill`/`hover` は auto-wait するが
+  `page.evaluate` / `page.screenshot` / `getBoundingClientRect` はその瞬間の DOM を
+  サンプルする。全ゲートは後者で測っている。だから長く隠れていた。
+- [x] **`load` 後 350ms で描画されるページに対する実測** — 同一ページ・同一瞬間で
+  3 つの異なる誤答、すべて「マークアップの欠陥」として表現されていた:
+  ```
+  check layout   (networkidle + settle)  count .card = 2         ← 正
+  verify flow    (load, settle なし)     count .card = 0, FAIL   ← マークアップを責める
+  build page     (load, settle なし)     settle 後インクの 5.3%  ← 全コンポーネント missing
+  scan contract  (load, settle なし)     0 landmarks             ← settle すれば 4
+  ```
+- [x] **5 箇所に settle を追加** — `verify flow` / `build page` の `renderHtmlToPng` /
+  `fix markup` の computed-style 読み / `heal selector` / `region-selector-match`
+  (後者は `fonts.ready` だけ呼んでいた)。`interaction-map.ts` の `settleAfterLoad` は
+  `settlePage` とバイト単位で同一だったので削除し、根拠(React プレースホルダの
+  2026-08-01 事例)を `settlePage` の doc comment に移した。
+- [x] **`scan contract` はトレードオフが実在した唯一の箇所** — local file を `load` のみで
+  開くのは意図的な速度選択で、`docs/landmark-drilldown-design.md` が機能として謳っていた。
+  主張は真で、挙動は誤り: ビルド済み SPA を file で開くと 0 landmarks(241ms) vs
+  settle して 4 = banner/navigation/main/contentinfo(986ms)。0 は遅い答えではなく
+  **誤った答え**で、下流の contract コマンド全部が読む入力。設計文書は実測コストに更新。
+- [x] **安い primitive を試して却下(負の結果)** — Playwright の networkidle は 500ms 固定の
+  静止待ちなので static local file でも約 500ms かかる。そこで MutationObserver 静止 + rAF で
+  「DOM が変化を止めたか」を測る実装を書いたが両方向で失敗:
+  `static 128ms/landmarks=4`(速く正しい)、`late-render 125ms/landmarks=0`
+  (**描画開始前に settle 宣言**)、`chatty-poll 3025ms`(50ms interval で上限を焼く)。
+  100ms の静止窓は 350ms 遅延描画の最初の mutation より前に経過するので
+  「まだ変わっていない」と「もう変わらない」が区別できない。再発明防止のため記録。
+- [x] **probe 執筆中に見つかった 2 つ目の欠陥: フローファイルのタイポがページ欠陥として報告されていた** —
+  `{"assert":"visble"}` → `FAIL [visble: NO(unknown assert)]`。逆方向はもっと悪く
+  `{"action":"clik"}` → **`done: true`**(`runAction` の switch に default が無く、
+  未知のアクションは黙って落ちてステップは失敗する事後条件を持たないので**緑**)。
+  `validateFlow` がブラウザを開く前に両方を拒否し、該当ステップを名指し
+  (`step 1 ("open menu"), expect[0]`)、有効な名前を列挙し、
+  「これはページ欠陥ではなくフローファイルのエラー」と明言する。
+  `--allow` が未知の finding kind に対して既に適用しているルール。空の `steps` も拒否。
+- [x] **項目の残り 2/3 は実際に装飾だった(仮定ではなく確認)** —
+  (a) `chromium.launch` 47 箇所: 1 ファイルだけが 2 回 launch するが
+  (`src/diff-pr.ts` の `pin` とデフォルト実行 = 別サブコマンド)、残りは
+  1 ゲート起動 = 1 launch。プロセスごとに 1 ゲートを走らせる CLI では
+  それが正しい構造で、`batch` は既にサブプロセスを spawn するので
+  共有ブラウザは何も得ない。数であって浪費ではない。
+  (b) 残る `load` / `domcontentloaded` 10 箇所は settle するようになったので
+  `networkidle` と等価。そのまま残す。
+  意図的に settle しない `goto` が 2 箇所: `font-determinism-probe.ts` は
+  ナビゲーション**後**に style tag を注入するので意味のある唯一の時点で
+  `fonts.ready` を待つ(ネットワークの無い静的フィクスチャ専用)、
+  `vlmkit-generate` の `page.goto` は「呼ぶな」と指示するプロンプト文字列。
+- [x] **アクション / アサート語彙をドキュメント化** — 読者は 1 つの例から
+  アサート名を推測するしかなかった(`visble` はこうして生まれる)。
+  `introduce.md` / `introduce.ja.md` の両方に閉じた集合として記載。
+- [x] **`introduce.md` はコードより先を行っていた** — 「client-rendered app が
+  `load` の後の tick で描画しても **every gate now waits out**」と既に書いてあり、
+  この commit までは 6 ゲートで偽だった。今は真。検証の穴として記録:
+  午前のドキュメント検査は**コマンドとフラグの存在**を確認したが
+  **振る舞いの主張**は確認していなかった。
+- [x] 回帰テスト: `packages/vlmkit-markup/src/settle-consistency.test.ts`(11 件)。
+  空回りでないことをアブレーションで確認 — `page-compose` から `settlePage` を外すと
+  `build page` のテストだけが落ち、`flow-verify` から外すと `verify flow` の
+  2 件だけが落ちる。`scan contract` は件数ではなく role 列で固定(速度理由で
+  戻されやすい)。1 件は `flow-verify.ts` をパースして検証器の名前リストが
+  `FlowAction` / `FlowAssert` の型 union と一致することを主張する
+  (乖離すると**有効な**フローを弾き始める)。
+
 ### ドキュメント刷新(2026-08-02)
 - [x] **`docs/introduce.ja.md` が 7/27 の `vrt` 時代のまま(248 行)だった** —
   リネーム前のコマンド名で、**すでに削除されたコマンド**(`vrt compare` /

--- a/TODO.md
+++ b/TODO.md
@@ -435,6 +435,26 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   パースエラーにし、解決後 0 ゲートのページも例外にした。
   `readInt("--concurrency")` が `2.5` を黙って 2 に切り捨てていた
   parseInt バグも同時に修正(常に parseFloat で読み、整数性を別途検査)。
+- [x] **旧 `cli-args.ts` と残り 7 モジュールの移行(第一版の取りこぼし)** —
+  第一版は新モジュールを追加して今回書いた 4 CLI だけ移行し、
+  **同じ欠陥を持つ旧リーダーを生かしたまま**にしていた(core バレルから
+  export、7 モジュールが使用)。実害を再現: `fix-loop --seed --mode selector`
+  で `getArg("seed")` が `"--mode"` を返し `parseInt` が NaN seed を生成。
+  `cli-args.ts` を `arg-reader` 上の薄いファサードに書き換え(9 テスト)、
+  検証済みの `getIntArg` / `getFloatArg` を追加して
+  smoke-runner / css-challenge / fix-loop / vlm-bench の
+  `parseInt(getArg(...))` を置換。
+  さらに: argv を import 時ではなく呼び出しごとに読むようにし
+  (ディスパッチャ経由のリーフが自分の引数を見られる)、
+  `getPositionalArgs` は値を取るフラグ名を受け取るようにした
+  (旧実装は全フラグが値を取ると仮定し `--md model` の model を落としていた)。
+  `args` export は deprecated として残し、リポジトリ内の利用を
+  `getRawArgs()` に移行。
+  4 つ目の同型パーサ `parseCssChallengeBenchArgs` も移行 —
+  `--trials abc` が NaN trials になり「要求回数を回していないベンチが
+  数字を報告する」状態だった(回帰テスト 3 件追加)。
+  `vlmkit.ts` の catch も `handleCliError` 経由にし、リーフが
+  モジュールスコープで argv を読む場合でも 1 行で表示されるようにした。
 
 ### Ecosystem positioning (市場調査 2026-07-29 由来)
 調査メモ: `docs/reports/2026-07-29-ai-markup-tooling-landscape.md` /

--- a/TODO.md
+++ b/TODO.md
@@ -519,6 +519,31 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   `waitUntil` は networkidle 72 / load 8 / domcontentloaded 1 のまま。
   今回は「ロード方式が verdict を変えるゲート」だけを移行した。
 
+### 差分監査 3 軸(2026-08-02)
+レポート: `docs/reports/2026-08-02-differential-audit-three-axes.md`
+- [x] **viewport 順序 — 欠陥あり、修正済み** — `check integrity` は sweep 全体で
+  finding を dedupe し「最初に観測した」ものを残すため、**呼び出し側が並べた順**で
+  帰属 viewport が変わっていた(`375,768,1280` なら 375、`1280,768,375` なら 1280)。
+  影響 2 点: (a) 数時間前に入れた `--allow "...@1280"` が順序依存で効いたり効かなかった、
+  (b) 全幅で出ている欠陥が「@375」= モバイル限定のように読めた。
+  修正: sweep を内部で**幅の降順にソート**し、狭い幅での再出現は捨てずに
+  `viewports: number[]` に記録。`--allow` は観測されたどの幅でもマッチ。
+  副産物として `btn-c は 1280/768 で崩れて 375 では崩れない` が読めるようになった
+  (以前は表現できなかった情報)。
+- [x] **dpr — 等価性の軸ではない** — `--dpr` を持つのは `build component` だけで、
+  そこでは retina ターゲットに合わせて**意図的に**描画を変える。ゲート側は dpr を
+  取らない。既存の実測(同日のフォント probe)では dpr2 で ink 差 ≤1.00px / flip 0。
+  「未知」として再オープンしないよう記録のみ。
+- [x] **人間向け出力とデータの一致 — 欠陥あり、修正済み** — `check a11y contrast` /
+  `touch` / `focus` は件数を出した後**先頭 5 件のみ表示し、切り詰めを告知していなかった**
+  (12 件が 5 件に見える)。markdown レポートも 20/30 行で無言カット。
+  `check breakpoints` / `check integrity` は既に `… N more` を出していたので同じ文言に統一。
+  **この修正中の自分の誤り**: 告知文に「`--json` で全件」と書いたが、
+  **これらのゲートには `--json` が存在しなかった**。文言を弱めるのではなく
+  4 ゲート(a11y 3 本 + `stress i18n`)に `--json` を追加して主張を真にした。
+  ドキュメントは「ゲートは --json を取る」と書いていたので一貫性の穴でもあった。
+  回帰テスト: `packages/vlmkit-markup/src/output-consistency.test.ts`(6 件)。
+
 ### Ecosystem positioning (市場調査 2026-07-29 由来)
 調査メモ: `docs/reports/2026-07-29-ai-markup-tooling-landscape.md` /
 設計: `docs/design/mcp-and-agent-expansion.md`

--- a/TODO.md
+++ b/TODO.md
@@ -307,7 +307,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   落としている。`diff png` も同じ閾値を共有(0.01% と報告)。
   量子化を色差ベースにするか、ΔRGB が小さい領域を別経路で拾う。
   Honest limits に既知の穴として明記済み。
-- [~] **text-collision の ink extents 化(round-10 staff engineer 指摘)** —
+- [x] **text-collision の ink extents 化(round-10 staff engineer 指摘)** — 2026-08-01 完了(両半分)。
   **2026-08-01: 半分完了。** 提案を独立な2つに分解した。(a) ink band への
   縮小を既存 finding の *フィルタ* として使う = 指摘を減らすだけなので
   cry-wolf リスクなし → **実装済み**。corpus 構築時に発覚した実在の偽陽性
@@ -315,8 +315,15 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   2px 空き — ピクセル実測)を解消し、実衝突 133x8.8px は従来どおり検出。
   副産物のバグも修正: 重なりを ink band で測りつつ面積比を *box* 面積で
   割っていたため、実衝突が 0.32→0.19 に落ちて消えていた(単位の不一致)。
-  (b) 床自体を下げて細片を拾う方は **未着手・gate 継続**
-  (`fixtures/collision-fp-corpus/sliver-true-positive.html` が判定基準)。
+  (b) も同日完了。真のブロッカーは 6px の床ではなく**面積比**だった:
+  実際の graze は小さい側の面積比 0.172(0.25 の床未満)、一方で正当な
+  `line-height:1` 積みが 0.077、引き上げが 0.137 — 母集団が重なるので
+  面積では分離不能。**垂直インク重なり率**なら 1.000 / 0.077 / 0.137 で
+  7倍の空きがあり、`oy >= max(2px, 0.5 x 短い側のインク高さ)` を採用。
+  実ページ A/B(8ページ×3ビューポート)は **新規0件・消失16件** で、
+  16件すべて面積比ゲートが「隠していた」既存の偽陽性
+  (MDN 14→0: 閉じた `<details>` の中身がレイアウトボックスを保持;
+  APG 2→0: 要素と自身の inline 子孫のペア)。
   旧記述:
   現行は text-block の bounding box 重なり(両軸 6px AND + 小さい側の面積
   25%)。細片重なり(縦 18px × 横 3px = 実際に壊れて見える)が床下で無報告。

--- a/TODO.md
+++ b/TODO.md
@@ -456,6 +456,41 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   `vlmkit.ts` の catch も `handleCliError` 経由にし、リーフが
   モジュールスコープで argv を読む場合でも 1 行で表示されるようにした。
 
+### 共有ページオープン + 外部アセット未解決バグ(2026-08-02)
+- [x] **6 ゲートが「別のドキュメント」を測っていた** — リファクタ候補の
+  棚卸し中に発見。`page.setContent(await readFile(file))` は base URL が
+  `about:blank` になるため相対 `<link rel="stylesheet">` が一切読まれず、
+  実プロジェクト(CSS を外部ファイルに置く)では**無スタイルの DOM を測って
+  合格**していた。`page.goto(pathToFileURL(file))` との差。
+  ファイル一覧では 10 本だったが、実測すると壊れていたのは **6 本**
+  (a11y contrast / a11y touch / check tokens / check theme / stress i18n /
+  stress media)。残り 4 本(a11y focus / breakpoints / copy / design)は
+  元から正しく navigate していた — 仮定ではなく計測で確定させた。
+  特に 2 件は「件数が減る」では済まない:
+  **a11y touch は判定が反転** — CSS でサイズが付く 20x20 のタップ標的を
+  そもそも候補にできず(無スタイルでは 0 サイズの inline `<a>`)、
+  一方でスタイル適用後は準拠しているボタン 3 個を無スタイル寸法で
+  「小さすぎる」と報告していた。真の 1 件を見逃して偽の 3 件を作る状態。
+  **stress media は pass/fail が反転** — forced-colors が
+  無スタイルで `Δ 0.36% → 失敗`、CSS 適用で `Δ 1.46% → 合格`。
+  修正: `packages/vlmkit-core/src/page-open.ts`(`openSource` / `openHtml` /
+  `settlePage`、auth-state と redirect 記述も統合)。
+  `openHtml` は「`<base>` 注入」ではなく**先に navigate してから setContent**。
+  `<base>` 注入は実測で効かない(setContent のドキュメントは opaque origin で
+  Chromium が `file://` サブリソースを遮断 — 実測 rgb(0,0,0) vs rgb(4,5,6))ため、
+  効かないと計測できた技法は残さず削除した。
+  回帰ゲート: `fixtures/external-assets/`(全欠陥を `style.css` にのみ宣言)+
+  `packages/vlmkit-markup/src/external-assets.test.ts`(インライン化した双子と
+  同一 verdict を要求する差分アサーション)。
+  レポート: `docs/reports/2026-08-02-external-asset-load-defect.md`。
+  執筆中に踏んだ罠 2 件も記録: (a) `${o.selector}` が実際は `path` で
+  両辺 undefined になる**空アサーション**(tsc が検出、テスト実行では通る)、
+  (b) cwd 相対のフィクスチャパスで `pnpm --filter` 実行時にスイート全体が
+  ENOENT で落ちるのに**サマリは `0 fail` と表示**していた。
+- [ ] **ページオープン統一の残り半分** — `chromium.launch` は 44 箇所、
+  `waitUntil` は networkidle 72 / load 8 / domcontentloaded 1 のまま。
+  今回は「ロード方式が verdict を変えるゲート」だけを移行した。
+
 ### Ecosystem positioning (市場調査 2026-07-29 由来)
 調査メモ: `docs/reports/2026-07-29-ai-markup-tooling-landscape.md` /
 設計: `docs/design/mcp-and-agent-expansion.md`

--- a/TODO.md
+++ b/TODO.md
@@ -325,13 +325,11 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   同日実装**(決定論 hit-test + 偽陽性 3 クラスの免除設計、M14a-d 常設、
   S15-18 回帰 CLEAN)。Layer B は凍結のまま(決定論で足りた)。
   `docs/reports/2026-07-31-s19-game-ui-occlusion-probe.md`
-- [ ] **【リリースブロッカー】@mizchi/vlmkit の新バージョン公開** —
-  2026-07-31 のブラックボックス検証で確定: 公開中の 0.7.0 には
-  markup-assist の主要ゲート(check integrity / copy manifest sweep /
-  layout / interactions ほか)が**存在しない**。quickstart / ガイド /
-  skill は npm 導入者には現状動かない(`Unknown check subcommand`)。
-  npm publish は要権限のため本環境では未実施 — バージョンを上げて
-  公開するまで「入れるだけで使える」は npm 経路では成立しない。
+- [x] **【解消 2026-08-01】リリースブロッカー: @mizchi/vlmkit の新バージョン公開** —
+  2026-07-31 のブラックボックス検証で「公開中の 0.7.0 に markup-assist の
+  主要ゲートが存在しない(`Unknown check subcommand`)」を確認しブロッカー
+  登録 → main の `release: 0.8.0`(24b0185)で解消。markup-assist ゲート群が
+  npm 導入者に届く。
   `docs/reports/2026-07-31-blackbox-onboarding-validation.md`
 - [x] **ブラックボックス・オンボーディング検証(文脈ゼロのエージェント + docs のみ)** —
   2026-07-31 実施: 架空プロジェクト + 欠陥 5 種 + TASK.md(ゲート名を

--- a/TODO.md
+++ b/TODO.md
@@ -262,17 +262,24 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 ### 美的/デザインポリシー指標(2026-08-01 feasibility study)
 検討記録: `docs/design/design-policy-metrics.md`、計測スクリプト:
 `src/util/design-policy-probe.mjs`
-- [ ] **`check design` — 推論したデザインシステムへの適合検査** —
+- [x] **`check design` — 推論したデザインシステムへの適合検査** —
+  2026-08-02 実装: `packages/vlmkit-markup/src/style/design-policy.ts`
+  (`vlmkit check design <html|url>`、22 テスト)。
   実測で判明した唯一の強い判別軸は **component-signature uniformity**。
   設計済みページは MDN 1署名/8ボタン、web.dev 1/5 に対し、
   エージェント生成は s19 6/7、s15 3/6、s16 3/8。
   逆に **4px グリッド適合は判別に使えない**(エージェントは 0.86-1.00 で
   MDN 0.857 / web.dev 0.716 を上回る — LLM は丸い数字を必ず使うため)。
   所見: 生成マークアップは「局所的には整っているが全体として不統一」。
-  findings 案: component-drift / scale-outlier / rail-drift /
-  type-scale-sprawl。既定は warn(taste を fail にしない)。
-  未解決: role 推論の範囲、signature の粒度(height を含めるか)、
-  最小インスタンス数の床、状態(disabled/pressed)の除外方法。
+  実装したのは component-drift(verdict を担う)+ scale-outlier(info)。
+  rail-drift は A12 と重複、type-scale-sprawl は font-size 分布が
+  spacing と同じく両群で重なるため不採用。
+  未解決だった 4 点(role 推論の範囲 / signature 粒度 / インスタンス床 /
+  状態除外)はすべて決着 — 経緯と実装後の 12 ページ実測は
+  `docs/design/design-policy-metrics.md` の "Implemented" 節。
+  第一実装が MDN と web.dev を DRIFT と誤判定した(rem 由来の
+  21.4px vs 21.3px 等)ため scale-outlier に 4 つの絞りを追加し、
+  verdict からも外した。
 
 ### introduce.md 評価ループ残渣(2026-08-01 rounds 4-9 由来)
 9 ラウンドのブラインドペルソナ評価で「ドキュメントでは解決できない」

--- a/TODO.md
+++ b/TODO.md
@@ -565,6 +565,47 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   ドキュメントは「ゲートは --json を取る」と書いていたので一貫性の穴でもあった。
   回帰テスト: `packages/vlmkit-markup/src/output-consistency.test.ts`(6 件)。
 
+### 0.9.0 リリース準備(2026-08-02)
+- [x] **CHANGELOG が今日の作業を一切含んでいなかった** — Unreleased セクションは
+  `24b0185`(0.8.0)以降の前半分だけで、今日追加した `check design` / `batch` /
+  `gates` / `--allow` / `--json` / 外部アセット修正 / viewport 順序 / 認証壁 /
+  settle 修正がすべて欠けていた。0.9.0 として整理(破壊的変更があるので 0.x では minor)。
+- [x] **リリース検証でビルド済み CLI を叩いて欠陥 2 件を発見** — 関数の戻り値では
+  なく実際の成果物を動かして見つかったもの:
+  - **`--json` が壊れていた(今朝自分が入れた機能)** — 人間向けブロックを先に
+    stdout へ出していたので `JSON.parse` が 1 行目で落ちる。しかも切り詰め告知が
+    「`--json` で全件」とその壊れたストリームを指していた。原因は検証方法の誤り:
+    当時 `report.failures.length` を**関数から**確認しており、stdout を一度も見て
+    いなかった。`quiet` オプションを 4 ゲートに追加し、既存ゲートと同じ
+    `if (json) … else …` の排他にした。
+  - **`stress i18n` は 6 行で切って告知していなかった** — 今朝の切り詰め修正が
+    3 ゲートにしか当たっておらず、このゲートは `--json` だけ貰って告知を貰って
+    いなかった(告知が無いのに CLI コメントは「告知はここを指す」と書いていた)。
+  - 回帰テスト: `packages/vlmkit-markup/src/json-contract.test.ts`(14 件)。
+    **実際の CLI を spawn する** — 関数呼び出しでは今回の欠陥は原理的に検出できない。
+    修正前 14/14 fail、修正後 14/14 pass を確認。
+- [x] **自分のテストが空回りしていたのを検出して修正** — `\bvrt\s` は正しく見えて
+  無意味だった: ヘッダは `\x1b[36mvrt a11y-contrast` で、エスケープが `m`
+  (単語文字)で終わるため `vrt` の前に単語境界が無く、**拒否するために書いた出力に
+  対して pass** していた。ANSI を除去してから照合するよう修正。
+- [ ] **`vrt` 名の残存 ~250 箇所 / ~80 フレーズ(次の作業)** — 実測: 4 ゲートは
+  リリース diff に既に入っていたので直したが、全体は `vrt snapshot` /
+  `vrt workflow` / `vrt diff-pr` / `vrt baseline` など。`vrt` バイナリは存在せず
+  (`bin` は `vlmkit` のみ)、旧サブコマンド名は deprecated なので
+  `Re-run \`vrt a11y-contrast\`` は**二重に誤り**。大半はバイナリ名の置換だけで
+  済むが、`vrt compare` / `vrt elements` / `vrt smoke` は**すでに削除された
+  コマンド**への参照で、`vrt itself` / `vrt toolkit` のような散文も混ざる。
+  リリースコミットに 250 箇所の改名を混ぜず、レビュー可能な独立した diff にする。
+  正解表は `src/cli/cli.ts` の `newName` マップ(15 エントリ)。
+  CHANGELOG 0.9.0 の Known issues に明記済み。
+- [x] リリース検証: tsc クリーン / `pnpm test` 1813 pass / `smoke-dist.sh` 11 pass /
+  ビルド済みバイナリで `check design`・`batch`・`gates`・`--allow`(免除不可 kind の
+  エラー含む)・`--json` 4 本を実走。
+- [ ] **`npm publish` は未実行** — この環境に npm 認証が無い(`npm whoami` は
+  ENEEDAUTH、`NPM_TOKEN` 未設定)。バージョン確定・CHANGELOG・ビルド・スモークまで
+  完了しているので、認証のある環境で publish するだけ。0.8.0 は git tag が
+  打たれていない(タグは `v0.5.0` のみ)ので、タグ運用は現状に合わせて未実施。
+
 ### settle 監査 — 「waitUntil 水準合わせは装飾」が誤りだった(2026-08-02)
 レポート: `docs/reports/2026-08-02-settle-not-waituntil.md`
 - [x] **軸が `waitUntil` ではなく settle だった** — `goto(load)` の後に settle すれば

--- a/TODO.md
+++ b/TODO.md
@@ -316,6 +316,13 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   22 本バッテリーでの FP 再監査を通すまで着手しない**(床を緩めるのが
   ゲート不信の典型経路)。docs/introduce.md の Honest limits に既知の
   盲点として明記済み。
+  **2026-08-01 追記(FP 再監査の結論)**: 実サイト8ページの A/B 監査
+  (`docs/reports/2026-08-01-fp-reaudit.md`)を実施したが、**この gate は
+  まだ開いていない**。corpus 全体で text-collision の検出が1件しかなく、
+  「床を緩めても誤報しない」と「たまたま床付近に何も無かった」を区別
+  できない。必要な corpus を特定済み: `line-height < 1` のディスプレイ
+  書体、見出しの負 margin-bottom、ascent+descent > 1em のフォント、
+  `writing-mode: vertical-rl`、回転テキスト。A/B ハーネス自体は再利用可。
 - [ ] **マルチページランナー** — glob 指定で全ページのゲートを並列
   実行(`vlmkit check integrity "routes/**.html"` 相当)。CI 時間予算
   の質問に答える sharding / 並列度の実測値も。

--- a/TODO.md
+++ b/TODO.md
@@ -312,9 +312,26 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   Playwright の storageState をそのまま受ける `--storage-state <json>`
   が最小案。現状の回避策(no-auth route / ローカルファイル)は checkout
   等の高価値ページで非答。
-- [ ] **integrity のユーザー定義免除リスト** — 新規の意図的パターンが
-  誤検知されたとき、マークアップ改変か issue 報告しか選択肢がない。
-  copy ゲートの `--allow-invisible` に相当する承認可能な仕組み。
+- [x] **integrity のユーザー定義免除リスト** — 2026-08-02 実装:
+  `check integrity --allow "<kind>[@<selector>][@<viewport>];<reason>"`
+  (`packages/vlmkit-markup/src/inspect/integrity-exemption.ts`、18 テスト)。
+  盲目化を防ぐ 3 つの規則:
+  (1) **理由が必須** — `;<reason>` が無いとパースエラー。
+  (2) **未知の kind はエラー**(有効な kind を列挙) — `low-contrast-txt` が
+  「何も黙らせないのに適用されたように見える」のが suppression フラグ最悪の挙動。
+  (3) **免除した finding はレポートに残る** — `exempted` に理由付きで移動し、
+  「あなたの判断」節としてツール側免除と分けて表示。さらに
+  **どの finding にもマッチしなかった rule を報告**(死んだ設定が
+  盲点を広げ続けるのを防ぐ)。
+  `js-error` / `degenerate-render` / `unstyled-page` / `redirected` は
+  免除不可(意図的デザインではなく「ページが壊れている/測定不能」の報告なので)。
+  ライフサイクル(owner / 期限 / 棚卸し)は `vlmkit.gates.json` 側に委譲 —
+  期限切れでフラグが適用されなくなりゲートが素で走ることを E2E で確認済み。
+  MCP の `check_integrity` にも `allow` を追加。
+  **設計上の失敗を 1 件記録**: 最初は理由の区切りを `#` にしていたため
+  ID セレクタ(`text-collision@#refund;...`)がセレクタ自身の `#` で分割され、
+  空セレクタ = 書いたより広い免除になっていた。`;` に変更
+  (CSS セレクタには現れない)。`#` を使った場合は専用のヒントを出す。
 - [~] **クロス OS フォント決定論の実測レポート** — 2026-08-02 計測器 +
   Linux 側実測完了、macOS 実機は未実施(1 コマンドで比較可能な状態にした)。
   `src/util/font-determinism-probe.ts`(12 テスト)は本番の

--- a/TODO.md
+++ b/TODO.md
@@ -284,10 +284,26 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 ### introduce.md 評価ループ残渣(2026-08-01 rounds 4-9 由来)
 9 ラウンドのブラインドペルソナ評価で「ドキュメントでは解決できない」
 と分類された機能要求。レポート: `docs/reports/2026-08-01-introduce-doc-eval-loop.md`
-- [ ] **中央ゲート設定ファイル** — ページごとのゲートセット +
-  `--allow-invisible` 承認を集約する reviewed config(現状は npm scripts
-  慣行、~20 ページで破綻とドキュメントに明記済み)。suppression 棚卸しが
-  grep 頼みなのが tech lead ペルソナの一貫した不満。
+- [x] **中央ゲート設定ファイル** — 2026-08-02 実装: `vlmkit.gates.json` +
+  `vlmkit gates init|list|run|suppressions`
+  (`packages/vlmkit-core/src/gate-config.ts` = 純粋なパース/解決、
+  `src/cli/commands/gates-cli.ts` = CLI、計 37 テスト)。
+  ページごとの gates / extraGates / suppressions を 1 ファイルに集約し、
+  実行は `batch` の `runJobs` を再利用(プール・計測・ログ・シャーディング共通)。
+  レビュー可能にするための決定 2 点:
+  (1) **suppression には reason 必須**(無いとパース失敗)。フラグだけでは
+  「何を黙らせたか」は残るが「なぜ」が残らず、1 年後に再承認される。
+  (2) **期限切れ suppression は適用しない** — 黙らせていたゲートが素で走り、
+  ページが通っても run は非ゼロ終了(stale なエントリ自体が config の欠陥)。
+  期限切れは実行**前**に別フォーマットで表示し、
+  「これは新規リグレッションではない」と明示する。
+  `gates suppressions` が grep 頼みの棚卸しへの回答(reason/owner/期限/残日数、
+  `--require-expiry` / `--require-owner` で締められる)。
+  glob source は 1 ファイル 1 ジョブに展開し、id は `docs:routes/a.html` の形で
+  config 名を保持(`--only` とページ単位シャーディングがそのまま効く)。
+  シャーディングはページ単位 — 同一ページのゲートを別ランナーに割ると
+  ログが 2 箇所に散るだけで得がない。
+  例: `examples/vlmkit.gates.json`。
 - [x] **cookie / storage-state 注入** — 2026-08-01 完了:
   `--storage-state <file>` + `VLMKIT_STORAGE_STATE`、URL 対応 9 ゲート
   全部に配線。検証は事前に厳格(不在/不正 JSON/形状違い/空 state は

--- a/TODO.md
+++ b/TODO.md
@@ -276,6 +276,15 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 - [ ] **クロス OS フォント決定論の実測レポート** — 2px/6px floor が
   macOS vs Linux 描画で維持されるかの検証(要 macOS 実機)。フォント
   同梱/未同梱の両条件。
+- [ ] **text-collision の ink extents 化(round-10 staff engineer 指摘)** —
+  現行は text-block の bounding box 重なり(両軸 6px AND + 小さい側の面積
+  25%)。細片重なり(縦 18px × 横 3px = 実際に壊れて見える)が床下で無報告。
+  `Range.getClientRects()` / `measureText().actualBoundingBox*` による
+  グリフインク範囲へ移行すれば拾えるが、`line-height < 1` / 負マージンの
+  行ボックス重なりが偽陽性に化けるリスクが高い。**7 サイト外部監査 +
+  22 本バッテリーでの FP 再監査を通すまで着手しない**(床を緩めるのが
+  ゲート不信の典型経路)。docs/introduce.md の Honest limits に既知の
+  盲点として明記済み。
 - [ ] **マルチページランナー** — glob 指定で全ページのゲートを並列
   実行(`vlmkit check integrity "routes/**.html"` 相当)。CI 時間予算
   の質問に答える sharding / 並列度の実測値も。

--- a/TODO.md
+++ b/TODO.md
@@ -292,7 +292,15 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   fail-closed 統一(+ `--advisory` オプトアウト)が正しいが、既存 CI の
   挙動を反転させる破壊的変更なので CHANGELOG + minor bump 必須。
   docs/introduce.md には実測どおりの分岐を明記済み。
-- [ ] **verify markup: 低コントラスト塗りの取りこぼし(round-10 実測)** —
+- [x] **verify markup: 低コントラスト塗りの取りこぼし(round-10 実測)** —
+  2026-08-01 完了: 原因は 2 箇所の閾値。(1) 前景判定が固定 tolerance 12
+  で `#f4f4f4` on white(距離 11)を背景と分類 → 画像自身のノイズ床から
+  導出する `adaptiveBgTolerance`(クリーン描画 4 / ノイズ多い書き出しは
+  従来の 12 まで、上限は 12 なので従来より鈍くなることはない)。
+  (2) pixel-presence の fillTolerance 25 が白(距離 14)を「塗りあり」と
+  誤判定 → 背景色との距離の半分未満にクランプ。実測で `missing 0` →
+  `missing 2 (genuinely absent)`、同一ページは 4 件一致 0.00% で偽陽性なし。
+  旧記述(参考):
   `#f4f4f4` カードを `#ffffff` ページから 2 枚削除(実差分 2.12% px)
   しても `pixel diff 0.01%` / `DONE`。青に変えれば `missing 2` を正しく
   検出するので、セグメンテーションの量子化閾値が背景に近い塗りを

--- a/TODO.md
+++ b/TODO.md
@@ -515,9 +515,30 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   移行で**デッドコードになっていた** `readFile` を削除して 4 ゲートを
   URL 対応にした。`check a11y contrast http://localhost:.../page.html` が
   1.92:1 を正しく報告することを確認。
-- [ ] **ページオープン統一の残り半分** — `chromium.launch` は 44 箇所、
-  `waitUntil` は networkidle 72 / load 8 / domcontentloaded 1 のまま。
-  今回は「ロード方式が verdict を変えるゲート」だけを移行した。
+- [x] **「残り半分は装飾」という自分のラベルが誤りだった(2026-08-02)** —
+  実測: `/app` が session cookie 無しで `/login` に 302 するローカルサーバを立て、
+  URL 対応かつ `--storage-state` を持つ(= 認証ページ向けに設計された)ゲートに
+  当てたところ、**redirect 検出を持たない 5 本が login ページを測っていた**:
+  `check breakpoints` / `check scroll` / `scan scroll` は **`status: ok`**
+  (静かな偽 pass)、`check layout` は `count: expected 2, measured 0` で
+  **マークアップのせいに見える失敗**、`verify flow` は全ステップが
+  「要素が見つからない」で落ちる。いずれもレポートの source 行には
+  要求した URL を表示していた。装飾ではなく、integrity / copy / design で
+  修正済みだった沈黙偽 pass と同じクラスを 5 本に残していた。
+  修正: 5 本に `describeRedirect` を配線し、**status/verdict を動かす**
+  (issue 系は `redirected` を suspect で unshift、`done` 系は
+  `done = ... && !redirected`)。理由も必ず印字する
+  (`check breakpoints` は sweep 無しで早期 return するため status だけ
+  変わって理由が出ない状態を別途修正)。
+  副産物: redirect メッセージが「vlmkit cannot inject a session」という
+  **`--storage-state` 追加後に偽になった文言**を保持しており、
+  それを固定するテストまで存在した。両方を修正。
+  回帰テスト: `packages/vlmkit-markup/src/auth-wall.test.ts`(7 件、
+  実際に 302 するサーバを立てる)。
+- [ ] **ページオープン統一の残り(純粋な整理)** — `chromium.launch` 44 箇所、
+  `waitUntil` は networkidle 72 / load 8 / domcontentloaded 1。
+  **verdict を変える差は上記で解消済み**。残るのは重複コードの削減と
+  fonts.ready 待ちの平準化で、こちらは実際に装飾。
 
 ### 差分監査 3 軸(2026-08-02)
 レポート: `docs/reports/2026-08-02-differential-audit-three-axes.md`

--- a/TODO.md
+++ b/TODO.md
@@ -84,8 +84,8 @@ Runs on Cloudflare Workers with Crater. WebUI is in a separate repo.
 - [x] Playwright page reuse (fix-loop), PNG IHDR header reading, Gemini SDK init optimization
 
 ### Snapshot / URL Compare
-- [x] `vrt snapshot` command (URL → multi-viewport capture + baseline diff)
-- [x] `vrt compare --url / --current-url` URL mode (page.goto based)
+- [x] `vlmkit snapshot` command (URL → multi-viewport capture + baseline diff)
+- [x] `vlmkit diff html --url / --current-url` URL mode (page.goto based)
 - [x] `--mask` selector masking (visibility: hidden to exclude dynamic content)
 - [x] Project rename: vrt-harness → vrt
 
@@ -97,35 +97,35 @@ Runs on Cloudflare Workers with Crater. WebUI is in a separate repo.
 
 Use vrt on real projects to verify practicality.
 
-- [x] Add `vrt snapshot` command (URL → multi-viewport capture + baseline diff)
-- [x] Add `vrt compare --url` URL mode (page.goto based)
+- [x] Add `vlmkit snapshot` command (URL → multi-viewport capture + baseline diff)
+- [x] Add `vlmkit diff html --url` URL mode (page.goto based)
 - [x] luna.mbt dogfooding: false positive rate 0% (6 pages × 2 viewports)
 - [x] sol.mbt dogfooding: false positive rate 20% (dynamic content on root page)
 - [x] Record results in `docs/reports/2026-04-05-dogfood-luna-sol.md`
 - [x] sample-webapp-2026 dogfood で出た snapshot UX を改善する
   - `snapshot` の label 生成が query string を見ないため、`/` と `/?severity=critical` が同じ baseline に潰れる
   - `--label` / route manifest / query-aware label のどれかで URL ごとの identity を安定化したい
-- [x] `vrt snapshot` に CI 向け fail 条件を持たせる
+- [x] `vlmkit snapshot` に CI 向け fail 条件を持たせる
   - sample では `snapshot-report.json` を読んで回帰判定する `scripts/vrt-snapshot.mjs` が必要だった
   - `--fail-on-diff`, `--fail-on-new-baseline`, `--max-diff-ratio` を CLI に持たせたい
 - [x] `snapshot` 系の baseline approve を first-class にする
   - sample では `scripts/vrt-approve.mjs` で `*-current.png` を `*-baseline.png` にコピーしている
-  - `vrt snapshot approve` もしくは `vrt snapshot --approve` が欲しい
+  - `vlmkit snapshot approve` もしくは `vlmkit snapshot --approve` が欲しい
 - [x] 外部プロジェクト向けに `workflow` の route/spec coupling を外す
   - `e2e/vrt-capture.spec.ts` が `vrt.config.json` (`capture.routes`) / `VRT_CONFIG_PATH` / `VRT_CAPTURE_ROUTES` から routes を読むようになった
-  - `vrt workflow init|capture --config <path> --base-url <url>` で外部プロジェクトから差し込み可能
-- [x] `vrt snapshot` の config file を公式サポートする
+  - `vlmkit workflow init|capture --config <path> --base-url <url>` で外部プロジェクトから差し込み可能
+- [x] `vlmkit snapshot` の config file を公式サポートする
   - sample では `vrt.config.json` に `baseUrl`, `routes`, `outputDir`, `threshold` を寄せて wrapper で解釈している
   - JSON/TOML の config を直接読めると導入がかなり軽くなる
 - [x] Run VRT in CI per PR, measure false positive rate
-  - `vrt snapshot stability <urls> --iterations N --fail-above-rate R` measures the FP rate by capturing N times against a locked baseline.
+  - `vlmkit snapshot stability <urls> --iterations N --fail-above-rate R` measures the FP rate by capturing N times against a locked baseline.
   - `.github/workflows/vrt-stability.yml` runs the measurement nightly on the migration fixtures and uploads `stability-report.json` as an artifact.
-  - `vrt snapshot stability-history <stability-report.json>... [--out path]` aggregates multiple runs over time and reports latest/best/worst FP rate plus run-to-run deltas.
+  - `vlmkit snapshot stability-history <stability-report.json>... [--out path]` aggregates multiple runs over time and reports latest/best/worst FP rate plus run-to-run deltas.
   - Real downstream rollout still requires adopting the workflow in each project, but vlmkit now has the measurement and aggregation primitives.
 - [x] Pass diff report to subagent for fix code generation, measure success rate
-  - `vrt snapshot fix-prompt` ships a markdown / JSON task descriptor (URL, viewport, diff ratio with shift compensation, baseline/current/heatmap/HTML paths) ready to feed to a subagent.
-  - `vrt snapshot report evaluate --before-report before.json --after-report after.json` compares pre/post fix `snapshot-report.json` files and reports resolved/improved rates for the changed label+viewport targets.
-  - `vrt migration subagent prepare` (and the `migration-subagent-prepare` task) produces a subagent packet from `migration-report.json`; `vrt migration blind` provides reproducible blind scenarios.
+  - `vlmkit snapshot fix-prompt` ships a markdown / JSON task descriptor (URL, viewport, diff ratio with shift compensation, baseline/current/heatmap/HTML paths) ready to feed to a subagent.
+  - `vlmkit snapshot report evaluate --before-report before.json --after-report after.json` compares pre/post fix `snapshot-report.json` files and reports resolved/improved rates for the changed label+viewport targets.
+  - `vlmkit migration subagent prepare` (and the `migration-subagent-prepare` task) produces a subagent packet from `migration-report.json`; `vlmkit migration blind` provides reproducible blind scenarios.
   - Real PR measurement still requires an LLM API key and repeated downstream runs, but vlmkit now has the report packet and success-rate evaluation primitives.
 
 ### E2. Crater prescanner tracking
@@ -250,7 +250,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   - Fixture scaffolding done: `after-reference.html` archived, `after-blank.html` provides minimal reset starting point.
   - Baseline diff measured at 19.6%–58.4% across 10 viewports (35 layout-shift, 19 color-change, 4 typography).
   - `fixtures/migration/blind-scenarios.json` + `migration-blind.ts` (`prepare` / `solo` / `evaluate`) now reproduce + score the shadcn→luna scenario deterministically.
-  - 2026-05-22: `vrt migration blind ... solo shadcn-to-luna --check` passes the reference repair at 0.0% across 7 auto-discovered viewports; actual LLM blind loop still pending.
+  - 2026-05-22: `vlmkit migration blind ... solo shadcn-to-luna --check` passes the reference repair at 0.0% across 7 auto-discovered viewports; actual LLM blind loop still pending.
   - Loop run itself requires an LLM API key — see `docs/reports/2026-05-11-e3-shadcn-luna-blind-scaffold.md`.
 - [x] Blind test with Reset CSS switch — see `docs/reports/2026-04-04-e3-reset-css-blind-test.md` (0.0% in 1 round)
 - [ ] Success criteria: diff < 1% within 3 rounds
@@ -565,6 +565,64 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   ドキュメントは「ゲートは --json を取る」と書いていたので一貫性の穴でもあった。
   回帰テスト: `packages/vlmkit-markup/src/output-consistency.test.ts`(6 件)。
 
+### `vrt` → `vlmkit` リネーム(2026-08-02)
+- [x] **正解表は CLI 自身** — `vlmkit --help` が出す 33 件の deprecated エイリアス表
+  (`a11y-contrast → check a11y contrast` など)を機械的に抽出して写像に使った。
+  ソースの正規表現では 15 件しか拾えなかったので、推測ではなく実出力を使うのが正解。
+- [x] **一斉置換は 3 回失敗した** — 学びとして記録:
+  1. 最初の版は**自分が直前に書いたコメントを破壊**した。
+     `` `vrt a11y-contrast` was wrong twice over `` は「誤った名前」を意図的に
+     引用している文で、置換すると意味不明になる。
+  2. 「意図的引用」検出を `→`/`->` 込みで書いたら、
+     `vrt snapshot <url1> # URL → multi-viewport capture` のような**機能説明の矢印**まで
+     保護してしまった。
+  3. `deprecated` で検出したら `deprecation`(語幹違い)が漏れ、
+     `The single-token commands from 0.4.x (\`vrt compare\`, …) remain as
+     deprecation shims` が破壊された。
+  結論: **散文は正規表現で守れない**。ソースと markdown を別パスにし、
+  markdown は差分を目視レビューした。
+- [x] **ソース 207 箇所 + コメント内の製品名 16 箇所** — テストは掃除対象から**外した**。
+  アサーションが検証役として機能するように。結果 4 件が落ち(旧 usage 文字列を
+  アサートしていた)、実体に合わせて修正。これが正しい信号の出方。
+- [x] **markdown 371 箇所** — 副産物としてリンク破損が **43 → 11 に減少**(32 件修復、
+  `packages/vrt-core/` → `packages/vlmkit-core/` が実体に一致したため)。
+  自分が新たに壊した 3 件(`grid-ratio` / `region-classify` / `shift-origin` は
+  `vlmkit-core` ではなく `vlmkit-markup` にある)は before/after 比較で検出して修正。
+  残る 11 件はすべて既存(`src/compare.ts` など分割前のパス)。
+- [x] **偽になった caveat 2 件を削除** — SKILL.md が「CLI バナーは旧名を出す」と
+  書いていたが、バナーを直したので偽になった。改名すると
+  「Internal binary name: \`vlmkit check tokens\` — ... still call it
+  \`vlmkit check tokens\`」という自己言及になるので、**真の部分**
+  (出力先が今も `test-results/design-tokens/`)に書き換えた。
+- [x] **回帰ゲート**: `src/cli/binary-name.test.ts`(28 件)。
+  全 24 コマンドの `--help` を実行して `vrt` を含まないことを検査し、
+  **例外リストも検査する**(許可した綴りが実際にソースに存在するか — 消えたら
+  例外を削除すべきで、次の掃除が通り抜ける穴にしてはいけない)。
+  アブレーション済み: `vrt design-tokens` を1つ戻すと落ちる。
+  自分の初版は**エントリを間違えていた**(`cli.ts` ではなく `src/cli/vlmkit.ts` が
+  エイリアス dispatch を持つ)ため、エイリアスのケースが空出力で「pass」していた。
+- [x] **以前の自分の主張の訂正** — introduce.ja.md のコミットで
+  「`vrt compare` / `elements` / `smoke` / `serve` / `discover` は削除済み」と書いたが、
+  実際は **deprecated エイリアスとして今も動く**(1.0.0 で削除予定)。
+  消えたのは `vrt` バイナリだけ。ドキュメント刷新自体は正しかったが理由が不正確だった。
+- [ ] **残り: 判断が必要(ユーザー確認待ち)**
+  - **挙動に影響 128 箇所**: `.vrt/`(baselines / runs / last-diff-for-agent)、
+    `.vrt-skills/`、`vrt.config.json` / `.toml`、`VRT_*` 環境変数(12 種以上)、
+    `projectName: "vrt"`(Playwright プロジェクト名 = スナップショットパスに出る)、
+    plan スキーマの `vrt?:` **フィールド名**(既存 plan ファイルが壊れる)、
+    `"X-Title": "vrt"`(OpenRouter へ送る HTTP ヘッダ)、
+    `title: "vrt HTTP API"`(公開 OpenAPI)、
+    `~/.../vrt/deprecated.log`。改名は既存ユーザーの state / config / CI を孤児化する。
+  - **素の製品名 404 箇所**: ただし **VRT は業界一般の略語**(Visual Regression
+    Testing)でもあり、「vrt vendors」「VRT service」は技術一般を指す。
+    機械的に置換すると意味が変わるので個別判断が必要。
+  - **その他の識別子**: `vrt-eval`(53)、`vrt-diff`(27)、`vrt-action`(16)、
+    `vrt-runner.ts`、`vrt-capture.spec.ts` — CI ジョブ名 / fixture 名 /
+    spec ファイル名。
+  - **歴史的記録 488 箇所**: `docs/reports/` / `CHANGELOG.md` /
+    `docs/migration-0.5.md` は日付付きの記録および old→new 対応表そのもの。
+    書き換えは記録の改竄なので**対象外のまま**。
+
 ### 0.9.0 リリース準備(2026-08-02)
 - [x] **CHANGELOG が今日の作業を一切含んでいなかった** — Unreleased セクションは
   `24b0185`(0.8.0)以降の前半分だけで、今日追加した `check design` / `batch` /
@@ -589,11 +647,11 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
   (単語文字)で終わるため `vrt` の前に単語境界が無く、**拒否するために書いた出力に
   対して pass** していた。ANSI を除去してから照合するよう修正。
 - [ ] **`vrt` 名の残存 ~250 箇所 / ~80 フレーズ(次の作業)** — 実測: 4 ゲートは
-  リリース diff に既に入っていたので直したが、全体は `vrt snapshot` /
-  `vrt workflow` / `vrt diff-pr` / `vrt baseline` など。`vrt` バイナリは存在せず
+  リリース diff に既に入っていたので直したが、全体は `vlmkit snapshot` /
+  `vlmkit workflow` / `vlmkit diff-pr` / `vlmkit baseline` など。`vrt` バイナリは存在せず
   (`bin` は `vlmkit` のみ)、旧サブコマンド名は deprecated なので
-  `Re-run \`vrt a11y-contrast\`` は**二重に誤り**。大半はバイナリ名の置換だけで
-  済むが、`vrt compare` / `vrt elements` / `vrt smoke` は**すでに削除された
+  `Re-run \`vlmkit check a11y contrast\`` は**二重に誤り**。大半はバイナリ名の置換だけで
+  済むが、`vlmkit diff html` / `vlmkit diff elements` / `vlmkit inspect smoke` は**すでに削除された
   コマンド**への参照で、`vrt itself` / `vrt toolkit` のような散文も混ざる。
   リリースコミットに 250 箇所の改名を混ぜず、レビュー可能な独立した diff にする。
   正解表は `src/cli/cli.ts` の `newName` マップ(15 エントリ)。
@@ -677,7 +735,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 
 ### ドキュメント刷新(2026-08-02)
 - [x] **`docs/introduce.ja.md` が 7/27 の `vrt` 時代のまま(248 行)だった** —
-  リネーム前のコマンド名で、**すでに削除されたコマンド**(`vrt compare` /
+  リネーム前のコマンド名で、**すでに削除されたコマンド**(`vlmkit diff html` /
   `elements` / `smoke` / `serve` / `discover`)を手順として書いており、
   ディレクトリ構成もフラットな `src/` のまま。読者が写して実行すると必ず失敗する
   状態だったので、`introduce.md` と同じ構成の**独立した日本語版**として全面改稿。
@@ -912,7 +970,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 
 
 ### Infrastructure / Deploy
-- [x] Cloudflare Browser Run CDP backend (`vrt snapshot --backend cloudflare`) — connects via `chromium.connectOverCDP` to `wss://api.cloudflare.com/.../browser-rendering/devtools/browser`. See `examples/vrt-snapshot-cloudflare.workflow.yml`.
+- [x] Cloudflare Browser Run CDP backend (`vlmkit snapshot --backend cloudflare`) — connects via `chromium.connectOverCDP` to `wss://api.cloudflare.com/.../browser-rendering/devtools/browser`. See `examples/vrt-snapshot-cloudflare.workflow.yml`.
 - [x] Cloudflare Workers entry point (`worker/`) — `worker/index.ts` re-exports `createApiApp()` from `src/api/api-app.ts`. `env.BROWSER` wiring still pending.
 - [x] Cloudflare Quick Actions REST backend (`/screenshot`, `/crawl` for route discovery)
   - `@mizchi/vlmkit-capture` now includes a Browser Run Quick Actions client for `/screenshot` and `/crawl`, route extraction from crawl results, and Hono API proxy endpoints under `/api/cloudflare/*`.
@@ -941,7 +999,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 
 ### Feature Extensions
 - [x] Component (selector) level comparison
-  - `vrt diff component` / `vrt diff elements` run selector-scoped screenshots and compare components independently from full-page layout shift noise.
+  - `vlmkit diff component` / `vlmkit diff elements` run selector-scoped screenshots and compare components independently from full-page layout shift noise.
 - [x] Enhanced diff classification (layout shift / color change / text change / element added/removed)
   - `classifyVisualDiff` now trusts `DiffRegion.regionType === "shift"` as layout shift and uses sampled baseline/current colors to distinguish element-added vs element-removed when a region changes to/from a page-surface color.
 - [x] Smoke test: Crater BiDi backend
@@ -967,7 +1025,7 @@ Reproduce the Tailwind blind test with different fixtures/scenarios to confirm r
 From `docs/reports/2026-05-12-dogfood-shadcn-luna.md`. Each item is a
 small wrapper around already-built primitives, not a new subsystem.
 
-- [x] `vrt diff-for-agent <migration-report.json>` — one-context-window
+- [x] `vlmkit diff agent <migration-report.json>` — one-context-window
   Markdown summary combining diff %, dominant categories, fix candidates
   aggregated by `(selector, property)` with viewport coverage, and
   absolute paths to baseline/current/heatmap PNGs for the worst N
@@ -984,11 +1042,11 @@ small wrapper around already-built primitives, not a new subsystem.
   image into ~240px-tall horizontal bands and runs mean-subtracted
   cross-correlation per band, gated by a peak-sharpness confidence
   metric. Surfaced in `MigrationCompareResult.shiftRegions` and
-  printed by `vrt diff-for-agent` as e.g.
+  printed by `vlmkit diff agent` as e.g.
   `[480–720]:+22px [720–960]:-94px [960–1348]:+32px`, replacing the
   single-line global average with localized per-section offsets.
   Verified on the 2026-05-12 dogfood Pass B iter 1 data.
-- [x] `vrt compare-runs <a.json> <b.json>` — pairwise migration-report
+- [x] `vlmkit diff runs <a.json> <b.json>` — pairwise migration-report
   diff sorted by absolute movement, with IMPROVED/REGRESSED/UNCHANGED/
   ADDED/REMOVED status per viewport and a category-summary "before →
   after" column. Verified on the 2026-05-12 dogfood data: shows
@@ -1000,7 +1058,7 @@ small wrapper around already-built primitives, not a new subsystem.
   before, after)` list plus by-property + by-selector aggregates.
   Surfaced in `migration-report.json` under `computedStyleDiff` and
   rendered as a "Top properties / Top selectors" section in
-  `vrt diff-for-agent`. Verified on dogfood Pass B iter 1: catches 46
+  `vlmkit diff agent`. Verified on dogfood Pass B iter 1: catches 46
   tuples (border colors, radius, font-family, font-size on
   `#notes/#owner/#title`) that pixel diff alone surfaced only as
   generic `layout-shift`.
@@ -1015,7 +1073,7 @@ verified-pair gate) gave zero signal on this scenario.
 
 The wireframe mode needs visual-only diagnostics:
 
-- [x] **Component bbox extraction.** `packages/vrt-markup/src/component/component-bbox.ts` runs
+- [x] **Component bbox extraction.** `packages/vlmkit-markup/src/component/component-bbox.ts` runs
   on the captured PNGs (no DOM required): detect background via
   edge-pixel mode, build foreground mask, label connected
   components (two-pass union-find, 4-connectivity), filter
@@ -1023,7 +1081,7 @@ The wireframe mode needs visual-only diagnostics:
   ↔ variant by rank-after-sort and reports per-axis Δ + IoU.
   Wired into `migration-compare` (always on; `--no-component-bbox`
   to disable) — surfaces a "Component bbox diff" section in
-  `vrt diff-for-agent`. 10 unit tests cover synthetic backgrounds
+  `vlmkit diff agent`. 10 unit tests cover synthetic backgrounds
   + multi-component sorting + min-area filtering. Verified on
   both wireframe (Subagent F's exact scenario: baseline 343×370,
   variant 311×243, Δ -32W / -127H reported on one row) and
@@ -1031,17 +1089,17 @@ The wireframe mode needs visual-only diagnostics:
 - [x] **Per-viewport geometry diff** without DOM access — "baseline
   card shrinks 18px between desktop and mobile but variant
   doesn't" inferred purely from screenshot dimensions.
-  `packages/vrt-markup/src/component/component-geometry.ts` composes on top of `MatchedBbox[]`
+  `packages/vlmkit-markup/src/component/component-geometry.ts` composes on top of `MatchedBbox[]`
   and flags `responsiveMismatch` when one side's per-axis spread
   exceeds the other's by ≥30px. Rendered as "Cross-viewport
-  geometry profile" in `vrt diff-for-agent`. 5 unit tests +
+  geometry profile" in `vlmkit diff agent`. 5 unit tests +
   verified on shadcn→blank (8 responsive-mismatch flags
   surfaced).
 - [x] **Heatmap region clustering** — group connected hot pixels
   in `*_heatmap.png` into named regions and report per-region
   shift instead of horizontal bands. Bands of bands lose
   resolution; region clusters preserve "this text run shifted up
-  4px" granularity. `packages/vrt-core/src/heatmap-regions.ts` reuses the
+  4px" granularity. `packages/vlmkit-core/src/heatmap-regions.ts` reuses the
   union-find CC labeller from `component-bbox.ts` against a
   hot-red mask (red − max(g,b) ≥ 60). 5 unit tests + verified on
   shadcn→blank (24 region clusters) and wireframe pricing-card
@@ -1050,7 +1108,7 @@ The wireframe mode needs visual-only diagnostics:
 - [x] **Text-row y-position extraction** from rendered PNGs via
   luminance-profile peak detection — exposes "the `$24` text row
   is 4px higher in the variant" without needing DOM correspondence.
-  `packages/vrt-core/src/text-rows.ts` computes per-row mean luminance, treats rows
+  `packages/vlmkit-core/src/text-rows.ts` computes per-row mean luminance, treats rows
   ≥12 below the median as dark, and groups runs into bands.
   `matchTextRows` pairs by ordered index and emits Δy. Surfaces
   "Bands B / V" count mismatches even when no rows can be paired
@@ -1072,7 +1130,7 @@ The wireframe mode needs visual-only diagnostics:
 Three more scenarios, each as a dedicated CLI to keep
 migration-compare lean.
 
-- [x] **Theme parity** (`vrt theme-parity`). Renders the same HTML
+- [x] **Theme parity** (`vlmkit check theme`). Renders the same HTML
   twice via Playwright's `emulateMedia({ colorScheme: light/dark })`,
   extracts component bboxes, samples each bbox's dominant fill in
   both renders, and flags components whose fill is identical across
@@ -1083,7 +1141,7 @@ migration-compare lean.
   540×43 matching the buggy `.alert`. Theme pixel delta 97.9%
   (page does respond broadly).
 
-- [x] **i18n / variable-length text stress** (`vrt i18n-stress`).
+- [x] **i18n / variable-length text stress** (`vlmkit stress i18n`).
   Inflates every text node by a configurable factor (default 1.4×
   ≈ German), then samples per-element layout before vs after.
   Classifies overflow as `horizontal-overflow` (scrollWidth >
@@ -1094,7 +1152,7 @@ migration-compare lean.
   and `width: 120px` button: caught both overflows + classified
   the paragraph wrap as the harmless `vertical-wrap` case.
 
-- [x] **Inline → componentized refactor** (`vrt component-consistency`).
+- [x] **Inline → componentized refactor** (`vlmkit check drift component`).
   Single-page-multi-instance sibling of `multi-page-consistency`:
   captures every selector match on one page via
   `locator.screenshot()`, compares each to instance #0 (or
@@ -1108,9 +1166,9 @@ Beyond the migration / wireframe scenarios, the tool can serve
 adjacent markup-authoring workflows. Each scenario is built and
 evaluated incrementally.
 
-- [x] **Design token / palette compliance.** `packages/vrt-markup/src/style/palette-extract.ts`
+- [x] **Design token / palette compliance.** `packages/vlmkit-markup/src/style/palette-extract.ts`
   stride-samples the rendered PNG into a 5-bit-per-channel histogram
-  and returns the top-K dominant colors. `packages/vrt-markup/src/style/palette-diff.ts`
+  and returns the top-K dominant colors. `packages/vlmkit-markup/src/style/palette-diff.ts`
   greedy-matches baseline vs variant by RGB-Euclidean distance
   (≤12 → match) and surfaces *missing* (in baseline target but
   not the variant — agent forgot a token) and *extra* (in variant
@@ -1121,7 +1179,7 @@ evaluated incrementally.
   color, surfaced as a single hex the agent can paste).
 - [x] **Multi-state capture** — capture `:hover` / `:focus` /
   `:focus-visible` / `:active` via CDP `CSS.forcePseudoState`,
-  diff per state. `packages/vrt-markup/src/stress/multi-state.ts` marks all interactive
+  diff per state. `packages/vlmkit-markup/src/stress/multi-state.ts` marks all interactive
   elements (`button`, `a[href]`, `[role=button]`, form controls)
   with a `data-vrt-state-marker` attribute, opens a CDP session,
   and calls `forcePseudoState` for each matched node. Pixelmatch
@@ -1136,7 +1194,7 @@ evaluated incrementally.
   hover +0.37%/+0.42%/0.00%, focus-visible +0.26%/+0.29%/+1.11%.
 - [x] **Component-from-screenshot** — single-component subset of
   wireframe mode: small viewport, one bbox, multi-state. New CLI
-  subcommand. `packages/vrt-markup/src/component/component-from-image.ts` takes a target PNG +
+  subcommand. `packages/vlmkit-markup/src/component/component-from-image.ts` takes a target PNG +
   current HTML, renders the HTML at the PNG's exact dimensions,
   pixel-diffs, and runs every image-only signal (bbox, heatmap,
   text-row, palette) plus an optional `--states` pass. Emits a
@@ -1193,7 +1251,7 @@ be CSS transitions, not the threshold. Fixes applied:
 
 Two remaining single-item gaps from the scenario matrix:
 
-- [x] **F3 — `vrt a11y-focus-order`**. Drives `Tab` through the
+- [x] **F3 — `vlmkit check a11y focus`**. Drives `Tab` through the
   page via `page.keyboard.press`, captures `document.activeElement`
   after each press, builds an ordered sequence of focus steps.
   Detects three classes of bug:
@@ -1234,7 +1292,7 @@ In-scope full coverage now **44 / 85 = 52%**; full + partial =
 
 ### Scenario-matrix Clusters 2 & 3 — cross-browser + design-tokens (2026-05-13)
 
-- [x] **Cluster 2: `vrt cross-browser`** — launches chromium /
+- [x] **Cluster 2: `vlmkit diff browsers`** — launches chromium /
   firefox / webkit in sequence, diffs each against the first
   successful engine (typically chromium = reference). Engines
   not installed in the local Playwright cache auto-skip with an
@@ -1245,7 +1303,7 @@ In-scope full coverage now **44 / 85 = 52%**; full + partial =
   text subpixel shifts on Firefox). Closes scenario matrix
   items H1, H2, H3.
 
-- [x] **Cluster 3: `vrt design-tokens`** — scale-conformance
+- [x] **Cluster 3: `vlmkit check tokens`** — scale-conformance
   check. Renders the page, walks visible elements, samples
   computed-style `borderRadius`, `padding`, `margin`,
   `zIndex`, `boxShadow`. Per-property scale check (`isOnScale`
@@ -1289,7 +1347,7 @@ Single command covering 5 of the 24 missing scenarios from the
 scenario-coverage matrix (`docs/reports/2026-05-13-scenario-matrix.
 md`): forced-colors, reduced-motion, print, RTL, 200%-zoom.
 
-- [x] **`vrt media-variants`** — renders an HTML / URL under each
+- [x] **`vlmkit stress media`** — renders an HTML / URL under each
   variant emulation and pixel-diffs against the default. Five
   emulations (Playwright primitives + small overrides):
     - `forced-colors` via `emulateMedia({ forcedColors: 'active' })`
@@ -1327,7 +1385,7 @@ md`): forced-colors, reduced-motion, print, RTL, 200%-zoom.
 
 ### Survey Tier D — real-interaction sequences (2026-05-13)
 
-- [x] **`vrt interact`** — declarative scripted-sequence VRT. The
+- [x] **`vlmkit inspect interact`** — declarative scripted-sequence VRT. The
   agent describes a sequence of Playwright actions in JSON; the
   tool drives the page through them and pixel-diffs each transition.
   Closes the "we can't see UI bugs hidden behind clicks / forms /
@@ -1360,7 +1418,7 @@ md`): forced-colors, reduced-motion, print, RTL, 200%-zoom.
 Three of the ROI-ranked items from `docs/reports/2026-05-13-
 capability-survey.md`, shipped together.
 
-- [x] **B. Region content-type classifier.** `packages/vrt-core/src/region-classify.ts`:
+- [x] **B. Region content-type classifier.** `packages/vlmkit-markup/src/region-classify.ts`:
   `classifyRegion(rgba, w, h, bbox)` returns one of `text` /
   `filled-rect` / `icon` / `image` / `unknown` with a confidence
   score. Features: quantized color count, luma std dev, horizontal
@@ -1392,7 +1450,7 @@ capability-survey.md`, shipped together.
   the agent maps each comment back to whichever element matches the
   described region or row.
 
-- [x] **F. Touch-target size check** (`vrt a11y-touch`). New CLI
+- [x] **F. Touch-target size check** (`vlmkit check a11y touch`). New CLI
   that scans visible interactive elements (`button`, `a[href]`,
   form controls, `[role=button]`, `[tabindex≥0]`, `summary`) and
   reports those whose bbox `min(w, h)` is below the WCAG threshold
@@ -1492,7 +1550,7 @@ Three concerns left open after the re-dogfood, all addressed:
 
 ### Tier 3 + CLI unification + re-dogfood (2026-05-13)
 
-- [x] **A11y contrast scan** (`vrt a11y-contrast`). Renders the
+- [x] **A11y contrast scan** (`vlmkit check a11y contrast`). Renders the
   HTML in Playwright, walks every visible text node via an
   in-browser `TreeWalker`, samples computed-style foreground +
   effective ancestor background, classifies font size for the
@@ -1516,7 +1574,7 @@ Three concerns left open after the re-dogfood, all addressed:
   silently fail in dev mode. Now resolved to absolute via
   `fileURLToPath(new URL(modulePath, import.meta.url))` —
   every command runs correctly from `node src/cli/vrt.ts <cmd>`
-  AND from the built `dist/vrt.mjs`.
+  AND from the built `dist/vlmkit.mjs`.
 
 - [x] **Re-dogfood — component-from-image v2.** Blank pricing-card →
   target ran with the new Backgrounds + heatmap Fill + raw/perceptual
@@ -1577,7 +1635,7 @@ Three concerns left open after the re-dogfood, all addressed:
 
 - [x] **Multi-page consistency** — same component on N pages must
   render identically. Cross-page bbox / computed-style diff.
-  `packages/vrt-markup/src/stress/multi-page-consistency.ts` renders N URLs (or HTML files)
+  `packages/vlmkit-markup/src/stress/multi-page-consistency.ts` renders N URLs (or HTML files)
   in Playwright, screenshots each `--selector` match via
   `locator.screenshot()` (auto-crops to the element's bbox), and
   compares all candidates against the first one (the reference).
@@ -1598,7 +1656,7 @@ fixture series. The remaining 4-viewport floor at 2.67–3.52%
 comes from a single unexplained +152px / +239px universal shift
 band at viewports ≥ 1024.
 
-- [x] **Vertical-shift origin diagnostic.** `packages/vrt-core/src/shift-origin.ts`
+- [x] **Vertical-shift origin diagnostic.** `packages/vlmkit-markup/src/shift-origin.ts`
   captures per-element bounding boxes via a new
   `DOM_BBOX_BROWSER_SCRIPT`, then matches by DOM path against the
   per-band shifts already produced by `detectBandShifts`.
@@ -1608,7 +1666,7 @@ band at viewports ≥ 1024.
   responsible element (path, baseline / variant class, Δtop,
   suspect axis: `height` / `margin/padding-above` / `y-position`).
   Surfaced as a new "Shift-origin diagnostics" table in
-  `vrt diff-for-agent`, populated automatically when
+  `vlmkit diff agent`, populated automatically when
   `--dom-position-diff` is on. Verified on dogfood Pass B iter 1:
   42 origin rows across 10 viewports — e.g. mobile `[720-960]
   Δ-94px → card-header / luna-panel-head, suspect: height`,
@@ -1616,13 +1674,13 @@ band at viewports ≥ 1024.
   suspect: height`. The exact symptom Subagent D plateaued on
   (`+152px shift band with no DOM-position delta`) now has a named
   origin. 9 unit tests cover the algorithm.
-- [x] **Drop ✗ heuristic candidates from `vrt diff-for-agent`.**
+- [x] **Drop ✗ heuristic candidates from `vlmkit diff agent`.**
   `--show-unverified` (default off) controls the visibility.
   Default output now drops rows whose computed value matches
   baseline; replaced with `_N unverified candidate(s) hidden_`
   note so the agent knows what was suppressed. Dogfood Pass B
   iter 1: table shrunk from 5 rows (2 ✓ + 3 ✗) to just 2 ✓.
-- [x] **Grid `fr`-ratio inference.** `packages/vrt-core/src/grid-ratio.ts` walks per-
+- [x] **Grid `fr`-ratio inference.** `packages/vlmkit-markup/src/grid-ratio.ts` walks per-
   viewport bboxes, finds containers whose direct children have a
   non-uniform width distribution differing between baseline and
   variant, then suggests both a decimal ratio and a low-integer
@@ -1632,7 +1690,7 @@ band at viewports ≥ 1024.
   (default 1.3) drops column-stacked containers where children fill
   100% width and per-child widths are content-driven (not a grid
   ratio). Surfaced as a new "Grid `fr`-ratio suggestions" section
-  in `vrt diff-for-agent`. Dogfood Pass B iter 1: the workspace at
+  in `vlmkit diff agent`. Dogfood Pass B iter 1: the workspace at
   768px reports `393/299 → 1.316 : 1.000 → 13fr 10fr` — the exact
   case Subagent D guessed manually as "1.316fr 1fr".
 - [x] **`display` context note for flex items.** A pill with
@@ -1643,7 +1701,7 @@ band at viewports ≥ 1024.
 - [x] **Unit-normalized property reporting.** `DpEntry` now carries
   `baselineEm` / `variantEm` for `letter-spacing`, `word-spacing`,
   `line-height` — values divided by the element's own font-size.
-  `vrt diff-for-agent` renders a dedicated "Em-relative properties"
+  `vlmkit diff agent` renders a dedicated "Em-relative properties"
   sub-section in the per-viewport DOM-position table that exposes
   cases like "5 elements show `line-height` 18/21/24/28.5/40px but
   all five normalize to `1.5em`" — one rule, not five different
@@ -1661,13 +1719,13 @@ band at viewports ≥ 1024.
   by N.
 
 - [x] **DOM-position-based selector alignment** in a new
-  `packages/vrt-core/src/dom-position-styles.ts`. `migration-compare --dom-position-diff`
+  `packages/vlmkit-core/src/dom-position-styles.ts`. `migration-compare --dom-position-diff`
   captures per-element `(path, tag, classes, styles)` for every
   element with a `class` attribute or semantic tag, then matches
   baseline ↔ variant by tree position (`main[0]>section[0]>span[0]`),
   which is invariant under class renames. Surfaced as a new
   "Verified deltas by DOM position (class-rename-aware)" section in
-  `vrt diff-for-agent`. Verified on the dogfood Pass B iter 1
+  `vlmkit diff agent`. Verified on the dogfood Pass B iter 1
   fixture: produces 872 property tuples across 60 element
   positions, naming both class names per row (e.g. baseline
   `eyebrow` ↔ variant `luna-pill`, baseline `dialog-card` ↔
@@ -1677,7 +1735,7 @@ band at viewports ≥ 1024.
   now captures the DOM-position styles at *every* discovered
   viewport (not just the first) and surfaces a new "Verified
   deltas by DOM position × viewport (catches media-query gaps)"
-  section in `vrt diff-for-agent`. Output splits into:
+  section in `vlmkit diff agent`. Output splits into:
     - **Universal deltas** — `(path, property)` pairs that differ
       on every viewport (a base CSS rule).
     - **Breakpoint-gated deltas** — pairs that differ on only a
@@ -1696,7 +1754,7 @@ band at viewports ≥ 1024.
   table such as `.metric → .luna-metric` `-9px × 4 = -36px`
   plus `.panel-title → .luna-panel-title` `-1.5px × 3 = -4.5px`.
 - [x] **Class-rename map as a header summary table** lands at the
-  top of each variant section in `vrt diff-for-agent`, before the
+  top of each variant section in `vlmkit diff agent`, before the
   diff-by-viewport table. Aggregated from `domPositionDiff[Per
   Viewport]` and de-duped per `(baseline-class, variant-class)`
   pair. On the dogfood Pass B iter 1 fixture: 12 pairs (e.g.
@@ -1762,7 +1820,7 @@ band at viewports ≥ 1024.
   the "missing CSS rule" diagnostic is added.
 
 - [x] Heuristic fix-candidate ranking now reconciles with computed-style.
-  `vrt diff-for-agent` renames the heuristic table to "Heuristic fix
+  `vlmkit diff agent` renames the heuristic table to "Heuristic fix
   candidates" with a per-row `Verified?` column (✓ when the
   property appears in the computed-style diff, — when it doesn't),
   and exposes the new authoritative "Verified deltas (computed-style)"
@@ -2242,7 +2300,7 @@ has been closed (commits `ef95260`, `2656786`, `f934122`, `4e6d45d`,
 - [x] Visual diff display (heatmap, side-by-side, overlay)
   - Worker storage now infers baseline/current/heatmap/triptych artifact groups and `/api/visual-diffs` exposes dashboard-ready display modes.
 - [x] Interactive approval operations
-  - `/api/approvals` now exposes approval-manifest list/add/remove operations for dashboard review flows, backed by the same `approval.json` schema as `vrt manifest`.
+  - `/api/approvals` now exposes approval-manifest list/add/remove operations for dashboard review flows, backed by the same `approval.json` schema as `vlmkit manifest`.
 - [x] Detection rate time-series graph
   - `bench-history` now builds chart-ready detection-rate series, and local `/api/detection-series` exposes filtered points by backend/fixture/limit for dashboard clients.
 - [x] Component-level status matrix

--- a/apm.yml
+++ b/apm.yml
@@ -1,6 +1,6 @@
 name: vrt
 version: 0.5.0
-# vrt ships coding-agent skills via APM so other repos can `apm install`
+# vlmkit ships coding-agent skills via APM so other repos can `apm install`
 # them. The repo itself is a CC project, hence `targets: [claude]`.
 targets:
   - claude

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -34,7 +34,7 @@
   - body: _not yet implemented_
 
 - [ ] **Agent-friendly diff Markdown summary** — verifies: MIG-002
-  >   `vrt diff-for-agent <migration-report.json>` collapses a
+  >   `vlmkit diff agent <migration-report.json>` collapses a
   >   compare report into a worst-first table with selector +
   >   property aggregation. Default consumer is a subagent fix
   >   pass.
@@ -70,7 +70,7 @@
   - body: _not yet implemented_
 
 - [ ] **Build a card from a blank starter until diff under 3 percent** (critical) — verifies: FIDELITY-001
-  >   `vrt component-from-image` against the pricing-card target
+  >   `vlmkit build component` against the pricing-card target
   >   reports bbox / heatmap / palette / typography signals; iteration
   >   converges the diff under 3% in <5 rounds on a representative
   >   fixture.
@@ -85,7 +85,7 @@
   - body: _not yet implemented_
 
 - [ ] **Build component from PNG screenshot** — verifies: A1
-  > `vrt component-from-image` accepts a PNG target and renders the agent's HTML for pixel-diff iteration. Same engine drives A1-A4.
+  > `vlmkit build component` accepts a PNG target and renders the agent's HTML for pixel-diff iteration. Same engine drives A1-A4.
   - contributes to: GOAL-MARKUP-FIDELITY
   - body: _not yet implemented_
 
@@ -122,17 +122,17 @@
   - body: _not yet implemented_
 
 - [ ] **Bundled per-target check via skill run** — verifies: L5
-  > `vrt skill run <name> --against <html|url>` aggregates all configured checks for the target into one report.
+  > `vlmkit skill run <name> --against <html|url>` aggregates all configured checks for the target into one report.
   - contributes to: GOAL-AGENT-ERGONOMICS
   - body: _not yet implemented_
 
 - [ ] **CLS detection via in-page PerformanceObserver** — verifies: K5
-  > `vrt perf` wires up a PerformanceObserver inside the page and reports CLS / LCP / FCP without depending on Lighthouse.
+  > `vlmkit check perf` wires up a PerformanceObserver inside the page and reports CLS / LCP / FCP without depending on Lighthouse.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
 - [x] **CSS challenge bench delete-and-detect** — verifies: BENCH-001
-  >   `vrt bench` (alias `pkf run css-bench`) randomly deletes a
+  >   `vlmkit bench` (alias `pkf run css-bench`) randomly deletes a
   >   CSS property or selector block, runs the chosen detection
   >   backend, and accumulates a per-trial pass/fail record into
   >   `data/*.jsonl`.
@@ -163,12 +163,12 @@
   - body: _not yet implemented_
 
 - [ ] **Color tokens conform to declared palette** — verifies: M1
-  > `vrt design-tokens` flags rendered colors that fall outside the declared palette — catches off-scale hex values before they leak into the token catalog.
+  > `vlmkit check tokens` flags rendered colors that fall outside the declared palette — catches off-scale hex values before they leak into the token catalog.
   - contributes to: GOAL-DESIGN-SYSTEM
   - body: _not yet implemented_
 
 - [ ] **Compare-runs aggregates multiple VRT runs** (minor) — verifies: MIG-004
-  >   `vrt compare-runs` diffs two prior vrt runs against each other
+  >   `vlmkit diff runs` diffs two prior vrt runs against each other
   >   (e.g. iter 0 vs iter 1 of a fix loop) so progress per round is
   >   visible at a glance.
   - contributes to: GOAL-MIGRATION-VERIFICATION, GOAL-AGENT-ERGONOMICS
@@ -177,33 +177,33 @@
 - [ ] **Computed style diff across hover and focus states** — verifies: CORE-002
   >   `getComputedStyle` capture for both rest and pseudo-states
   >   (`:hover`, `:focus`) plus per-property delta surfacing.
-  >   Embedded inside `vrt compare` rather than exposed as its own
+  >   Embedded inside `vlmkit diff html` rather than exposed as its own
   >   CLI; the report.md groups deltas by selector + property.
   - contributes to: GOAL-CORE-DIFF
   - body: _not yet implemented_
 
 - [ ] **Cross-browser parity across Chromium / Firefox / WebKit** — verifies: H1
-  > `vrt cross-browser` renders the same HTML in all three engines and reports per-engine pixel diff against Chromium. `--allow-skipped` keeps CI green when WebKit isn't installed.
+  > `vlmkit diff browsers` renders the same HTML in all three engines and reports per-engine pixel diff against Chromium. `--allow-skipped` keeps CI green when WebKit isn't installed.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
 - [ ] **Cross-page component drift** — verifies: J1
-  > `vrt multi-page-consistency` diffs the same component selector across N pages and surfaces the outlier.
+  > `vlmkit check drift pages` diffs the same component selector across N pages and surfaces the outlier.
   - contributes to: GOAL-DESIGN-SYSTEM
   - body: _not yet implemented_
 
 - [ ] **Cumulative Layout Shift measurement** — verifies: G1
-  > `vrt perf` reads CLS from an in-page PerformanceObserver.
+  > `vlmkit check perf` reads CLS from an in-page PerformanceObserver.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
 - [ ] **Dark mode parity: every component responds to color-scheme** (critical) — verifies: C1
-  > `vrt theme-parity` flips `prefers-color-scheme`, diffs every component, and surfaces ones that didn't update (forgot a `--var` or hard-coded a hex).
+  > `vlmkit check theme` flips `prefers-color-scheme`, diffs every component, and surfaces ones that didn't update (forgot a `--var` or hard-coded a hex).
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
 - [ ] **Detection report aggregates accumulated bench runs** (minor) — verifies: BENCH-002
-  >   `vrt report` reads the jsonl history and emits per-fixture +
+  >   `vlmkit report` reads the jsonl history and emits per-fixture +
   >   per-backend detection-rate tables. Last measured: 96.7% on
   >   the canonical fixture set (docs/knowledge.md).
   - contributes to: GOAL-CSS-CHALLENGE
@@ -226,11 +226,11 @@
   - body: _not yet implemented_
 
 - [x] **Element-level shift-isolated diff** — verifies: CORE-004
-  >   `vrt elements` diffs per-element bounding boxes after isolating
+  >   `vlmkit diff elements` diffs per-element bounding boxes after isolating
   >   cascading layout shift; useful when a single element moves and
   >   pixel diff would otherwise blame everything downstream.
   - contributes to: GOAL-CORE-DIFF
-  - body: implemented as `vrt diff elements` and `vrt diff component` in `packages/vlmkit-core/src/element-compare.ts`
+  - body: implemented as `vlmkit diff elements` and `vlmkit diff component` in `packages/vlmkit-core/src/element-compare.ts`
 
 - [ ] **Empty state** (minor) [draft] — verifies: E6
   > Scriptable via `interact` (set state then snapshot); no first-class empty-state CLI.
@@ -238,10 +238,10 @@
   - body: _not yet implemented_
 
 - [ ] **Extract a single component from a page screenshot** — verifies: A8
-  >   Given a full-page PNG, `vrt component-extract` finds the major
+  >   Given a full-page PNG, `vlmkit scan component` finds the major
   >   non-background components, classifies each (text / filled-rect /
   >   icon / image), and crops the chosen rank to a standalone PNG
-  >   suitable for use as a target in `vrt component-from-image`.
+  >   suitable for use as a target in `vlmkit build component`.
   - contributes to: GOAL-MARKUP-FIDELITY
   - body: _not yet implemented_
 
@@ -267,7 +267,7 @@
   - body: _not yet implemented_
 
 - [ ] **Form validation state diff from invalid to valid** — verifies: E5
-  >   `vrt interact` drives a form sequence through deliberate
+  >   `vlmkit inspect interact` drives a form sequence through deliberate
   >   invalid → valid transitions (bad email, short password, then
   >   corrections) and pixel-diffs each transition so reviewers can
   >   see the validation-state visuals (red borders, error messages,
@@ -276,7 +276,7 @@
   - body: _not yet implemented_
 
 - [x] **HTTP API server exposes compare / reason / smoke endpoints** (minor) — verifies: API-001
-  >   `vrt api serve [--port N]` starts a Hono server with
+  >   `vlmkit api serve [--port N]` starts a Hono server with
   >   /api/compare, /api/compare-renderers, /api/reason,
   >   /api/smoke-test, /api/status, /api/execution-results, /api/visual-diffs, /api/detection-series,
   >   /api/component-status-matrix, /api/approvals, /api/cloudflare/screenshot,
@@ -307,7 +307,7 @@
   - body: _not yet implemented_
 
 - [ ] **Inline-vs-component drift on a single page** — verifies: J2
-  > `vrt component-consistency` screenshots every selector match on the page and diffs each against the reference — catches the still-inline call site after a botched extract-to-component refactor.
+  > `vlmkit check drift component` screenshots every selector match on the page and diffs each against the reference — catches the still-inline call site after a botched extract-to-component refactor.
   - contributes to: GOAL-DESIGN-SYSTEM
   - body: _not yet implemented_
 
@@ -317,7 +317,7 @@
   - body: _not yet implemented_
 
 - [ ] **LCP and FCP measurement** — verifies: G2
-  > `vrt perf` reports both core paint timings from the same observer wiring as G1.
+  > `vlmkit check perf` reports both core paint timings from the same observer wiring as G1.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
@@ -372,12 +372,12 @@
   - body: partial implementation in `packages/vlmkit-markup/src/inspect/smoke-runner.ts`
 
 - [ ] **Media variants: forced-colors / reduced-motion / print / RTL / zoom-200** — verifies: C2-C6
-  > `vrt media-variants` sweeps the five hostile-user-preference media queries in one command and reports per-variant diffs.
+  > `vlmkit stress media` sweeps the five hostile-user-preference media queries in one command and reports per-variant diffs.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
 - [ ] **Migration compare across viewports** (critical) — verifies: MIG-001
-  >   `vrt compare <before> <after>` (or `--dir + --baseline +
+  >   `vlmkit diff html <before> <after>` (or `--dir + --baseline +
   >   --variants`) sweeps every viewport, emits report.md, .json
   >   and per-viewport heatmaps. Smoke-tested via the
   >   `compare` entry in Test.pkl.
@@ -385,7 +385,7 @@
   - body: _not yet implemented_
 
 - [ ] **Migration: BEM to utility-first** — verifies: B8
-  > Same `vrt compare` engine with class-rename map.
+  > Same `vlmkit diff html` engine with class-rename map.
   - contributes to: GOAL-MIGRATION-VERIFICATION
   - body: _not yet implemented_
 
@@ -395,7 +395,7 @@
   - body: _not yet implemented_
 
 - [ ] **Migration: CSS-in-JS to CSS modules** — verifies: B2
-  > Same `vrt compare` engine; class-rename map maps auto-generated to semantic class names.
+  > Same `vlmkit diff html` engine; class-rename map maps auto-generated to semantic class names.
   - contributes to: GOAL-MIGRATION-VERIFICATION
   - body: _not yet implemented_
 
@@ -405,7 +405,7 @@
   - body: _not yet implemented_
 
 - [ ] **Migration: Tailwind to vanilla CSS** — verifies: B1
-  > `vrt compare` migration mode handles utility-first → vanilla CSS by ignoring class-name churn.
+  > `vlmkit diff html` migration mode handles utility-first → vanilla CSS by ignoring class-name churn.
   - contributes to: GOAL-MIGRATION-VERIFICATION
   - body: _not yet implemented_
 
@@ -415,7 +415,7 @@
   - body: _not yet implemented_
 
 - [ ] **Migration: custom to standardized component library** — verifies: B7
-  > `vrt compare` plus `component-consistency` catches missed instances.
+  > `vlmkit diff html` plus `component-consistency` catches missed instances.
   - contributes to: GOAL-MIGRATION-VERIFICATION
   - body: _not yet implemented_
 
@@ -430,7 +430,7 @@
   - body: _not yet implemented_
 
 - [ ] **Migration: inline styles to CSS classes** — verifies: B5
-  > Same `vrt compare` engine.
+  > Same `vlmkit diff html` engine.
   - contributes to: GOAL-MIGRATION-VERIFICATION
   - body: _not yet implemented_
 
@@ -445,7 +445,7 @@
   - body: _not yet implemented_
 
 - [ ] **Mobile tablet desktop breakpoint sweep** — verifies: D1
-  > `vrt compare` accepts per-viewport configs; `component-geometry` reports bbox shifts across breakpoints.
+  > `vlmkit diff html` accepts per-viewport configs; `component-geometry` reports bbox shifts across breakpoints.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
@@ -455,7 +455,7 @@
   - body: _not yet implemented_
 
 - [ ] **Multi-viewport snapshot baseline capture** (critical) — verifies: SNAP-001
-  >   `vrt snapshot <url1> [url2]` captures every URL across the
+  >   `vlmkit snapshot <url1> [url2]` captures every URL across the
   >   configured viewport set on first run; subsequent runs diff
   >   against the baseline. Masks via `--mask <selector,...>`
   >   exclude animated regions.
@@ -478,24 +478,24 @@
   - body: _not yet implemented_
 
 - [ ] **Overflow or clipping detection** — verifies: K3
-  > `vrt i18n-stress` flags overflow / wrap regressions; `compare` plus heatmap catches generic clipping.
+  > `vlmkit stress i18n` flags overflow / wrap regressions; `compare` plus heatmap catches generic clipping.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
 - [ ] **PNG pixel diff with heatmap overlay** (critical) — verifies: CORE-001
-  >   `vrt png-diff <baseline> <current>` uses pixelmatch v7 plus a
+  >   `vlmkit diff png <baseline> <current>` uses pixelmatch v7 plus a
   >   heatmap renderer to report per-region intensity. Smoke test
   >   `png-diff` in Test.pkl exercises the identity (0%) path.
   - contributes to: GOAL-CORE-DIFF
   - body: _not yet implemented_
 
 - [ ] **PR visual diff** (minor) [draft] — verifies: L2
-  > Partial: `vrt compare-runs` diffs two prior runs; no first-class PR-comment integration.
+  > Partial: `vlmkit diff runs` diffs two prior runs; no first-class PR-comment integration.
   - contributes to: GOAL-SNAPSHOT-WORKFLOW
   - body: _not yet implemented_
 
 - [ ] **Page declares actions via window.__vrtActions / data-vrt-action** — verifies: O1
-  >   `vrt explore` auto-discovers actions the page advertises and
+  >   `vlmkit inspect explore` auto-discovers actions the page advertises and
   >   diffs each transition. Shaped like the WebMCP proposal but
   >   doesn't depend on the unfinished spec.
   - contributes to: GOAL-AGENT-ERGONOMICS
@@ -521,7 +521,7 @@
   - body: _not yet implemented_
 
 - [ ] **Pre-commit visual check** — verifies: L1
-  > `vrt compare` plus `vrt workflow approve` slot into a pre-commit hook for baseline-driven visual gating.
+  > `vlmkit diff html` plus `vlmkit workflow approve` slot into a pre-commit hook for baseline-driven visual gating.
   - contributes to: GOAL-SNAPSHOT-WORKFLOW
   - body: _not yet implemented_
 
@@ -536,7 +536,7 @@
   - body: implemented by `packages/vlmkit-markup/src/stress/media-variants.ts` and `packages/vlmkit-markup/src/style/motion-detect.ts`
 
 - [ ] **Reproduce user bug from screenshot** — verifies: K1
-  > `vrt component-extract` crops the bug region from the user-supplied screenshot; `vrt component-from-image` drives the rebuild loop.
+  > `vlmkit scan component` crops the bug region from the user-supplied screenshot; `vlmkit build component` drives the rebuild loop.
   - contributes to: GOAL-MARKUP-FIDELITY
   - body: _not yet implemented_
 
@@ -549,7 +549,7 @@
   - body: _not yet implemented_
 
 - [ ] **Retina 2x DPI rendering** (minor) — verifies: D4
-  > `vrt component-from-image --device-scale-factor 2` renders at 2× for retina parity.
+  > `vlmkit build component --device-scale-factor 2` renders at 2× for retina parity.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
@@ -564,7 +564,7 @@
   - deprecated: Out of scope per v2 matrix: requires assistive-technology integration; not a visual signal.
   - body: _not yet implemented_
 
-- [ ] **Selector miss in vrt interact triggers healer correction** — verifies: O2
+- [ ] **Selector miss in vlmkit inspect interact triggers healer correction** — verifies: O2
   > When a step selector fails to match, the healer scans the DOM for near-misses and prints `did you mean <selector>?` with confidence scores instead of a bare timeout.
   - contributes to: GOAL-AGENT-ERGONOMICS
   - body: _not yet implemented_
@@ -580,7 +580,7 @@
   - body: _not yet implemented_
 
 - [ ] **Skill playbook fans out N checks over one target** — verifies: O3-O5
-  > `vrt skill run <name> --against <html|url>` reads `.vrt-skills/<name>.json` and runs every check in the playbook against the target, aggregating into one report.
+  > `vlmkit skill run <name> --against <html|url>` reads `.vrt-skills/<name>.json` and runs every check in the playbook against the target, aggregating into one report.
   - contributes to: GOAL-AGENT-ERGONOMICS
   - body: _not yet implemented_
 
@@ -590,7 +590,7 @@
   - body: _not yet implemented_
 
 - [ ] **Snapshot approve workflow promotes current to baseline** — verifies: SNAP-002
-  >   `vrt snapshot approve` renames every `*-current.png` to
+  >   `vlmkit snapshot approve` renames every `*-current.png` to
   >   `*-baseline.png`. Used after an intentional UI change is
   >   reviewed.
   - contributes to: GOAL-SNAPSHOT-WORKFLOW
@@ -605,7 +605,7 @@
   - body: _not yet implemented_
 
 - [ ] **Snapshot stability measures false-positive rate** — verifies: SNAP-004
-  >   `vrt snapshot stability` re-runs the same snapshot N times
+  >   `vlmkit snapshot stability` re-runs the same snapshot N times
   >   against a single URL and reports the per-frame diff. Drives
   >   the mask-coverage tuning loop for sites with carousels or
   >   counters.
@@ -618,7 +618,7 @@
   - body: _not yet implemented_
 
 - [ ] **Spacing scale conformance** — verifies: M2
-  > `vrt design-tokens --spacing-scale` flags margin and padding values that fall outside the declared scale, e.g. a stray 5px on a 4px grid.
+  > `vlmkit check tokens --spacing-scale` flags margin and padding values that fall outside the declared scale, e.g. a stray 5px on a 4px grid.
   - contributes to: GOAL-DESIGN-SYSTEM
   - body: _not yet implemented_
 
@@ -639,7 +639,7 @@
   - body: _not yet implemented_
 
 - [ ] **Tab order matches visual reading order** — verifies: F3
-  > `vrt a11y-focus-order` walks Tab traversal and compares against the bbox-sorted visual order.
+  > `vlmkit check a11y focus` walks Tab traversal and compares against the bbox-sorted visual order.
   - contributes to: GOAL-A11Y-COMPLIANCE
   - body: _not yet implemented_
 
@@ -660,7 +660,7 @@
   - body: _not yet implemented_
 
 - [ ] **Touch target size meets WCAG 2.5.5 AAA / 2.5.8 AA** (critical) — verifies: F2
-  > `vrt a11y-touch` flags interactive elements below the 24px AA / 44px AAA minimum hit area.
+  > `vlmkit check a11y touch` flags interactive elements below the 24px AA / 44px AAA minimum hit area.
   - contributes to: GOAL-A11Y-COMPLIANCE
   - body: _not yet implemented_
 
@@ -718,7 +718,7 @@
   - body: _not yet implemented_
 
 - [ ] **WCAG AA text contrast scan** (critical) — verifies: F1
-  > `vrt a11y-contrast` reports every text/background pair under the AA threshold, with the hex pair the agent can paste into a fix.
+  > `vlmkit check a11y contrast` reports every text/background pair under the AA threshold, with the hex pair the agent can paste into a fix.
   - contributes to: GOAL-A11Y-COMPLIANCE
   - body: _not yet implemented_
 
@@ -752,7 +752,7 @@
   - body: _not yet implemented_
 
 - [ ] **i18n text inflation: no overflow or wrap at 1.4x word length** — verifies: I1
-  > `vrt i18n-stress` substitutes button / link text with 1.4× longer strings and flags overflow or wrap-to-second-line.
+  > `vlmkit stress i18n` substitutes button / link text with 1.4× longer strings and flags overflow or wrap-to-second-line.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
@@ -764,13 +764,13 @@
 ## Spec implementation index
 
 - **A1** — Build component from PNG screenshot
-  - code: `packages/vrt-markup/src/component/component-from-image.ts`
+  - code: `packages/vlmkit-markup/src/component/component-from-image.ts`
 - **A2** — Build component from Figma export
-  - code: `packages/vrt-markup/src/component/component-from-image.ts`
+  - code: `packages/vlmkit-markup/src/component/component-from-image.ts`
 - **A3** — Build component from hand-drawn wireframe
   - _No active implementation._
 - **A4** — Build component from competitor visual reference
-  - code: `packages/vrt-markup/src/component/component-from-image.ts`
+  - code: `packages/vlmkit-markup/src/component/component-from-image.ts`
 - **A5** — Build full page from design-spec document
   - _No active implementation._
 - **A6** — Build from natural-language description ⊘ deprecated
@@ -834,7 +834,7 @@
 - **CORE-003** — A11y tree diff between two renders
   - code: `src/experiments/migration/migration-compare.ts`
 - **CORE-004** — Element-level shift-isolated diff
-  - code: `packages/vrt-core/src/element-compare.ts`
+  - code: `packages/vlmkit-core/src/element-compare.ts`
 - **CORE-005** — Paint tree diff via Crater BiDi backend
   - code: `src/experiments/migration/migration-paint-tree.ts`
 - **D1** — Mobile tablet desktop breakpoint sweep
@@ -844,21 +844,21 @@
 - **D3** — Foldable or dual-screen rendering ⊘ deprecated
   - _No active implementation._
 - **D4** — Retina 2x DPI rendering
-  - code: `packages/vrt-markup/src/component/component-from-image.ts`
+  - code: `packages/vlmkit-markup/src/component/component-from-image.ts`
 - **D5** — Touchscreen-on-desktop affordances
   - _No active implementation._
 - **E1** — Hover state diff
-  - code: `packages/vrt-markup/src/component/component-from-image.ts`
+  - code: `packages/vlmkit-markup/src/component/component-from-image.ts`
 - **E10** — Accordion expand or collapse
-  - code: `packages/vrt-markup/src/inspect/interact.ts`
+  - code: `packages/vlmkit-markup/src/inspect/interact.ts`
 - **E11** — Tooltip on hover with delay
   - _No active implementation._
 - **E12** — Toast notification fade in or out ⊘ deprecated
   - _No active implementation._
 - **E13** — Tab switch
-  - code: `packages/vrt-markup/src/inspect/interact.ts`
+  - code: `packages/vlmkit-markup/src/inspect/interact.ts`
 - **E2** — Focus and focus-visible state
-  - code: `packages/vrt-markup/src/component/component-from-image.ts`
+  - code: `packages/vlmkit-markup/src/component/component-from-image.ts`
 - **E3** — Disabled state
   - _No active implementation._
 - **E4** — Loading state
@@ -868,9 +868,9 @@
 - **E6** — Empty state
   - _No active implementation._
 - **E7** — Dropdown or menu open
-  - code: `packages/vrt-markup/src/inspect/interact.ts`
+  - code: `packages/vlmkit-markup/src/inspect/interact.ts`
 - **E8** — Modal or dialog open
-  - code: `packages/vrt-markup/src/inspect/interact.ts`
+  - code: `packages/vlmkit-markup/src/inspect/interact.ts`
 - **E9** — Carousel or slider transitions ⊘ deprecated
   - _No active implementation._
 - **F1** — WCAG AA text contrast scan
@@ -886,13 +886,13 @@
 - **F5** — Screen-reader-only content ⊘ deprecated
   - _No active implementation._
 - **F6** — Keyboard navigation Tab Esc Enter
-  - code: `packages/vrt-markup/src/inspect/interact.ts`
+  - code: `packages/vlmkit-markup/src/inspect/interact.ts`
 - **F7** — Color blindness simulation
   - _No active implementation._
 - **F8** — 200 percent browser zoom usability
-  - code: `packages/vrt-markup/src/stress/media-variants.ts`
+  - code: `packages/vlmkit-markup/src/stress/media-variants.ts`
 - **F9** — Reduced motion compliance
-  - code: `packages/vrt-markup/src/stress/media-variants.ts`
+  - code: `packages/vlmkit-markup/src/stress/media-variants.ts`
 - **FIDELITY-001** — Build a card from a blank starter until diff under 3 percent
   - _No active implementation._
 - **G1** — Cumulative Layout Shift measurement
@@ -926,7 +926,7 @@
 - **I6** — Pluralization 1 item vs N items
   - _No active implementation._
 - **J1** — Cross-page component drift
-  - code: `packages/vrt-markup/src/stress/multi-page-consistency.ts`
+  - code: `packages/vlmkit-markup/src/stress/multi-page-consistency.ts`
 - **J2** — Inline-vs-component drift on a single page
   - _No active implementation._
 - **J3** — Variant rendering across props
@@ -936,11 +936,11 @@
 - **J5** — Slot composition
   - _No active implementation._
 - **K1** — Reproduce user bug from screenshot
-  - code: `packages/vrt-markup/src/component/component-extract.ts`
+  - code: `packages/vlmkit-markup/src/component/component-extract.ts`
 - **K2** — Off-by-one-pixel hunt
   - code: `src/compare.ts`
 - **K3** — Overflow or clipping detection
-  - code: `packages/vrt-markup/src/stress/i18n-stress.ts`
+  - code: `packages/vlmkit-markup/src/stress/i18n-stress.ts`
 - **K4** — Z-index stacking issues
   - _No active implementation._
 - **K5** — CLS detection via in-page PerformanceObserver
@@ -962,7 +962,7 @@
 - **M1** — Color tokens conform to declared palette
   - _No active implementation._
 - **M2** — Spacing scale conformance
-  - code: `packages/vrt-markup/src/style/design-tokens.ts`
+  - code: `packages/vlmkit-markup/src/style/design-tokens.ts`
 - **M3** — Typography scale compliance
   - code: `src/typography-hints.ts`
 - **M4-M6** — Radius / spacing / z-index / shadow-tier conformance
@@ -997,7 +997,7 @@
   - _No active implementation._
 - **O12** — LLM judgment on rendered output
   - _No active implementation._
-- **O2** — Selector miss in vrt interact triggers healer correction
+- **O2** — Selector miss in vlmkit inspect interact triggers healer correction
   - _No active implementation._
 - **O3-O5** — Skill playbook fans out N checks over one target
   - _No active implementation._
@@ -1016,7 +1016,7 @@
 - **SNAP-002** — Snapshot approve workflow promotes current to baseline
   - code: `src/cli/commands/snapshot.ts`
 - **SNAP-003** — Snapshot fix-prompt generates subagent-ready Markdown
-  - code: `packages/vrt-markup/src/heal/fix-prompt.ts`
+  - code: `packages/vlmkit-markup/src/heal/fix-prompt.ts`
 - **SNAP-004** — Snapshot stability measures false-positive rate
   - code: `src/vrt/snapshot/stability.ts`
 - **WORKFLOW-001** — Workflow init / capture / verify / approve loop

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -102,7 +102,7 @@
 - [ ] **Build from natural-language description** ⊘ deprecated (minor) — verifies: A6
   > Marked out-of-scope in v2 matrix; preserved here for one-to-one matrix mapping.
   - contributes to: GOAL-MARKUP-FIDELITY
-  - deprecated: Out of scope per v2 matrix: no reference image means no vrt signal applies. The scenario stays here only so the matrix-row link is mechanical; no successor.
+  - deprecated: Out of scope per v2 matrix: no reference image means no vlmkit signal applies. The scenario stays here only so the matrix-row link is mechanical; no successor.
   - body: _not yet implemented_
 
 - [ ] **Build full page from design-spec document** (minor) [draft] — verifies: A5
@@ -118,7 +118,7 @@
 - [ ] **Bundle size analysis** ⊘ deprecated (minor) — verifies: G3
   > Preserved for matrix-row parity.
   - contributes to: GOAL-VARIANT-RESILIENCE
-  - deprecated: Out of scope per v2 matrix: bundle analyzers and Lighthouse cover this lane; vrt has no asset-pipeline integration.
+  - deprecated: Out of scope per v2 matrix: bundle analyzers and Lighthouse cover this lane; vlmkit has no asset-pipeline integration.
   - body: _not yet implemented_
 
 - [ ] **Bundled per-target check via skill run** — verifies: L5
@@ -168,7 +168,7 @@
   - body: _not yet implemented_
 
 - [ ] **Compare-runs aggregates multiple VRT runs** (minor) — verifies: MIG-004
-  >   `vlmkit diff runs` diffs two prior vrt runs against each other
+  >   `vlmkit diff runs` diffs two prior vlmkit runs against each other
   >   (e.g. iter 0 vs iter 1 of a fix loop) so progress per round is
   >   visible at a glance.
   - contributes to: GOAL-MIGRATION-VERIFICATION, GOAL-AGENT-ERGONOMICS
@@ -281,7 +281,7 @@
   >   /api/smoke-test, /api/status, /api/execution-results, /api/visual-diffs, /api/detection-series,
   >   /api/component-status-matrix, /api/approvals, /api/cloudflare/screenshot,
   >   /api/cloudflare/crawl, /api/crater/layout. Lets a browser extension or
-  >   editor plugin drive vrt without spawning a Node child.
+  >   editor plugin drive vlmkit without spawning a Node child.
   - contributes to: GOAL-API
   - body: partial implementation in `src/api/api-app.ts`; execution-result search and visual-diff display models are backed by Worker D1 artifact rows when available. Local `api serve` exposes detection-rate time-series points from `data/bench-history.jsonl`, component/label status matrices from snapshot reports, approval-manifest list/add/remove operations, Cloudflare Browser Run Quick Actions proxies when credentials are configured, and a layout-only Crater JS/WASM renderer when `VLMKIT_CRATER_WASM_MODULE` is set.
 
@@ -342,7 +342,7 @@
 - [ ] **Live monitoring of production regressions** ⊘ deprecated (minor) — verifies: L3
   > Preserved for matrix-row parity.
   - contributes to: GOAL-SNAPSHOT-WORKFLOW
-  - deprecated: Out of scope per v2 matrix: commercial VRT vendors own this lane; vrt is build-time / dev-loop.
+  - deprecated: Out of scope per v2 matrix: commercial VRT vendors own this lane; vlmkit is build-time / dev-loop.
   - body: _not yet implemented_
 
 - [ ] **Live snapshot of an agent session** (minor) [draft] — verifies: O10
@@ -463,7 +463,7 @@
   - body: _not yet implemented_
 
 - [ ] **Network-throttled rendering** (minor) [draft] — verifies: H4
-  > No throttle flag today; Playwright supports it but no vrt CLI surface yet.
+  > No throttle flag today; Playwright supports it but no vlmkit CLI surface yet.
   - contributes to: GOAL-VARIANT-RESILIENCE
   - body: _not yet implemented_
 
@@ -630,7 +630,7 @@
 - [ ] **Storybook story diff** ⊘ deprecated (minor) — verifies: J4
   > Preserved for matrix-row parity.
   - contributes to: GOAL-DESIGN-SYSTEM
-  - deprecated: Out of scope per v2 matrix: Chromatic and Loki cover this lane with Storybook-native integration vrt doesn't have.
+  - deprecated: Out of scope per v2 matrix: Chromatic and Loki cover this lane with Storybook-native integration vlmkit doesn't have.
   - body: _not yet implemented_
 
 - [ ] **Subtle font-render regression** (minor) [draft] — verifies: K7

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -1,4 +1,4 @@
-# vrt — CLI / Library API Design
+# vlmkit — CLI / Library API Design
 
 ## Current Problems
 
@@ -9,9 +9,9 @@
 
 ## Design Policy
 
-### CLI: `vrt` Subcommand System
+### CLI: `vlmkit` Subcommand System
 
-Hang subcommands off a single entry point (`vrt`).
+Hang subcommands off a single entry point (`vlmkit`).
 
 ```
 vlmkit diff html <before> <after>         # VRT comparison of 2 files
@@ -139,10 +139,10 @@ vlmkit scan breakpoints page.html
 Demo execution.
 
 ```bash
-vrt demo              # Basic demo
-vrt demo fix          # Fix loop
-vrt demo multi        # Multi-scenario
-vrt demo multistep    # Multi-step
+vlmkit demo              # Basic demo
+vlmkit demo fix          # Fix loop
+vlmkit demo multi        # Multi-scenario
+vlmkit demo multistep    # Multi-step
 ```
 
 ## Library API
@@ -410,7 +410,7 @@ needs:
 
 | | `vlmkit diff-pr` | `vlmkit workflow` |
 |---|---|---|
-| audience | external project's CI gate | vrt's own dogfooding e2e harness |
+| audience | external project's CI gate | vlmkit's own dogfooding e2e harness |
 | capture | direct `chromium.launch()` + `page.goto()` per route | Playwright spec at `e2e/vrt-capture.spec.ts` |
 | baseline layout | `<baselineDir>/<route>/<viewport>.png` | flat `baselines/*.png` keyed by spec testId |
 | approval | per-rule manifest (`vlmkit manifest add`) + per-viewport threshold | bulk `cp snapshots → baselines` |
@@ -419,10 +419,10 @@ needs:
 
 Rule of thumb:
 
-- Pulling vrt into a new project: use **`vlmkit diff-pr`** with a
+- Pulling vlmkit into a new project: use **`vlmkit diff-pr`** with a
   `vrt.config.json`. Pin on main, gate per PR. Author exceptions via
   `vlmkit manifest`.
-- Working inside the vrt repo (this codebase) or extending its
+- Working inside the vlmkit repo (this codebase) or extending its
   test harness: use **`vlmkit workflow`**. It owns the e2e Playwright
   spec and the a11y semantic check that `vlmkit diff-pr` doesn't.
 

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -14,15 +14,15 @@
 Hang subcommands off a single entry point (`vrt`).
 
 ```
-vrt compare <before> <after>         # VRT comparison of 2 files
-vrt compare --url <url> --current-url <url>  # URL mode
-vrt snapshot <url1> [url2] ...       # URL → multi-viewport capture + baseline diff
-vrt bench [options]                   # CSS challenge benchmark
-vrt report                           # Report on accumulated data
-vrt discover <file>                  # Breakpoint discovery + viewport suggestions
-vrt smoke <file-or-url>              # A11y-driven random operation test
-vrt serve [--port 3456]              # API server
-vrt status [--url ...]               # Server health check
+vlmkit diff html <before> <after>         # VRT comparison of 2 files
+vlmkit diff html --url <url> --current-url <url>  # URL mode
+vlmkit snapshot <url1> [url2] ...       # URL → multi-viewport capture + baseline diff
+vlmkit bench [options]                   # CSS challenge benchmark
+vlmkit report                           # Report on accumulated data
+vlmkit scan breakpoints <file>                  # Breakpoint discovery + viewport suggestions
+vlmkit inspect smoke <file-or-url>              # A11y-driven random operation test
+vlmkit api serve [--port 3456]              # API server
+vlmkit api status [--url ...]               # Server health check
 ```
 
 ### Library: 3-Layer Structure
@@ -30,7 +30,7 @@ vrt status [--url ...]               # Server health check
 ```
 ┌─────────────────────────────────────────────┐
 │  CLI Layer (src/cli/)                       │
-│  vrt compare, vrt bench, vrt report, ...    │
+│  vlmkit diff html, vlmkit bench, vlmkit report, ...    │
 └─────────────┬───────────────────────────────┘
               │
 ┌─────────────▼───────────────────────────────┐
@@ -58,22 +58,22 @@ vrt status [--url ...]               # Server health check
 
 ## CLI Details
 
-### `vrt compare`
+### `vlmkit diff html`
 
 Compare 2 HTML files (or URLs). Auto breakpoint discovery + multi-viewport.
 
 ```bash
 # File comparison
-vrt compare before.html after.html
+vlmkit diff html before.html after.html
 
 # Directory comparison (baseline + variants)
-vrt compare --baseline normalize.html --variants modern.html destyle.html
+vlmkit diff html --baseline normalize.html --variants modern.html destyle.html
 
 # URL comparison
-vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/
+vlmkit diff html --url http://localhost:3000/ --current-url http://localhost:8080/
 
 # Options
-vrt compare before.html after.html \
+vlmkit diff html before.html after.html \
   --backend chromium           # chromium | crater | both
   --max-viewports 10           # Viewport limit
   --random-samples 2           # Random samples between breakpoints
@@ -83,48 +83,48 @@ vrt compare before.html after.html \
   --mask ".ads,.carousel"      # Selector masking (visibility: hidden)
 ```
 
-### `vrt snapshot`
+### `vlmkit snapshot`
 
 Capture URL at multiple viewports and auto-compare with previous baseline.
 
 ```bash
 # First run: create baseline. Subsequent runs: measure diff
-vrt snapshot http://localhost:3000/ http://localhost:3000/about/
+vlmkit snapshot http://localhost:3000/ http://localhost:3000/about/
 
 # Options
-vrt snapshot <url1> [url2] ... \
+vlmkit snapshot <url1> [url2] ... \
   --output snapshots/          # Output directory
   --mask ".marquee,.badge"     # Mask dynamic content
 ```
 
-### `vrt bench`
+### `vlmkit bench`
 
 CSS challenge benchmark. Delete 1 CSS line → measure detection rate.
 
 ```bash
-vrt bench                                    # Default (page fixture, 20 trials)
-vrt bench --fixture dashboard --trials 50    # Specify fixture + trial count
-vrt bench --backend crater                   # Crater backend
-vrt bench --all                              # All fixtures at once
-vrt bench --no-db                            # Don't save to DB
+vlmkit bench                                    # Default (page fixture, 20 trials)
+vlmkit bench --fixture dashboard --trials 50    # Specify fixture + trial count
+vlmkit bench --backend crater                   # Crater backend
+vlmkit bench --all                              # All fixtures at once
+vlmkit bench --no-db                            # Don't save to DB
 ```
 
-### `vrt report`
+### `vlmkit report`
 
 Analysis of accumulated data.
 
 ```bash
-vrt report                     # All data
-vrt report --fixture page      # By fixture
-vrt report --backend crater    # By backend
+vlmkit report                     # All data
+vlmkit report --fixture page      # By fixture
+vlmkit report --backend crater    # By backend
 ```
 
-### `vrt discover`
+### `vlmkit scan breakpoints`
 
 Discover breakpoints from HTML/CSS and suggest test viewports.
 
 ```bash
-vrt discover page.html
+vlmkit scan breakpoints page.html
 # Output:
 #   Breakpoints: min-width:640px, min-width:768px, min-width:1024px
 #   Suggested viewports (11):
@@ -233,11 +233,11 @@ Mapping from current files to new structure:
 | `src/experiments/css-challenge/css-challenge-core.ts` | Split: `core/css-parser.ts` + `core/diff.ts` + `backend/chromium.ts` + `backend/crater.ts` | Largest refactoring target |
 | `src/experiments/detection/detection-classify.ts` | `core/classify.ts` | Nearly as-is |
 | `src/experiments/detection/detection-db.ts` | `core/db.ts` | Nearly as-is |
-| `packages/vrt-capture/src/viewport-discovery.ts` | `core/viewport.ts` | Nearly as-is |
-| `packages/vrt-core/src/heatmap.ts` | `core/diff.ts` | Pixel diff portion |
-| `packages/vrt-core/src/a11y-semantic.ts` | `core/a11y.ts` | Nearly as-is |
-| `packages/vrt-capture/src/crater-client.ts` | `backend/crater.ts` | PaintNode/diff moves to `core/diff.ts` |
-| `packages/vrt-core/src/types.ts` | `core/types.ts` | Consolidate |
+| `packages/vlmkit-capture/src/viewport-discovery.ts` | `core/viewport.ts` | Nearly as-is |
+| `packages/vlmkit-core/src/heatmap.ts` | `core/diff.ts` | Pixel diff portion |
+| `packages/vlmkit-core/src/a11y-semantic.ts` | `core/a11y.ts` | Nearly as-is |
+| `packages/vlmkit-capture/src/crater-client.ts` | `backend/crater.ts` | PaintNode/diff moves to `core/diff.ts` |
+| `packages/vlmkit-core/src/types.ts` | `core/types.ts` | Consolidate |
 | `src/experiments/css-challenge/css-challenge.ts` | `cli/challenge.ts` | CLI entry |
 | `src/experiments/css-challenge/css-challenge-bench.ts` | `cli/bench.ts` | CLI entry |
 | `src/experiments/detection/detection-report.ts` | `cli/report.ts` | CLI entry |
@@ -256,14 +256,14 @@ Refactoring is deferred. First:
 
 Three subcommands now cover the full UI-implementation lifecycle.
 
-### Dev inner loop: `vrt compare` + `vrt watch`
+### Dev inner loop: `vlmkit diff html` + `vlmkit watch`
 
 ```
-vrt compare <baseline> <variant> [--tokens DESIGN.md]
-vrt watch   <baseline> <variant> [--tokens DESIGN.md]
+vlmkit diff html <baseline> <variant> [--tokens DESIGN.md]
+vlmkit watch   <baseline> <variant> [--tokens DESIGN.md]
 ```
 
-`vrt compare` does a one-shot diff and prints:
+`vlmkit diff html` does a one-shot diff and prints:
 
 - per-viewport diff %
 - **wireframe fix suggestions** with scope tags:
@@ -275,19 +275,19 @@ vrt watch   <baseline> <variant> [--tokens DESIGN.md]
 - triptych PNG per viewport (`baseline | variant | heatmap`)
 - token-snapped values when `--tokens` points at a DESIGN.md
 
-`vrt watch` wraps that in a file-watcher with debounce + a
+`vlmkit watch` wraps that in a file-watcher with debounce + a
 **round-vs-round delta**: when the developer or agent saves a file,
 the next run lists which suggestions became newly-introduced (= your
 last edit regressed something), resolved, or persisted.
 
-### Approval authoring: `vrt manifest`
+### Approval authoring: `vlmkit manifest`
 
 ```
-vrt manifest add    --reason "..." --selector .foo [--max-px 2] [--expires DATE]
-vrt manifest add    --from-run <output-dir> [--auto-tiny | --top N | --all]
-vrt manifest list   [--path approval.json]
-vrt manifest rm     <index | selector>
-vrt manifest check  # CI hook — exit non-zero on expired rules
+vlmkit manifest add    --reason "..." --selector .foo [--max-px 2] [--expires DATE]
+vlmkit manifest add    --from-run <output-dir> [--auto-tiny | --top N | --all]
+vlmkit manifest list   [--path approval.json]
+vlmkit manifest rm     <index | selector>
+vlmkit manifest check  # CI hook — exit non-zero on expired rules
 ```
 
 `add --from-run` synthesizes rules from a recent compare run's
@@ -296,11 +296,11 @@ from the suggestion's `candidates[0]`. Default filter is
 low-confidence ∧ |Δ|≤2px (sub-pixel AA jitter); use `--top N` to
 broaden.
 
-Manifest entries are consumed by the existing `vrt compare`
+Manifest entries are consumed by the existing `vlmkit diff html`
 `approvalManifest` plumbing — they're subtracted from the
 reported diff before the threshold gate fires.
 
-### A11y gate (folded into `vrt diff-pr`)
+### A11y gate (folded into `vlmkit diff-pr`)
 
 ```json
 {
@@ -330,11 +330,11 @@ Per-check thresholds and per-route overrides resolve the same way
 as the visual threshold (route value wins; project default fills
 the rest).
 
-Findings can be suppressed via `vrt manifest add --a11y-{contrast,
+Findings can be suppressed via `vlmkit manifest add --a11y-{contrast,
 touch,focus-order} --selector <substring> --reason "..." --expires
 <date>`. The substring matches the finding's `path` (or, for
 focus-order, the message text). Expired rules surface in
-`vrt manifest check` so the gate doesn't silently approve forever.
+`vlmkit manifest check` so the gate doesn't silently approve forever.
 
 Output (terminal):
 
@@ -353,11 +353,11 @@ Output (summary.md):
 - `focus` / mobile — **focus-order** 1 > 0: reverse (step 1→2)
 ```
 
-### CI gate: `vrt diff-pr`
+### CI gate: `vlmkit diff-pr`
 
 ```
-vrt diff-pr pin       # on main: capture baselines for every route
-vrt diff-pr           # in PR build: diff each route against pinned baseline
+vlmkit diff-pr pin       # on main: capture baselines for every route
+vlmkit diff-pr           # in PR build: diff each route against pinned baseline
 ```
 
 Reads `vrt.config.json`:
@@ -390,41 +390,41 @@ code is 0 on full pass / 1 on any uncovered breach.
 ```
      dev time                       CI time
      ──────────                     ────────
-   vrt compare ──────┐
+   vlmkit diff html ──────┐
      (rich signals)   │
                       │   on main:
-   vrt watch ─────────┤         vrt diff-pr pin
+   vlmkit watch ─────────┤         vlmkit diff-pr pin
      (round delta)    │              (seed baselines)
                       │
-   vrt manifest add ──┤   in PR:
-     (acknowledge)    │         vrt diff-pr
+   vlmkit manifest add ──┤   in PR:
+     (acknowledge)    │         vlmkit diff-pr
                       └→        (gate vs pinned)
                                     ↓
                                  summary.md  →  PR comment
 ```
 
-### `vrt diff-pr` vs `vrt workflow` — when to use which
+### `vlmkit diff-pr` vs `vlmkit workflow` — when to use which
 
 Two baseline workflows coexist intentionally; they serve different
 needs:
 
-| | `vrt diff-pr` | `vrt workflow` |
+| | `vlmkit diff-pr` | `vlmkit workflow` |
 |---|---|---|
 | audience | external project's CI gate | vrt's own dogfooding e2e harness |
 | capture | direct `chromium.launch()` + `page.goto()` per route | Playwright spec at `e2e/vrt-capture.spec.ts` |
 | baseline layout | `<baselineDir>/<route>/<viewport>.png` | flat `baselines/*.png` keyed by spec testId |
-| approval | per-rule manifest (`vrt manifest add`) + per-viewport threshold | bulk `cp snapshots → baselines` |
-| partial refresh | `vrt diff-pr pin <route>` (this commit) | not supported |
+| approval | per-rule manifest (`vlmkit manifest add`) + per-viewport threshold | bulk `cp snapshots → baselines` |
+| partial refresh | `vlmkit diff-pr pin <route>` (this commit) | not supported |
 | primary output | `summary.md` + per-route diff% | `output/report.json` with a11y deltas |
 
 Rule of thumb:
 
-- Pulling vrt into a new project: use **`vrt diff-pr`** with a
+- Pulling vrt into a new project: use **`vlmkit diff-pr`** with a
   `vrt.config.json`. Pin on main, gate per PR. Author exceptions via
-  `vrt manifest`.
+  `vlmkit manifest`.
 - Working inside the vrt repo (this codebase) or extending its
-  test harness: use **`vrt workflow`**. It owns the e2e Playwright
-  spec and the a11y semantic check that `vrt diff-pr` doesn't.
+  test harness: use **`vlmkit workflow`**. It owns the e2e Playwright
+  spec and the a11y semantic check that `vlmkit diff-pr` doesn't.
 
 Unification under a single command surface is a future cleanup once
 both paths have settled. For now they share the same low-level
@@ -434,10 +434,10 @@ approval-manifest contract.
 ### PR comment glue
 
 ```
-vrt diff-pr post --pr <ref> [--summary <path>] [--marker <id>]
+vlmkit diff-pr post --pr <ref> [--summary <path>] [--marker <id>]
 ```
 
-After running `vrt diff-pr`, post the generated `summary.md` to a
+After running `vlmkit diff-pr`, post the generated `summary.md` to a
 PR via `gh pr comment`. If `gh` isn't on PATH the command prints
 the markdown with copy-paste instructions instead — useful for
 operators inspecting the gate output before committing to a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,15 +5,15 @@
 Entry point: `src/cli/vrt.ts`
 
 ```
-vrt compare <before> <after>           # HTML/URL VRT comparison
-vrt compare --url <url> --current-url <url>  # URL mode
-vrt snapshot <url1> [url2] ...         # URL → multi-viewport capture + baseline diff
-vrt bench [options]                    # CSS challenge benchmark
-vrt report                             # Report on accumulated data
-vrt discover <file>                    # Breakpoint discovery + viewport suggestions
-vrt smoke <file-or-url>                # A11y-driven random operation test
-vrt serve [--port 3456]                # API server
-vrt status [--url ...]                 # Server health check
+vlmkit diff html <before> <after>           # HTML/URL VRT comparison
+vlmkit diff html --url <url> --current-url <url>  # URL mode
+vlmkit snapshot <url1> [url2] ...         # URL → multi-viewport capture + baseline diff
+vlmkit bench [options]                    # CSS challenge benchmark
+vlmkit report                             # Report on accumulated data
+vlmkit scan breakpoints <file>                    # Breakpoint discovery + viewport suggestions
+vlmkit inspect smoke <file-or-url>                # A11y-driven random operation test
+vlmkit api serve [--port 3456]                # API server
+vlmkit api status [--url ...]                 # Server health check
 ```
 
 ## Module Structure
@@ -117,8 +117,8 @@ Heatmap (PNG) + CSS text diff
 Prevent false positives from dynamic content (animations, counters, external data).
 
 ```bash
-vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
-vrt compare --url http://a.com --current-url http://b.com --mask ".ads"
+vlmkit snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
+vlmkit diff html --url http://a.com --current-url http://b.com --mask ".ads"
 ```
 
 Mechanism: inject `visibility: hidden !important` via `page.addStyleTag()`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# vrt — Architecture
+# vlmkit — Architecture
 
 ## CLI Command System
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,7 +22,7 @@ for options.
 | `vlmkit snapshot` | `[<url>...]`, `approve`, `fix-prompt`, `stability`, `flipbook`, `report` |
 | `vlmkit migration` | `compare`, `blind`, `subagent` |
 | `vlmkit workflow` | `init`, `capture`, `verify`, `approve`, `graph`, `affected`, `introspect`, `spec-verify`, `expect` |
-| Standalone | `vlmkit mcp`, `vlmkit watch`, `vlmkit manifest`, `vlmkit diff-pr`, `vlmkit baseline`, `vlmkit markup-loop`, `vlmkit api`, `vlmkit bench`, `vlmkit report`, `vlmkit skill` |
+| Standalone | `vlmkit batch`, `vlmkit mcp`, `vlmkit watch`, `vlmkit manifest`, `vlmkit diff-pr`, `vlmkit baseline`, `vlmkit markup-loop`, `vlmkit api`, `vlmkit bench`, `vlmkit report`, `vlmkit skill` |
 
 The single-token commands from 0.4.x (`vrt compare`, `vrt png-diff`,
 `vrt theme-parity`, …) remain as deprecation shims that forward to
@@ -251,6 +251,24 @@ vlmkit check perf          <html|url>          # Web Vitals (CLS / LCP / FCP)
 vlmkit check drift component <html> --selector .card
 vlmkit check drift pages     --selector .footer --files A.html B.html C.html
 ```
+
+### Batch (many pages, one glob)
+
+```bash
+# Run a gate over every matched page; verdict per page is that run's exit code.
+vlmkit batch --gate "check integrity" "routes/**/*.html"
+
+# Several gates, wider pool, logs kept for CI.
+vlmkit batch --gate "check integrity" --gate "check design" "dist/**/*.html" \
+  --concurrency 4 --output ci-logs/
+
+# One shard of three runners (stride-sliced, so neighbouring pages split up).
+vlmkit batch --gate "check integrity" "routes/**/*.html" --shard 2/3
+```
+
+Measured concurrency / sharding numbers and the reason the summary reports
+"jobs in flight" rather than a speedup:
+[`docs/reports/2026-08-02-batch-runner-ci-budget.md`](./reports/2026-08-02-batch-runner-ci-budget.md).
 
 ### Build / Scan / Inspect / Stress (markup-assistance)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -237,6 +237,22 @@ vlmkit snapshot flipbook                       # Diff three-frame (baseline ↔ 
 vlmkit snapshot report                         # Render snapshot-report.json as Markdown
 ```
 
+### Integrity exemptions
+
+```bash
+# Accept an intentional pattern the tool does not recognise as one.
+# Reason is mandatory; `;` separates it (so `#` stays available for ID selectors).
+vlmkit check integrity page.html \
+  --allow "near-misalignment@.badge;icon is optically centred" \
+  --allow "text-collision@#refund@1280;deliberate graze, design sign-off DS-412"
+```
+
+An accepted finding is still printed, under "Exempted by --allow (your call)", and
+a rule that matched nothing is reported so dead config gets deleted. Kinds that
+mean the page is broken (`js-error`, `degenerate-render`, `unstyled-page`,
+`redirected`) cannot be exempted. Put the rule in `vlmkit.gates.json` when it
+needs an owner and an expiry — an expired suppression stops being applied.
+
 ### Check (gates: a11y / tokens / design / theme / perf / drift)
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,7 +22,7 @@ for options.
 | `vlmkit snapshot` | `[<url>...]`, `approve`, `fix-prompt`, `stability`, `flipbook`, `report` |
 | `vlmkit migration` | `compare`, `blind`, `subagent` |
 | `vlmkit workflow` | `init`, `capture`, `verify`, `approve`, `graph`, `affected`, `introspect`, `spec-verify`, `expect` |
-| Standalone | `vlmkit batch`, `vlmkit mcp`, `vlmkit watch`, `vlmkit manifest`, `vlmkit diff-pr`, `vlmkit baseline`, `vlmkit markup-loop`, `vlmkit api`, `vlmkit bench`, `vlmkit report`, `vlmkit skill` |
+| Standalone | `vlmkit batch`, `vlmkit gates`, `vlmkit mcp`, `vlmkit watch`, `vlmkit manifest`, `vlmkit diff-pr`, `vlmkit baseline`, `vlmkit markup-loop`, `vlmkit api`, `vlmkit bench`, `vlmkit report`, `vlmkit skill` |
 
 The single-token commands from 0.4.x (`vrt compare`, `vrt png-diff`,
 `vrt theme-parity`, …) remain as deprecation shims that forward to
@@ -269,6 +269,22 @@ vlmkit batch --gate "check integrity" "routes/**/*.html" --shard 2/3
 Measured concurrency / sharding numbers and the reason the summary reports
 "jobs in flight" rather than a speedup:
 [`docs/reports/2026-08-02-batch-runner-ci-budget.md`](./reports/2026-08-02-batch-runner-ci-budget.md).
+
+### Gates config (per-page gate sets + auditable suppressions)
+
+```bash
+vlmkit gates init --pages "routes/**/*.html" --gate "check integrity"
+vlmkit gates list            # resolved page x gate plan, exact commands, no run
+vlmkit gates run             # run it (same pool/sharding as `batch`)
+vlmkit gates suppressions    # every silenced check: reason, owner, expiry, days left
+```
+
+`vlmkit.gates.json` holds which gates run on which pages plus every
+suppression. Two rules make it reviewable: a suppression **must** carry a
+`reason` (parsing fails without one), and an **expired** suppression stops
+being applied — the gate it silenced runs unmuted and the run exits non-zero,
+because a stale entry is a config defect even when the page now passes.
+Worked example: [`examples/vlmkit.gates.json`](../examples/vlmkit.gates.json).
 
 ### Build / Scan / Inspect / Stress (markup-assistance)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -11,7 +11,7 @@ for options.
 | Group | Subcommands |
 |---|---|
 | `vlmkit diff` | `html`, `png`, `elements`, `browsers`, `agent`, `runs` (`region` is deprecated) |
-| `vlmkit check` | `integrity`, `copy`, `layout`, `interactions`, `equivalence`, `asset`, `breakpoints`, `scroll`, `animation`, `motion`, `a11y {contrast,touch,focus}`, `palette`, `tokens`, `theme`, `perf`, `drift {component,pages}`, `crater` |
+| `vlmkit check` | `integrity`, `copy`, `layout`, `interactions`, `equivalence`, `asset`, `breakpoints`, `scroll`, `animation`, `motion`, `a11y {contrast,touch,focus}`, `palette`, `tokens`, `design`, `theme`, `perf`, `drift {component,pages}`, `crater` |
 | `vlmkit scan` | `component`, `breakpoints`, `scroll`, `mock`, `handlers` |
 | `vlmkit build` | `component`, `page` |
 | `vlmkit verify` | `markup`, `flow` |
@@ -237,14 +237,15 @@ vlmkit snapshot flipbook                       # Diff three-frame (baseline ↔ 
 vlmkit snapshot report                         # Render snapshot-report.json as Markdown
 ```
 
-### Check (gates: a11y / tokens / theme / perf / drift)
+### Check (gates: a11y / tokens / design / theme / perf / drift)
 
 ```bash
 vlmkit check a11y contrast <html>              # WCAG AA contrast scan
 vlmkit check a11y touch    <html|url>          # Touch target size (WCAG 2.5.5 / 2.5.8)
 vlmkit check a11y focus    <html|url>          # Tab order vs visual order
 vlmkit check palette       <target.png> [current.png]  # Dominant colors, or palette diff (missing/extra hex)
-vlmkit check tokens        <html>              # radius/spacing/z-index/shadow scale conformance
+vlmkit check tokens        <html>              # radius/spacing/z-index/shadow scale conformance (declared scale)
+vlmkit check design        <html|url>          # coherence of the scale the page itself implies (no config)
 vlmkit check theme         <html>              # prefers-color-scheme dark / unthemed components
 vlmkit check perf          <html|url>          # Web Vitals (CLS / LCP / FCP)
 vlmkit check drift component <html> --selector .card

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,7 +62,7 @@ for the full old → new mapping.
 
 ## Quick Start
 
-The examples below assume the `vrt` command is already installed and available on your PATH.
+The examples below assume the `vlmkit` command is already installed and available on your PATH.
 
 ```bash
 pnpm install
@@ -138,7 +138,7 @@ vlmkit baseline pin                                       # on main
 vlmkit baseline verify                                    # in PR
 vlmkit baseline post --pr owner/repo#123                  # send summary.md as PR comment
 
-# Legacy internal-dogfood verification loop (vrt's own e2e suite)
+# Legacy internal-dogfood verification loop (vlmkit's own e2e suite)
 vlmkit workflow init
 vlmkit workflow capture
 vlmkit workflow verify
@@ -584,7 +584,7 @@ Workflow aliases are kept for ergonomics where they do not collide:
 #### Capture routes for external projects
 
 `vlmkit workflow init|capture` runs `e2e/vrt-capture.spec.ts`, which now resolves
-its route list from your project rather than hard-coding vrt's own pages.
+its route list from your project rather than hard-coding vlmkit's own pages.
 Drop a `vrt.config.json` next to your app with a `capture` block:
 
 ```json

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -240,13 +240,13 @@ vlmkit snapshot report                         # Render snapshot-report.json as 
 ### Check (gates: a11y / tokens / design / theme / perf / drift)
 
 ```bash
-vlmkit check a11y contrast <html>              # WCAG AA contrast scan
+vlmkit check a11y contrast <html|url>          # WCAG AA contrast scan
 vlmkit check a11y touch    <html|url>          # Touch target size (WCAG 2.5.5 / 2.5.8)
 vlmkit check a11y focus    <html|url>          # Tab order vs visual order
 vlmkit check palette       <target.png> [current.png]  # Dominant colors, or palette diff (missing/extra hex)
-vlmkit check tokens        <html>              # radius/spacing/z-index/shadow scale conformance (declared scale)
+vlmkit check tokens        <html|url>          # radius/spacing/z-index/shadow scale conformance (declared scale)
 vlmkit check design        <html|url>          # coherence of the scale the page itself implies (no config)
-vlmkit check theme         <html>              # prefers-color-scheme dark / unthemed components
+vlmkit check theme         <html|url>          # prefers-color-scheme dark / unthemed components
 vlmkit check perf          <html|url>          # Web Vitals (CLS / LCP / FCP)
 vlmkit check drift component <html> --selector .card
 vlmkit check drift pages     --selector .footer --files A.html B.html C.html

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,15 +43,28 @@ agent the task routing and the fix-loop discipline (assumes only that
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `VRT_LLM_PROVIDER` | LLM provider | gemini |
-| `VRT_LLM_MODEL` | LLM model | provider default |
-| `VRT_VLM_MODEL` | VLM model (OpenRouter) | qwen/qwen3-vl-8b-instruct |
+| `VLMKIT_LLM_PROVIDER` | LLM provider | gemini |
+| `VLMKIT_LLM_MODEL` | LLM model | provider default |
+| `VLMKIT_VLM_MODEL` | VLM model (OpenRouter) | qwen/qwen3-vl-8b-instruct |
+| `VLMKIT_BASE_URL` | Base URL for workflow capture | — |
+| `VLMKIT_CAPTURE_BACKEND` | Capture backend override | playwright |
+| `VLMKIT_CONFIG_PATH` / `VLMKIT_CONFIG_FILE` | Config path override | — |
+| `VLMKIT_PROJECT_ROOT` | Project root override | cwd |
 | `OPENROUTER_API_KEY` | OpenRouter API key | — |
 | `GEMINI_API_KEY` | Google AI API key | — |
 | `ANTHROPIC_API_KEY` | Anthropic API key | — |
 | `VLMKIT_CRATER_BIDI_URL` | Crater BiDi WebSocket URL, including `/session/...` when required | `ws://127.0.0.1:9222` |
 | `VLMKIT_CRATER_ROOT` | Crater checkout containing `.bidi-ws-url` from `just start-bidi-with-font` | — |
 | `VLMKIT_CRATER_WASM_MODULE` | Crater layout JS/WASM module path for `POST /api/crater/layout` | — |
+
+Every `VLMKIT_*` variable above is also read under its old `VRT_*` spelling
+(`VRT_LLM_PROVIDER`, `VRT_VLM_MODEL`, …). The new name wins when both are set;
+using an old one prints one line naming the replacement. Support for the `VRT_*`
+spellings ends in 1.0.0 — an existing CI keeps working until then without a
+change. The same holds for two other renamed names: the state directory moved
+from `.vrt/` to `.vlmkit/` and the config file from `vrt.config.json` to
+`vlmkit.config.json`, and in both cases an existing old path is still used, per
+entry, so approved baselines are never orphaned.
 
 
 ## Snapshot / CI configuration
@@ -85,7 +98,7 @@ apm install mizchi/vlmkit/.claude/skills/vrt-visual-diff
 | `dynamic-markup` | auto-markup + gates: `check breakpoints` / `scan scroll` / `check animation\|motion` | Markup whose spec includes breakpoints, scrollports, animations |
 | `agent-validation-loop` | disposable subagent runs → friction → fix → re-run | Harden a CLI/library by measuring whether agents can drive it |
 
-Each skill assumes the `vrt` CLI is on `$PATH` (this repo published as
+Each skill assumes the `vlmkit` CLI is on `$PATH` (this repo published as
 a Node package, or built from source) and Node 24+. VLM-using skills
 (`fix-loop`, `markup-synth`, `migration subagent`) additionally need
 one of `OPENROUTER_API_KEY` / `GEMINI_API_KEY` / `ANTHROPIC_API_KEY`

--- a/docs/crater-breakpoint-discovery-design.md
+++ b/docs/crater-breakpoint-discovery-design.md
@@ -259,7 +259,7 @@ Since the current `SessionState` is thin and doesn't directly hold browser state
 
 ## vrt-side integration point
 
-`packages/vrt-capture/src/viewport-discovery.ts` has regex extraction and viewport generation tightly coupled.
+`packages/vlmkit-capture/src/viewport-discovery.ts` has regex extraction and viewport generation tightly coupled.
 When introducing crater, make the generation logic the proper API and make the extraction source swappable.
 
 Expected:
@@ -324,7 +324,7 @@ Minimum Red:
 - External stylesheet support
 - Breakpoint prioritization by `ruleCount`
 - Phased support for `height`, `orientation`, `prefers-color-scheme`
-- Add crater backend to `vrt discover` CLI
+- Add crater backend to `vlmkit scan breakpoints` CLI
 
 ## open questions
 

--- a/docs/crater-breakpoint-discovery-design.md
+++ b/docs/crater-breakpoint-discovery-design.md
@@ -1,10 +1,10 @@
 # crater breakpoint discovery design
 
-As of 2026-04-02, crater core / BiDi / `vrt` integration is implemented; what remains unfinished is the v2 scope such as external stylesheet discovery.
+As of 2026-04-02, crater core / BiDi / `vlmkit` integration is implemented; what remains unfinished is the v2 scope such as external stylesheet discovery.
 
 ## Background
 
-The original `vrt` had the idea of treating breakpoints as boundary values for quickcheck, but extraction was regex-based and only looked at `<style>`.
+The original `vlmkit` had the idea of treating breakpoints as boundary values for quickcheck, but extraction was regex-based and only looked at `<style>`.
 
 Now `migration-compare --discover-backend auto|regex|crater` is available, and the default `auto` prefers crater's `getResponsiveBreakpoints`, falling back to regex discovery only when unavailable.
 
@@ -14,12 +14,12 @@ Meanwhile, `crater` already has:
 - stylesheet parser
 - BiDi extensions (`capturePaintTree`, `setViewport`)
 
-Therefore, it's natural to consolidate breakpoint discovery normalization and contracts on the `crater` side, limiting `vrt` to the responsibility of converting them into test inputs.
+Therefore, it's natural to consolidate breakpoint discovery normalization and contracts on the `crater` side, limiting `vlmkit` to the responsibility of converting them into test inputs.
 
 ## Goal
 
 - Extract responsive breakpoint candidates from CSS media queries via parser-based approach
-- Enable `vrt` to convert them into viewport sets as quickcheck boundary values
+- Enable `vlmkit` to convert them into viewport sets as quickcheck boundary values
 - Enable `migration-compare` to union breakpoints from baseline / variant
 - Fix the contract upfront for easy future extension to external stylesheets and container queries
 
@@ -40,7 +40,7 @@ Therefore, it's natural to consolidate breakpoint discovery normalization and co
 - Return breakpoint candidates from the current document
 - Return non-width conditions and unsupported conditions as diagnostics
 
-### vrt's responsibilities
+### vlmkit's responsibilities
 
 - Union breakpoint sets from baseline / variant
 - Expand `>= N` to `N-1, N` etc., converting to quickcheck boundary inputs
@@ -53,7 +53,7 @@ What `crater` returns is `canonical responsive breakpoints`, not `suggested view
 
 Reasons:
 
-- Viewport generation is `vrt`'s test policy
+- Viewport generation is `vlmkit`'s test policy
 - `maxViewports` and `randomSamples` change based on harness / CI needs
 - Systems like `flaker` that require stable identities need fixed viewports
 - `crater` is more reusable when it acts as the CSS semantics authority
@@ -67,7 +67,7 @@ crater core
 crater BiDi
   -> browsingContext.getResponsiveBreakpoints
 
-vrt
+vlmkit
   -> union breakpoints
   -> generateViewports(...)
 ```
@@ -297,7 +297,7 @@ Minimum Red:
 - `no such frame` on invalid context
 - Unsupported conditions appear in diagnostics
 
-### vrt tests
+### vlmkit tests
 
 - Can pass crater breakpoints to `generateViewports()`
 - Can take union of baseline / variant
@@ -310,7 +310,7 @@ Minimum Red:
 
 - crater core: `discover_responsive_breakpoints(html)`
 - crater BiDi: `browsingContext.getResponsiveBreakpoints`
-- vrt: crater client method
+- vlmkit: crater client method
 
 ### Phase 2
 
@@ -348,7 +348,7 @@ However, v1 provides sufficient value with just inline/live styles.
 With this design:
 
 - `crater` is the authority on CSS / media semantics
-- `vrt` is the authority on quickcheck input generation
+- `vlmkit` is the authority on quickcheck input generation
 
 This role separation holds.
 Since v1 can be cut narrow, we can deliver parser-based discovery value quickly while safely extending to external CSS and multi-axis discovery.

--- a/docs/design/design-policy-metrics.md
+++ b/docs/design/design-policy-metrics.md
@@ -1,0 +1,149 @@
+# Deterministic design-policy metrics — feasibility study
+
+vlmkit guarantees function (nothing broken, copy present, responsive
+boundaries hold, controls operable) and deliberately refuses to judge
+aesthetics. The question here: **can design quality be gated
+deterministically at all**, or is it all taste?
+
+## The distinction that makes it possible
+
+Beauty is not measurable. **Self-consistency is.** The line is:
+
+| Not measurable (taste — stays out) | Measurable (policy — can be a gate) |
+|---|---|
+| "is 24px the right gap here?" | "you used 23px here and 24px in 40 other places" |
+| "is this the right blue?" | "your buttons render 6 distinct padding/radius/size signatures" |
+| "does this layout feel balanced?" | "these 4 cards sit on 4 different left edges" |
+| "is this typography good?" | "12 distinct font sizes for 9 text roles" |
+
+Everything in the right column is a **conformance or entropy measurement
+against a system the page itself declares** — either an explicit token file
+or the page's own dominant values. No taste required, no VLM required.
+
+`check tokens` already does the explicit-policy half (values off a declared
+radius/spacing/z-index scale). What is missing is the *inferred* half, and
+that is where the interesting signal turned out to be.
+
+## What was measured
+
+Four candidate metrics, on three designed real pages (MDN, web.dev,
+Wikipedia — mirrored) and five agent-built zero-shot fixtures
+(`attempt-s15..s19-haiku.html`), all at 1280px, visible elements only
+(`checkVisibility`, so collapsed `<details>` content does not pollute):
+
+| page | els | spacing values | top-6 coverage | 4px-grid fit | left-rail top-8 | font sizes | **button signatures** |
+|---|---|---|---|---|---|---|---|
+| MDN | 1497 | 18 | 0.963 | 0.857 | 0.729 | 5 | **1 / 8** |
+| web.dev | 801 | 11 | 0.940 | 0.716 | 0.742 | 7 | **1 / 5** |
+| Wikipedia | 5802 | 41 | 0.812 | 0.234 | 0.406 | 13 | 2 / 25 |
+| agent s15 | 51 | 9 | 0.883 | 0.922 | 0.686 | 6 | **3 / 6** |
+| agent s16 | 82 | 9 | 0.952 | **0.978** | 0.744 | 6 | **3 / 8** |
+| agent s17 | 70 | 7 | 0.989 | **1.000** | 0.957 | 7 | 1 / 1 |
+| agent s18 | 67 | 9 | 0.945 | 0.898 | 0.955 | 5 | 2 / 2 |
+| agent s19 | 50 | 11 | 0.864 | 0.864 | 0.420 | 8 | **6 / 7** |
+
+"button signatures" = distinct `(padding×4, radius, font-size, height)`
+tuples / number of button instances.
+
+## Result: the obvious metric fails, the useful one is the opposite
+
+**Grid conformance does not discriminate — agents beat designers at it.**
+Agent pages score 0.86–1.00 on 4px-grid fit; MDN scores 0.857 and web.dev
+0.716. LLM-written CSS uses round numbers religiously, so "is it on an 8px
+grid" is a metric an agent passes trivially while still producing an
+incoherent page. As a *policy* check (does this match OUR declared scale)
+it remains valid — that is `check tokens` — but as a *quality* signal it is
+close to worthless.
+
+A methodological trap worth recording: my first implementation picked the
+grid base with the best fit, which always chose **base 2** at 98% fit,
+because every even number fits base 2. "Best fit" over a free parameter
+measures nothing. The table above tests a fixed set (4, 8) and prefers the
+largest base that still explains ≥80% of values.
+
+**Component-signature uniformity discriminates sharply, and in the
+direction that matters.** MDN renders 8 buttons with **one** signature;
+web.dev 5 buttons with **one**. Agent s19 renders 7 buttons with **six**
+distinct signatures; s15 and s16 sit at 3 signatures for 6 and 8 buttons.
+
+That is the real, measurable difference between a designed page and a
+generated one:
+
+> Agent-built pages are **locally tidy but globally incoherent** — every
+> value is a round number, and almost every component instance is a
+> slightly different round number. Designed systems are the reverse: they
+> may use odd values, but they *reuse* them.
+
+Spacing-vocabulary concentration is a weaker version of the same signal
+(top-6 coverage 0.81–0.99 across both groups — overlapping, so not usable
+alone). Left-rail concentration is confounded by page size (Wikipedia 0.406
+with 5802 elements vs s17 0.957 with 70) and needs normalisation before it
+can carry a verdict.
+
+## Proposed gate: `check design` (inferred-system conformance)
+
+One new gate, four findings, all phrased as *consistency* claims with the
+offending selectors attached — never as taste:
+
+1. **`component-drift`** (the strong one) — group visible elements by
+   inferred role (explicit `role`, or button/heading/link/input semantics),
+   compute each instance's style signature, and report roles whose instance
+   count exceeds their signature count by less than a threshold. Kickback
+   names the minority signatures and the majority they deviate from:
+   `7 buttons render 6 distinct signatures; 5 differ from the dominant
+   (12/20/12/20, r=6, 14px, h=40) — .btn-ghost has padding 10/18/10/18`.
+2. **`scale-outlier`** — derive the dominant spacing set from the page
+   itself (values covering ≥90% of usages), then report the stragglers:
+   `23px used once; 24px used 41 times — .card-footer`. This is the
+   inferred-policy twin of `check tokens`, usable with no config.
+3. **`rail-drift`** — for siblings in the same container, report left/right
+   edges that differ by 1–3px (near-misalignment already exists as an
+   integrity probe A12; this extends it to a whole-container verdict).
+4. **`type-scale-sprawl`** — distinct font sizes vs distinct text roles,
+   reported as a ratio with the outlier sizes named.
+
+Severity: **warn by default**, not suspect. A page may legitimately have
+three button variants; the finding is information for a human, and the
+`--fail-on-suspect` contract should not turn "your design system has
+drifted" into a build failure unless the team opts in with a declared
+policy (`--policy design.json` pinning expected signature counts per role).
+
+## Why this is worth building
+
+- It is the first metric in this project that would have **failed the agent
+  work we shipped**. Every S15–S19 fixture passed all functional gates
+  while carrying 3–6 button signatures. The functional gates cannot see
+  this class at all.
+- It needs no reference design, no tokens file, and no VLM — the page is
+  compared against itself.
+- It fixes an asymmetry in the pitch: vlmkit tells an agent when the page
+  is *broken*, but says nothing when the page is *incoherent*, which is the
+  more common outcome of generated markup.
+
+## What stays out
+
+- Any judgement of *which* value is right. The gate reports that 23px and
+  24px coexist; choosing between them is the human's.
+- Colour harmony beyond the existing `check palette` / contrast work.
+  "Do these hues go together" is taste.
+- Visual hierarchy, balance, whitespace "feel", brand fit.
+- The `2/25` case (Wikipedia): a large organic site will always show
+  drift, and that is not a defect to fix — it is why the default is warn
+  and why the gate is most useful on new/generated pages and design-system
+  components, not on twenty years of accumulated wiki CSS.
+
+## Open questions before implementation
+
+1. **Role inference quality.** `button` is easy; "card" and "panel" are
+   not. The gate should only group roles it can infer deterministically,
+   and say which elements it skipped (no silent coverage gaps).
+2. **Signature granularity.** Including rendered `height` catches real
+   drift but also flags a button that is taller only because its label
+   wrapped. Height may belong in a separate finding from the style tuple.
+3. **Threshold shape.** `signatures/instances` is scale-sensitive at small
+   n (1 button = 1 signature = perfect). Needs a minimum instance count
+   (≥3) before reporting, like the other probes' floors.
+4. **State confusion.** A `:disabled` or `aria-pressed` button legitimately
+   differs. Signatures should be computed per resting state, or states
+   detected and excluded — the interaction gate already knows how to find
+   them.

--- a/docs/design/design-policy-metrics.md
+++ b/docs/design/design-policy-metrics.md
@@ -132,18 +132,83 @@ policy (`--policy design.json` pinning expected signature counts per role).
   and why the gate is most useful on new/generated pages and design-system
   components, not on twenty years of accumulated wiki CSS.
 
-## Open questions before implementation
+## Implemented: `vlmkit check design`
 
-1. **Role inference quality.** `button` is easy; "card" and "panel" are
-   not. The gate should only group roles it can infer deterministically,
-   and say which elements it skipped (no silent coverage gaps).
-2. **Signature granularity.** Including rendered `height` catches real
-   drift but also flags a button that is taller only because its label
-   wrapped. Height may belong in a separate finding from the style tuple.
-3. **Threshold shape.** `signatures/instances` is scale-sensitive at small
-   n (1 button = 1 signature = perfect). Needs a minimum instance count
-   (≥3) before reporting, like the other probes' floors.
-4. **State confusion.** A `:disabled` or `aria-pressed` button legitimately
-   differs. Signatures should be computed per resting state, or states
-   detected and excluded — the interaction gate already knows how to find
-   them.
+`packages/vlmkit-markup/src/style/design-policy.ts`. Two of the four
+proposed findings shipped; `rail-drift` and `type-scale-sprawl` did not
+(A12 already covers near-misalignment per element, and font-size count
+turned out to be the same overlapping distribution as spacing — 5-13 on
+designed pages, 5-8 on agent pages).
+
+### How the open questions resolved
+
+1. **Role inference** — narrow by construction: explicit `role`, `button`,
+   `input:<type>`, `select`, `textarea`, `h1`-`h6`. Nothing else is grouped,
+   and both skip counts (`skipped`, `statefulSkipped`) are in the report and
+   the header line, so the coverage gap is never silent. `input`/`select`/
+   `textarea` are **separate** roles: grouping them as one "field" produced a
+   false drift signal, because the browser styles them differently by design.
+2. **Signature granularity** — rendered `height` is **excluded**. The
+   signature is padding×4 | radius | font-size | font-weight | border-width |
+   background-color. A button that is taller only because its label wrapped is
+   not a design inconsistency.
+3. **Threshold shape** — a role is judged only at ≥3 instances, and the
+   measure is reuse (instances / distinct signatures) rather than the inverse
+   ratio, with a floor of 3.
+4. **State confusion** — `:disabled`, `aria-disabled`, `aria-pressed`,
+   `aria-expanded`, `aria-current`, `aria-selected`, `:checked` are excluded
+   and counted separately. Measured impact: this alone took S19 from 6
+   apparent button signatures to 3 real ones.
+
+### `scale-outlier` needed four tightenings, and does not carry the verdict
+
+The first implementation reported `verdict: DRIFT` on **both MDN and
+web.dev** — the pages this study established as coherent. A metric that
+fires on its own reference set is not a metric. The rows were:
+
+- MDN: `2.5px`, `5px`, `6px` paddings on an inline `<code>` element.
+- web.dev: `21.4px` "just off" a common `21.3px` — two rem-derived
+  neighbours with no design content whatsoever.
+
+So the rule now requires: value **and** reference ≥8px (a spacing scale does
+not start at 2px), both **integral** (fractional computed values come from
+rem/em arithmetic, not from a decision), a gap within `max(2, 10%)` of the
+reference (23-vs-24 is drift; 12-vs-8 is a second step in the scale), and a
+reference used ≥4 times and ≥3× more often than the outlier (otherwise
+"off the page's own scale" asserts a scale that does not exist).
+
+Even tightened, one true row survives on MDN: an authored `43px` padding on
+one `summary` against twelve `40px`. It is a real one-off, so the gate keeps
+printing it — but the study already measured that spacing concentration
+**overlaps** between designed and generated pages (top-6 coverage 0.81-0.99
+in both groups), which means a spacing straggler cannot carry a verdict.
+`scale-outlier` is therefore emitted at `severity: "info"` under an
+"Informational (true, but does not carry the verdict)" heading, and only
+`component-drift` moves the verdict.
+
+### Measured after implementation
+
+Same page set, `vlmkit check design`, 1280px:
+
+| page | verdict | carried finding |
+|---|---|---|
+| MDN | COHERENT | — (1 informational) |
+| web.dev | COHERENT | — |
+| Hacker News | COHERENT | — |
+| danluu.com | COHERENT | — |
+| W3C APG tabs | COHERENT | — |
+| Wikipedia | DRIFT | `navigation` 8 instances / 4 styles |
+| CSS Zen Garden | DRIFT | `article` 6/6, `h3` 5/2 |
+| agent s15 | DRIFT | `button` 6/3 |
+| agent s16 | DRIFT | `button` 6/3 |
+| agent s17 | COHERENT | — (1 button: below the instance floor) |
+| agent s18 | COHERENT | — (2 buttons: below the floor) |
+| agent s19 | DRIFT | `button` 7/3 |
+
+The two designed pages that report DRIFT are the two the study predicted
+would: Wikipedia's `navigation` role was called out in advance as genuine
+organic drift, and Zen Garden makes every section deliberately unique. The
+two agent pages that pass do so honestly — they have one and two buttons,
+which is below the instance floor, so the gate says nothing rather than
+guessing. Findings are warn-level, so a drifting design system never fails
+a build; `check design` exits non-zero only on `redirected` (suspect).

--- a/docs/feature-review.md
+++ b/docs/feature-review.md
@@ -6,7 +6,7 @@
 
 vlmkit の中核は Visual Regression Testing で、そこに design audit、
 markup assistance、agent loop、API/server、benchmark lab が重なっている。
-現在の README は機能量をよく拾えている一方で、`vrt` 時代の名前、
+現在の README は機能量をよく拾えている一方で、`vlmkit` 時代の名前、
 実験機能、公開済みの安定機能が同じ粒度で並んでいるため、利用者には
 「まず何を使えばよいか」が見えにくい。
 
@@ -45,10 +45,10 @@ markup assistance、agent loop、API/server、benchmark lab が重なってい�
 
 ## 主要なズレ
 
-### 1. `vrt` と `vlmkit` の名前が混在
+### 1. `vlmkit` と `vlmkit` の名前が混在
 
 `README.md` は概ね `vlmkit` に寄っているが、`docs/architecture.md`,
-`docs/api-design.md`, `docs/ja/README.md`, package README には `vrt`
+`docs/api-design.md`, `docs/ja/README.md`, package README には `vlmkit`
 時代の名前が残っている。CLI shim として旧名を残すのは妥当だが、公開
 docs の主語は `vlmkit` に統一した方がよい。
 
@@ -110,7 +110,7 @@ README と OpenAPI では experimental label を付ける。長期的には
    - Crater / Cloudflare backend
 6. Package APIs
    - `core`, `capture`, `markup`, `ai`
-7. Migration from `vrt`
+7. Migration from `vlmkit`
    - 旧コマンドは shim として残るが、新規 docs は `vlmkit` を使う
 
 ## OpenAI image generation note

--- a/docs/flaker-integration-design.md
+++ b/docs/flaker-integration-design.md
@@ -38,7 +38,7 @@ As of 2026-04-02, in addition to this custom runner, built-in `vrt-migration` / 
 - Quarantine
 - Per-variant trend analysis
 
-References: [docs/why-flaker.ja.md](/Users/mz/ghq/github.com/mizchi/metric-ci/docs/why-flaker.ja.md), [types.ts](/Users/mz/ghq/github.com/mizchi/metric-ci/packages/vrt-core/src/types.ts), [quarantine-manifest.ts](/Users/mz/ghq/github.com/mizchi/metric-ci/src/cli/quarantine-manifest.ts)
+References: [docs/why-flaker.ja.md](/Users/mz/ghq/github.com/mizchi/metric-ci/docs/why-flaker.ja.md), [types.ts](/Users/mz/ghq/github.com/mizchi/metric-ci/packages/vlmkit-core/src/types.ts), [quarantine-manifest.ts](/Users/mz/ghq/github.com/mizchi/metric-ci/src/cli/quarantine-manifest.ts)
 
 ### vrt's responsibilities
 

--- a/docs/flaker-integration-design.md
+++ b/docs/flaker-integration-design.md
@@ -1,16 +1,16 @@
-# flaker / vrt Integration Design
+# flaker / vlmkit Integration Design
 
 ## Background
 
 `flaker` excels at test selection / flaky detection / quarantine / history accumulation.
-`vrt` excels at VRT execution, approval, migration fix loop, and renderer diff analysis.
+`vlmkit` excels at VRT execution, approval, migration fix loop, and renderer diff analysis.
 
 Combining these two allows VRT to operate not as a one-off comparison tool but as a test suite with retry, quarantine, and trend analysis capabilities in CI.
 
 Target repositories:
 
 - `flaker`: [/Users/mz/ghq/github.com/mizchi/metric-ci](/Users/mz/ghq/github.com/mizchi/metric-ci)
-- `vrt`: [/Users/mz/ghq/github.com/mizchi/vrt](/Users/mz/ghq/github.com/mizchi/vrt)
+- `vlmkit`: [/Users/mz/ghq/github.com/mizchi/vrt](/Users/mz/ghq/github.com/mizchi/vrt)
 
 ## Goal
 
@@ -25,7 +25,7 @@ Target repositories:
 - Merging `approval.json` into `flaker.quarantine.json`
 - Adding a built-in runner to `flaker` itself from the start
 
-Initial implementation places the custom runner on the `vrt` side, called from `flaker` as an external command.
+Initial implementation places the custom runner on the `vlmkit` side, called from `flaker` as an external command.
 As of 2026-04-02, in addition to this custom runner, built-in `vrt-migration` / `vrt-bench` adapters on the `metric-ci` side and artifact collection workflows are implemented.
 
 ## Responsibility Boundary
@@ -40,7 +40,7 @@ As of 2026-04-02, in addition to this custom runner, built-in `vrt-migration` / 
 
 References: [docs/why-flaker.ja.md](/Users/mz/ghq/github.com/mizchi/metric-ci/docs/why-flaker.ja.md), [types.ts](/Users/mz/ghq/github.com/mizchi/metric-ci/packages/vlmkit-core/src/types.ts), [quarantine-manifest.ts](/Users/mz/ghq/github.com/mizchi/metric-ci/src/cli/quarantine-manifest.ts)
 
-### vrt's responsibilities
+### vlmkit's responsibilities
 
 - HTML/URL rendering comparison
 - pixel diff / paint tree diff / computed style diff
@@ -58,7 +58,7 @@ Therefore, the integration centers on the runner protocol, not an import adapter
 ```text
 flaker sample/run/quarantine
   -> custom runner
-    -> vrt migration-compare
+    -> vlmkit migration-compare
       -> report.json + test results
         -> flaker DuckDB
 ```
@@ -71,14 +71,14 @@ Top priority. `migration-compare` already outputs machine-readable reports, enab
 
 ### Phase 2: Playwright VRT import
 
-Analyze existing `playwright test`-based `vrt` via `flaker import --adapter playwright` or `collect`.
+Analyze existing `playwright test`-based `vlmkit` via `flaker import --adapter playwright` or `collect`.
 
 ### Phase 3: report import
 
 Add adapters to directly feed `migration-report.json` and `bench-report.json` into `flaker`.
 
-As of 2026-04-02, built-in `vrt-migration` and `vrt-bench` adapters exist on the `metric-ci` side, handling `migration-report.json` and `bench-report.json` directly via `import / collect / report summarize`. The `vrt`-side `src/experiments/flaker/flaker-vrt-report-adapter.ts` remains for custom adapter paths and legacy report supplementation.
-The `vrt` side has `.github/workflows/migration-report.yml`, running 1 scenario via `workflow_dispatch` and producing artifact name `migration-report`. To avoid conflicts with `metric-ci collect` defaults, initial operation fixes 1 run = 1 scenario.
+As of 2026-04-02, built-in `vrt-migration` and `vrt-bench` adapters exist on the `metric-ci` side, handling `migration-report.json` and `bench-report.json` directly via `import / collect / report summarize`. The `vlmkit`-side `src/experiments/flaker/flaker-vrt-report-adapter.ts` remains for custom adapter paths and legacy report supplementation.
+The `vlmkit` side has `.github/workflows/migration-report.yml`, running 1 scenario via `workflow_dispatch` and producing artifact name `migration-report`. To avoid conflicts with `metric-ci collect` defaults, initial operation fixes 1 run = 1 scenario.
 Similarly, `.github/workflows/bench-report.yml` runs 1 fixture of `css-challenge-bench` with Chromium backend, producing artifact name `bench-report`. Since the `vrt-bench` adapter expects a single `bench-report.json` in the artifact, this also fixes 1 run = 1 fixture.
 
 ## Why Start with Migration VRT
@@ -205,7 +205,7 @@ Reasons for not making `approved` a separate status:
 - `approved` is run metadata, not identity
 - Including `approved` in identity would fragment history
 
-`approved` details are preserved in `vrt`-side report artifacts.
+`approved` details are preserved in `vlmkit`-side report artifacts.
 
 ## Approval and Quarantine Separation
 
@@ -253,7 +253,7 @@ test-results/flaker-vrt/
     migration-reset-css-report.json
 ```
 
-`stdout` outputs the report path. Deep-dive by examining `vrt`'s artifacts.
+`stdout` outputs the report path. Deep-dive by examining `vlmkit`'s artifacts.
 
 ## flaker.toml example
 
@@ -284,7 +284,7 @@ flaky_rate_threshold = 30.0
 min_runs = 5
 ```
 
-When operating in the `vrt` standalone repository, the runner lives in this repo, and artifact collection uses `metric-ci`'s built-in `vrt-migration` adapter.
+When operating in the `vlmkit` standalone repository, the runner lives in this repo, and artifact collection uses `metric-ci`'s built-in `vrt-migration` adapter.
 
 ## Implementation Phases
 
@@ -327,7 +327,7 @@ As of 2026-04-02, all 3 items above are complete. What remains is not built-in r
 
 ### 1. Runner placement
 
-Initial implementation on the `vrt` side is fine. Reasons:
+Initial implementation on the `vlmkit` side is fine. Reasons:
 
 - Direct access to internal APIs like `runMigrationCompare()`
 - `metric-ci` side is currently rename/development in progress with a dirty worktree

--- a/docs/introduce.ja.md
+++ b/docs/introduce.ja.md
@@ -1,248 +1,610 @@
-# vrt — Visual Regression Testing ツールキット
+# vlmkit とは
 
-## vrt とは
+このプロジェクトを初めて見る人向けの紹介です。前提知識は仮定しません
+（CSS ツールにも AI エージェントにも詳しくなくて構いません）。
 
-vrt は、Web ページの見た目の変化を検出・分析するためのコマンドラインツールです。
+英語版は [`introduce.md`](./introduce.md) で、同じ内容を維持しています。
 
-ピクセル単位の画像比較だけでなく、computed style の差分、アクセシビリティツリーの差分、AI による CSS 自動修正まで一貫して扱えます。Playwright ベースで動作し、ローカルの HTML ファイルとライブ URL の両方に対応しています。
+## 何を解決するのか
 
-## 主なユースケース
+Web ページが本当に**正しい**と、どうやって分かるのでしょうか。
 
-- **CSS リファクタリング前後の検証** — Tailwind → vanilla CSS、Reset CSS 切り替えなど
-- **UI ライブラリのバージョンアップ** — shadcn/ui → 自作コンポーネントなど
-- **クロスレンダラ比較** — Chromium vs Crater (独自レンダリングエンジン)
-- **CI での自動回帰検出** — PR ごとに差分を計測し false positive 率を管理
+多くのチームでの正直な答えは「誰かが見た」です。人がスクリーンショットを
+眺めて、スクロールして、「大丈夫そう」と言う。これは次の理由でうまく機能
+しません。
 
-## インストール
+- 768px だけで壊れているが、誰も 768px を見ていなかった。
+- 絶対配置のラベル 2 つが 50px 重なっているが、数字が長くなったときだけ。
+- ボタンはマウスでは動くが実体は `<div>` + click ハンドラで、キーボードと
+  スクリーンリーダーでは操作できない。
+- 仕様のコピーは「無料トライアルを開始」なのにページは「トライアルを開始」。
+  ピクセルを眺めても気づかない。
+- CSS リファクタで何も壊れていない — ただ 1 箇所、1 つの viewport だけ。
+  顧客が見つけるまで誰も気づかない。
+
+この問題は最近さらに鋭くなりました。**AI コーディングエージェントが大量の
+HTML/CSS を書く**ようになり、「完了しました」というエージェントの主張は
+人間の目視よりさらに当てになりません。検証せずに「検証済み」と報告する
+だけでなく、検査可能なゴールを与えると**ゴールを騙しにくる**ものもいます。
+必須コピーを不可視テキストに隠す、アサーションが通る 50ms だけ ARIA 属性を
+反転させる — どちらもこのプロジェクトの評価実行で実際に起きました（どちらも
+現在は検出されます。後述）。
+
+## 考え方: 見るのではなく測る
+
+vlmkit は実ブラウザ（Playwright 経由の headless Chromium）でページを描画し、
+「正しく見えるか？」を**毎回同じ結果になる合否判定**に変換します。DOM
+ジオメトリ、ピクセル演算、computed style、アクセシビリティ探査。眺めるべき
+スクリーンショットも、ループ内の AI 判断もありません。末尾に明記した 3 つの
+オプション機能を除き、**API キーは不要**です。
+
+（名前は VLM = vision-language model ですが、このプロジェクトは「VLM に
+ページを判定させ、正解データと突き合わせて測る」ところから始まり、
+**VLM 判定こそが不安定な部分だった**と分かりました。測定が製品になり、
+VLM 機能はキー必須のオプションに降格しました。名前は化石です。）
+
+チェックが失敗したとき、単に「失敗」とは言いません。このプロジェクトで
+*kickback* と呼ぶもの — 欠陥、位置（CSS セレクタ）、測定値、多くの場合
+修正の方向 — を出力します。
+
+```
+x [page-overflow-x] @768: The page scrolls horizontally by 156px at 768px
+  viewport width — sticking out: main > p:nth-of-type(1) (right edge 924px).
+x [text-collision] @1280: "Total: €1,240" overlaps "Refunds: €80" by 52x17px —
+  same-layer text blocks must not overlap; check negative margins…
+```
+
+この形式は意図的です。人間が読めて、AI エージェントの次のプロンプトに
+そのまま貼れます。名指しされたものを直し、再実行し、緑になるまで繰り返す。
+**このループが製品です。**
+
+vlmkit はこれらのチェックを **gate（ゲート）** と呼びます。通るか止めるかの
+どちらかで、固定したゲートの集合が「その作業の完了」の定義になります。
+インストール前に知っておくべきこと:
+
+- 単一描画のゲートは数秒。複数 viewport のゲートは幅を複数描画し
+  （`check integrity` は 3 つ）、`check breakpoints --sweep` は fuzz の
+  全ステップを描画するので、ブレイクポイントの多いページでは数十秒側に
+  なります — 修正ループで 10 回再実行しても十分安い範囲です。
+  findings の severity は 2 段階で、**終了コードの契約は全ゲート共通**です。
+  - **suspect はコマンドを失敗させます。** DEFECTS / VIOLATED / FAILED /
+    NOT DONE の verdict、欠落コピー行、ポインタ専用コントロール —
+    どの欠陥レベルの finding も、フラグ無しで非ゼロ終了します。
+    「欠陥を見つけたが exit 0」が既定の検証ツールは足を撃つ道具なので、
+    無視したい側に立証責任を置いています。
+  - **warn は、どのフラグでも終了コードに影響しません。**
+  - **`--advisory` は print-and-succeed に戻します。** CI をゲートする前に
+    パイロット運用するためです（導入順は後述）。
+  - **エラーは必ず失敗します。** 到達不能な URL、存在しないファイル、
+    30 秒のアイドルタイムアウトは非ゼロ終了 — 静かな pass にはなりません。
+
+  （`--fail-on-suspect` は以前必要だった場所すべてで今も受理されますが、
+  その挙動が既定になったため no-op です。）
+- セットアップは 2 コマンド — `npm install -D @mizchi/vlmkit` と
+  `npx playwright install chromium`（ブラウザのダウンロード。150MB 程度、
+  数分、一度だけ。CI コンテナではシステムライブラリのため `--with-deps` を
+  付けます）。この文書の内容に他のツールは不要です — ただしユーザー定義の
+  ゲート（copy manifest / layout contract / flow script）はそのファイルを
+  自分で書く必要があります。
+- ファイルか dev サーバに向けるだけです。ナビゲートしてネットワークが
+  アイドルになるまで待つ（30 秒上限）ので、React/Vue/クライアント描画は
+  問題ありません。CSS-in-JS も含め、スタイルが存在してから測ります。
+  `load` の 1 tick 後に描画するクライアントアプリも、全ゲートが待ちます。
+  ファイルを渡した場合は **file: URL へナビゲートする**ので、隣にある
+  `style.css` や画像などの相対アセットが解決されます（2026-08-02 まで
+  一部のゲートは HTML 文字列を `setContent` していて、**スタイル未適用の
+  DOM を測って合格を出していました** — 後述の Honest limits と
+  [レポート](./reports/2026-08-02-external-asset-load-defect.md)）。
+  正直な裏面: **決してアイドルにならない**ページ（常時ポーリング、
+  WebSocket）は 30 秒上限に当たり、半端に落ち着いたページを測るのではなく
+  ゲートがエラーになります — ローカルに描画したファイルか、ソケットの無い
+  ルートに向けてください。
+  ログインの内側のページには、セッションを渡します:
+  `--storage-state auth.json`（全ゲートまとめてなら
+  `VLMKIT_STORAGE_STATE=auth.json`）。e2e スイートが既に作っている
+  Playwright の storage-state ファイルをそのまま使えます。
+
+### 主要なチェックが実際に何を測っているか
+
+「決定論的」は形容詞にすぎないので、機構を書きます。どこが強くてどこで
+外すかを予測できるように。
+
+| チェック | 機構 | 限界 |
+|---|---|---|
+| テキストの上塗り（occlusion） | 各テキスト範囲のグリフ帯を `elementFromPoint` でサンプリング。ヒットした要素が無関係で**かつ**不透明に塗る場合（背景 alpha ≥ 0.5 / 背景画像 / 置換要素）のみカウント。サンプリング中はページ全体でヒットテストを強制するので、`pointer-events: none` の装飾も捕まえる | canvas/video/クロスオリジン iframe の中身、覆わずに可読性を壊す blend mode |
+| 横オーバーフロー | 原因を**順位付けではなく測定**する。候補ごとに自身の `width`/`min-width` を無効化して `scrollWidth` を再読み取りするので、kickback は引き伸ばされた祖先ではなく硬い要素を名指しする | |
+| コピーの可視性 | 文書全体**と全ての open shadow root**（コンポーネントライブラリのコピーも対象）のテキストノードを幾何的に検査 | closed shadow root、`<canvas>` に描かれた文字 |
+| 不可視 / 低コントラスト | computed な文字色と解決された単色背景の WCAG コントラスト。**合成背景（グラデーション、画像）はスキップし、スキップしたことを報告**する — 推測しない | `background-clip: text` のグラデーション文字は判定せずスキップ |
+| テキスト衝突 | テキストブロック矩形の対ごとの重なり。**両軸**で 6px 以上**かつ**小さい側の面積の 25% 以上。positioned レイヤと `aria-hidden` 側は免除 | 細片の重なり（Honest limits 参照） |
+| スクリーンリーダー専用の免除 | 幾何的判定: 完全にクリップ（面積ゼロ / `clip` / `clip-path` inset）なら意図的、部分的に切れているなら欠陥 | |
+| デザイン一致 | 単色塗りの連結成分分割 → 位置/サイズ/色でペアリング → 画像間のピクセル確認 | 写真・グラデーション主体のターゲット |
+| デザインの自己一貫性 | 推論したロールごとに描画スタイル署名を集め、署名の再利用率を見る（[実測に基づくしきい値](./design/design-policy-metrics.md)） | ロールを決定論的に推論できない要素（「カード」「パネル」等）は対象外 |
+
+## 何ができるのか
+
+以下はすべて、ローカル HTML ファイルか URL に対する 1 コマンドです。
+
+**「ページを壊した？」** — `check integrity` は 3 つの viewport を一度に
+走査し、目視では気づかない欠陥を探します: 横オーバーフロー、重なり/切れ/
+はみ出したテキスト、他要素に塗り潰されたテキスト、不可視テキスト、
+潰れたコンテナ、JS エラー、読み込み失敗したリソース、スタイル未適用の
+描画。参照デザインは不要です。意図的なパターン（スクリーンリーダー専用
+テキスト、ヒーローのオーバーレイ、省略記号による切り詰め）は認識され、
+失敗ではなく exempt として報告されます。このゲートには実ページでの
+偽陽性監査があります:
+[ミラーした外部 5 サイト](./reports/2026-07-30-integrity-external-dogfood.md)
+（example.com、danluu.com、CSS Zen Garden、Hacker News、W3C APG）で
+偽陽性 4 クラスを発見（すべて回帰テスト付きで修正）、真の陽性 1 件
+（Hacker News は実際に 768px で横スクロールする）。
+finding が複数の幅で出た場合は、観測したすべての幅が出ます
+（`@1280,768,375` と `@1280,768` は直し方が違うので）。
+
+**「文言は正確？」** — `check copy` は必須コピーのプレーンテキスト一覧を
+受け取り、各行がページ上に**可視の状態で**一字一句あることを検証します。
+折りたたまれたアコーディオンや非選択タブを（ARIA 属性から見つけて）開くので
+設計上隠れているコピーも通り、どの状態で各行が現れたかをレポートが記録
+します。トリックで隠されたコピーは別扱いです: font-size 0、透明色、
+画面外配置、背景と同色の文字 — それぞれ理由クラス付きで指摘されます。
+この**不可視検出器**（コピー照合全体ではなく、この部分）は実サイト 7 件
+（MDN、Wikipedia、W3C、web.dev、Hacker News、danluu.com、example.com）に
+対して監査済みで、その 7 サイトのサンプルでは偽陽性ゼロでした —
+[手法と全結果](./reports/2026-07-31-copy-invisible-real-site-audit.md)。
+manifest 自体は 3 行の規約です。
+
+```
+# copy.txt — 1 行 1 必須コピー。"# " 始まりはコメント
+無料トライアルを開始
+いつでもキャンセルできます
+```
+
+空白は正規化され、照合は**大文字小文字を区別**し（casing は仕様）、
+行はページ上のどこにあっても構いません。1 つだけ先に整理しておきます。
+2 つのゲートが矛盾しているように見えるケース: スクリーンリーダー専用
+テキストとして**のみ**存在する文字列（アイコンのみのボタンの
+アクセシブル名）です。integrity はこれを免除します — 完全にクリップされた
+矩形は認識済みの意図的パターンなので。同じ文字列が manifest の行でもある
+場合、copy ゲートは理由クラス `visually-hidden` で
+「存在するが不可視」と報告し、`--allow-invisible visually-hidden` で
+明示的に受理します。verdict は copy ゲートが持ち、受理はフラグ —
+静かな pass にはなりません。
+
+**「実際に振る舞う？」** — `check breakpoints --sweep` はレスポンシブ境界が
+正確であること（レイアウトが壊れる幅が無い、768px で 1px ずれない）を
+証明します。`check interactions` は各コントロールでキーを押し、ARIA 状態
+遷移をマップして、何にも繋がっていない disclosure を捕まえます。兄弟の
+`scan handlers`（または `check interactions --handlers`）が
+**クリック可能な `<div>`** を捕まえます: role もキーボード経路も無い click
+ハンドラです。両方を実行してください — 素の `check interactions` は
+`<div onclick>` のページを `status: ok` と報告します。`verify flow` は
+スクリプト化したユーザー動線を実行し、各ステップの結果をライブ DOM 上で
+検証します。ある評価では、カードゲーム画面が「カードを出す → 敵 HP が
+ちょうど 6 減る → エネルギーを消費 → ターン終了 → block 5 に 8 ダメージ」を
+生き延びる必要があり、すべての数値をクリックして確認しました。
+
+**「デザインと一致している？」** — `verify markup` はビルドをターゲット
+スクリーンショットと比較し、1 つの verdict と完全な修正リストを返します:
+欠けている / 位置がずれている / サイズ違い / 順序違いのコンポーネントを
+セレクタ付きで。機構は vision model ではなく決定論的です。両画像をピクセル
+連結性で単色領域に分割し、位置/サイズ/色でターゲットと描画をペアリングし、
+ペアにならなかった領域は**ブロックを許す前に反対側の画像で必ず再確認**
+します — 「欠けている」はその bbox に同じ色が実際に描画側にあれば降格され
+（抽出器が隣に統合しただけ）、「余分」はターゲットに同じ色があれば降格され
+ます。形式上どうしても残る注意点: 描画側の領域は DOM セレクタに戻せますが、
+**欠けている**領域はターゲットにしか存在しないので、セレクタ無しで bbox と
+色で報告されます。
+この機構が境界も決めます: 単色塗りの UI comp 向けであり（retina スケーリング
+と JPEG ノイズは処理済み）、写真やグラデーション主体のアートは領域分割が
+粗くペアリングも緩くなります。`scan mock` が retina/Figma 書き出しを先に
+CSS ピクセルへ正規化して、比較を公平にします。
+
+**「今日の変更は見た目を変えた？」** — `snapshot` は初回に baseline を
+キャプチャし、以降は viewport ごとのピクセル差分（ヒートマップ付き）を
+報告します。意図した変更は承認し、それ以外を調査します。`diff-pr` が
+同じことを CI ゲートとして行います。
+
+**「この生成画像は使える？」** — `check asset` は画像（画像生成モデルの
+キャラクターアートなど）がページのスロットに入る前に検査します:
+アスペクト比、背景が本当に透明か（矩形に敷かれていないか）、ほぼ空でないか、
+置かれる背景に対してシルエットが読めるか、そしてパレット調和 —
+アセットの主要色のうちページ自身のパレット近傍にある割合。低い割合は
+fail ではなく warn です。アートディレクションは人間の判断なので。
+
+**「ページはそれ自身と一貫している？」** — `check design` はトークン
+ファイルを必要としません。推論したロールで要素をグループ化し、各インスタンスの
+描画スタイル署名を計算して、**スタイルがほとんど再利用されていない**ロールを
+報告します —「7 個のボタンが 3 種類の異なるスタイルで描画されている」。
+これはこのプロジェクトで唯一、**自分たちが出荷したエージェント成果物を
+落としていた**測定です: zero-shot フィクスチャはすべて機能ゲートを通過し
+ながら、ボタンのスタイルを 3 種類抱えていました。これは*一貫性*の主張であり、
+趣味の主張ではありません — 23px と 24px が共存していると報告し、選択は
+あなたに残します — そして findings は warn レベルなので、ドリフトした
+デザインシステムがビルドを落とすことはありません。しきい値は設計済み
+ページと生成ページを実測して決めました
+（[調査記録](./design/design-policy-metrics.md)）。特筆すべきは
+**4px グリッド適合はシグナルとして棄却**されたことです。LLM が書く CSS は
+MDN より**良い**スコアを出すからです。
+
+コピペ用のチートシート（どんなときに使うか付き。`verify flow` だけは
+ページ固有の flow スクリプトが必要なので載せていません）:
 
 ```bash
-git clone https://github.com/mizchi/vrt.git
-cd vrt
-pnpm install
+# 編集中 — レイアウト/CSS を変えた後:
+npx vlmkit check integrity page.html                         # 何か壊れた?
+# push 前 — 仕様化されたコピーを持つページ:
+npx vlmkit check copy page.html --manifest copy.txt          # 文言は正確かつ可視?
+# push 前 — レスポンシブなページ:
+npx vlmkit check breakpoints page.html --sweep               # 境界は保たれている?
+# push 前 — 操作するコントロールがあるページ:
+npx vlmkit check interactions page.html                      # キーボードで操作できる?
+# デザインに合わせて作っている最中:
+npx vlmkit verify markup attempt.html --target design.png    # デザインと一致?
+# 継続的 / CI — 回帰追跡:
+npx vlmkit snapshot http://localhost:3000/ --output .vlmkit/snapshots   # 何が変わった?
+# 生成画像をページに入れる前（シルエットとパレットの検査には背景色と
+# ページのスクリーンショットが必要）:
+npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent \
+  --against-bg "#1a1424" --page-palette page.png                        # 使える?
 ```
 
-Playwright のブラウザも必要です:
+反復は編集後に同じコマンドを再実行するだけです。ゲートが内側のループで、
+watch モードはありません（`vlmkit watch` は baseline/variant のペアを
+差分する別の古いツールで、ゲートの再実行器ではありません）。
+先に知っておくと良い挙動: コピー照合は空白正規化するが**大文字小文字を
+区別**する部分文字列照合（casing は仕様として扱う）。
+`check breakpoints` は CSS が宣言する各ブレイクポイントの 1px 下・当該値・
+1px 上を描画し、`--sweep` は間の幅を 320px〜1280px で 25px 刻みに fuzz
+します。コンソール出力は長い finding 一覧を切り詰めることがありますが、
+必ず「あと N 件」と告知し、`--json` には全件入っています。
+CI ではどのゲートも既に失敗するステップです — suspect は非ゼロ終了します:
+
+```yaml
+# .github/workflows/ui-gates.yml（関係するステップ）
+- run: npm ci && npx playwright install chromium --with-deps
+- run: npx vlmkit check integrity dist/index.html
+```
+
+まだあります: デザイントークン適合（トークンにすべきハードコード値）、
+ダークテーマのパリティ、WCAG コントラスト/タッチ/フォーカス検査、
+40% 長い翻訳テキストでのレイアウト生存、リファクタで死んだ CSS セレクタの
+置換候補、フレームワーク移行の視覚的等価性。全体像は `vlmkit --help` に、
+まさにこの「〜したい」の形で整理されています。
+
+## サイト全体をまとめて回す
+
+上のレシピはどれも 1 ページ単位です。ルートツリー全体には:
 
 ```bash
-npx playwright install chromium
+vlmkit batch --gate "check integrity" "routes/**/*.html"        # 並列、1 つでも落ちれば exit 1
+vlmkit batch --gate "check integrity" --gate "check design" "dist/**/*.html" --output ci-logs/
+vlmkit batch --gate "check integrity" "routes/**/*.html" --shard 2/3   # CI ランナー 3 台の 1 つ
 ```
 
-## 基本的な使い方
+ページごとの判定はそのゲート実行の**終了コード**なので、標準の終了コード
+契約に従うものはすべて batch 可能です。実測した並列度 / シャーディングの
+コストは
+[`reports/2026-08-02-batch-runner-ci-budget.md`](./reports/2026-08-02-batch-runner-ci-budget.md)
+にあります（4 コア / 9 ページ / `check integrity` で、並列
+1→34.9s、2→20.0s、4→13.1s、8→11.0s。ジョブ単体の時間は並列度で膨らむため、
+出力は速度向上ではなく「平均同時実行数」を表示します）。
 
-### 1. ファイル比較 (`vrt compare`)
+ページ数が増えたら、シェル履歴ではなくファイルに計画を置きます。次節の
+`vlmkit.gates.json` がその置き場所です。
 
-2つの HTML ファイルを複数の viewport で比較します。
+## チームで導入する
+
+リードが訊く運用上の質問に、率直に答えます。
+
+- **copy manifest は誰が保守する？** リポジトリ内のプレーンテキスト
+  ファイルで、対象ページの隣に置きます。仕様として扱ってください:
+  コピー変更と manifest 変更は同じ PR で移動し、manifest 更新の忘れは
+  静かにドリフトするのではなく CI の copy ゲートで**名指しされた失敗行**
+  として現れます。
+- **baseline はいつ再承認する？** `snapshot` は誰かが `snapshot approve`
+  を実行するまで保存済み baseline と比較し続けます — それが意図的で
+  レビュー可能な再 baseline の手順です。baseline は選んだ出力ディレクトリ内の
+  ファイル（PNG + JSON レポート）で、サービスもロックインもありません。
+  使い捨て CI ランナーでは: baseline ディレクトリをコミットする（または
+  CI キャッシュから復元する）、そして変更を意図した PR の中で、比較を
+  実行するのと同じ環境で `snapshot approve` を実行して再 baseline します。
+- **偽陽性のトリアージ経路は？** finding を読んでください。ゲート自身が
+  意図を認識したなら既に `exempted` の下にあります（失敗ではありません）。
+  意図的に隠したコピーなら `--allow-invisible <class>` でそのクラスを受理。
+  integrity が意図的パターンを誤検知するなら `--allow` に理由を書いて
+  受理します（下の Honest limits に構文）。それでもツール側の問題だと
+  思うなら報告してください — 免除セットは実際にそうやって育ちました。
+- **ゲート設定はどこに置く？** contract、flow、copy manifest、snapshot 設定
+  （`vrt.config.json` — これも visual-regression-testing 由来の命名化石）は
+  リポジトリ内のファイルです。**どのページにどのゲートを走らせるか**と
+  **すべての suppression** は `vlmkit.gates.json` に置きます:
+
+  ```json
+  { "defaults": { "gates": ["check integrity", "check design"] },
+    "pages": [
+      { "id": "home", "source": "routes/index.html",
+        "extraGates": ["check copy --manifest copy/home.txt"] },
+      { "id": "docs", "source": "routes/docs/**/*.html" },
+      { "id": "checkout", "source": "https://staging.example.com/checkout",
+        "suppressions": [ {
+          "gate": "check copy",
+          "flag": "--allow-invisible visually-hidden",
+          "reason": "sr-only のスキップリンク。文言は法務がレビューする",
+          "owner": "web-platform",
+          "expires": "2027-01-31" } ] } ] }
+  ```
+
+  `vlmkit gates list` は各ページが実行する正確なコマンドを表示し、
+  `gates run` は並列実行（CI ランナー向けに `--shard i/n`）、
+  `gates suppressions` が棚卸しです — 黙らせたチェックすべてを
+  理由 / owner / 残日数付きで、期限切れを先頭に表示します。
+  このファイルをレビューに値するものにしている規則が 2 つあります:
+  **suppression には `reason` が必須**であること、そして
+  **`expires` を過ぎたら適用されなくなる**こと — ゲートが素で走って
+  run が失敗するので、古い免除は蓄積せずに気づかれます。
+  設定ファイル無しで一回だけ掃きたいときは、上の
+  `vlmkit batch` が glob を直接受け取ります。
+
+  古い規約（1 ページ 1 npm script）も今も動き、数ページなら十分です。
+  その帰結が設定ファイルが存在する理由です: 有効な suppression を
+  すべて見るにはスクリプトを grep することになり、20 ページを超えると
+  重くなります。
+  なお、実行ごとに `.vlmkit/run-ledger.jsonl` へ JSON 1 行が追記されます
+  — timestamp、tool、source、ツールごとの `headline` オブジェクト
+  （integrity と snapshot は `verdict` を、他はそれぞれの数値、例えば
+  copy は `{"missing":0}`）。これは設定ではなくローカルの監査証跡です:
+  gitignore してください。エージェントの節で最も意味を持ちます。
+- **自分たちのルールを書ける？** はい — 2 つのゲートは設計上ユーザー定義
+  です。`check layout --contract layout.json` は構造ルールを機械検査可能な
+  contract にします。これがフォーマット全体です — viewport 幅ごとに
+  検査されるルールの一覧:
+
+  ```json
+  { "rules": [
+    { "selector": ".sidebar",   "at": 1280, "width": 260 },
+    { "selector": ".stat-card", "at": 768,  "perRow": 2, "count": 4 },
+    { "selector": "button",     "at": 375,  "minHeight": 48 },
+    { "selector": "header",     "at": 375,  "above": "main", "fullWidth": true }
+  ] }
+  ```
+
+  （`minHeight` は全マッチを検査します — タッチターゲット規則向け。
+  `width` / `perRow` / `above` / `count` / `visible` が残りを覆います。）
+  `verify flow --flow flow.json` が振る舞いに対して同じことをします —
+  各ステップがアクションを実行し、結果の DOM 状態を検証します:
+
+  ```json
+  { "steps": [
+    { "label": "カードを出す",
+      "do": { "action": "click", "selector": "[data-testid=card-strike]" },
+      "expect": [
+        { "assert": "text", "selector": "[data-testid=enemy-hp]", "contains": "38/44" },
+        { "assert": "attr", "selector": "[data-testid=end-turn]", "name": "aria-disabled", "equals": "false" }
+      ] }
+  ] }
+  ```
+
+  ツールのコードを書かずに、デザインシステムと振る舞いの規則がゲートに
+  なります。
+- **エージェントと新人で何が違う？** 同じ kickback です。新人は名指しで
+  測定された CSS の学びを得て、エージェントは審判を得ます。MCP サーバは
+  9 つのエージェント呼び出し可能なツール — この文書の主要ゲート
+  （check_integrity、check_copy、verify_flow、…）+ ページビルダ — を
+  公開します。
+- **manifest は複数ページにどうスケールする？** 共有コピーは共有更新を
+  意味します: あるコンポーネントの CTA テキストが変わって 5 ページに
+  現れるなら、同じ PR で 5 つの manifest が変わります — manifest を忘れた
+  ページは copy ゲートで失敗します。ただし**そのページのゲートが実際に
+  CI に配線されている場合に限ります**（その配線はあなたの保守範囲です）。
+  manifest 更新は他のコピー変更と同じレビューを通ります。
+- **CI で flaky になる？** ジオメトリ系のゲートは毎回同じピン留めした
+  Chromium で DOM レイアウトを測るので、**フォントが一致していれば**
+  マシン間で安定します。同一フォントでのメトリクスの揺れは約 1px。
+  suspect の床は実測値です — ページオーバーフローは 2px から、テキスト
+  衝突は両軸 6px 必要、そして実際の欠陥は床を数十 px 超えるので、
+  フォントが一致していれば verdict が反転することは稀です。
+  **フォントの欠落は別物**です: フォールバックが reflow を起こし、
+  どの床も越え得ます。フォントはページと一緒に配る（webfont）か CI
+  イメージに入れてください（Honest limits 参照）。
+  ピクセル厳密な `snapshot` の baseline は別の獣です: 比較するのと同じ
+  環境で生成してください（CI の中、または共有コンテナ 1 つ）。macOS で
+  作った baseline を Linux で差分すると、フォントのアンチエイリアスで
+  食い違います — これは「誰もが無視するゲート」への典型的な道です。
+- **導入はどう進める？** 1 ページでパイロット（`check integrity` を実行し、
+  既存の負債が出てくることを期待する）→ 重要ページのゲートを CI に追加
+  （既定で fail closed。パイロット中は `--advisory`）→ 仕様が安定している
+  ところで contract と manifest を育てる。エージェント連携は任意で、
+  最後で構いません。
+
+## AI コーディングエージェント向け: 監査証跡を持つ審判
+
+（コーディングエージェントを使っていないなら、この節は飛ばしてください。
+上のすべては単体で機能します。）
+
+使っているなら、vlmkit の役割は審判です。19 のシナリオ評価
+（ページは [`fixtures/auto-markup-proof/`](../fixtures/auto-markup-proof/)、
+記録は [`docs/reports/`](./reports/)）で機能したループはこれです。
+
+1. エージェントにタスクと固定した**完了条件** — すべて通る必要がある
+   ゲートの集合（例: `check integrity` CLEAN + `check copy --manifest`
+   欠落 0 + `scan handlers` / `check interactions` に suspect 無し）— を
+   与える。
+2. エージェントが作り、自分でゲートを実行し、失敗レポートを読み、直し、
+   繰り返す。安価なモデルでも問題なくこなします — 上でリンクした
+   zero-shot シナリオの試行は Claude Haiku 4.5 が駆動し、ゲートの完了
+   条件に到達しました（一部は監査由来の kickback ラウンドを経てから。
+   どれがそうかはレポートに書いてあります）。小さいモデルに欠けていた
+   精度をゲートが供給しました。
+3. すべてのゲート実行は自動的に `.vlmkit/run-ledger.jsonl` に追記されます
+   （1 実行 1 JSON 行: timestamp、tool、source、そのツールの headline
+   数値）。単一の verdict フィールドではなく `tool` で grep してください —
+   headline の形はツールごとです。エージェントが「検証しました」と言った
+   ときは ledger を確認します。「検証済み」の主張の下で ledger が空なら、
+   それ自体が finding です — その捕獲は
+   [ブラックボックス導入実行](./reports/2026-07-31-blackbox-onboarding-validation.md)
+   で実際に起きました。
+
+連携方法は CLI そのもの、MCP サーバ
+（`.mcp.json` に
+`{ "mcpServers": { "vlmkit": { "command": "npx", "args": ["-y", "@mizchi/vlmkit", "mcp"] } } }`
+— ゲートがエージェントがネイティブに呼ぶツールになります）、または
+`markup-assist` スキル（ルーティング表、ループ規律、そして
+*「check copy を通すためにコピーを隠すな」*
+*「ツール自体が実行に失敗したら STOP して報告せよ。自作チェックで代用して
+検証済みと主張するな」* といった規則を含む SKILL.md 1 枚を、このリポジトリの
+`.claude/skills/markup-assist/` からコピーする）です。
+
+エージェントはこれらのゲートを騙そうとしたか？ しました。事例は記録して
+あります: `font-size: 0` の span に隠されたコピー
+（[S18](./reports/2026-07-31-s18-zero-shot-chat-tool-gate-gaming.md)）、
+アサーションを通すために 50ms だけ反転させられた `aria-disabled`
+（支援技術には嘘をついたまま。
+[S19](./reports/2026-07-31-s19-game-ui-occlusion-probe.md)）、
+自作チェックへの静かなフォールバックを「検証済み」と報告
+（[ブラックボックス実行](./reports/2026-07-31-blackbox-onboarding-validation.md)）。
+それぞれが対策になりました — 可視テキスト照合
+（[12 ベクタの隠蔽バッテリー](./reports/2026-07-31-copy-gate-silencing-battery.md)
++ [7 サイト監査](./reports/2026-07-31-copy-invisible-real-site-audit.md)）、
+disabled なコントロールを貫く force-click、ledger で監査可能な主張。
+リンクしたレポートがテスト証跡です。これは将来のエージェントが新しい
+トリックを見つけるのを止めませんが、試された分は閉じてあります。
+
+## Honest limits
+
+信頼は明示された境界に宿るので、重要なものを挙げます。
+
+- **「意図的」は魔法ではなく測定で認識されます。** integrity ゲートが
+  免除するのは幾何的に検証できるパターンです — スクリーンリーダー専用
+  テキスト（完全にクリップ。部分的に切れているものは違う）、画像置換、
+  ヒーローのオーバーレイ、省略記号の切り詰め。
+  検証できないパターンには**ユーザー定義の免除**があります:
+  `--allow "<kind>[@<selector>][@<viewport>];<reason>"`（繰り返し可）。
+  理由は必須（無いルールは拒否）、未知の finding kind は静かな no-op では
+  なくエラー、受理した finding も理由付きで `exempted` に残り、
+  どれにもマッチしなかったルールは報告されます（死んだ免除が削除される
+  ように）。4 つの kind は免除できません — `js-error` /
+  `degenerate-render` / `unstyled-page` / `redirected` — デザイン判断では
+  なく「ページが壊れている / 測定不能」の報告なので。owner と期限を
+  付けたい場合は `vlmkit.gates.json` の suppression に入れてください。
+  copy ゲートには意図的に隠したコピー向けの同等物
+  `--allow-invisible <class>` があります。
+- **緑のゲート集合は正しさの証明ではありません。** ゲートは符号化した
+  欠陥クラスを捕まえます。このプロジェクトは自分の偽陰性を面倒な方法で
+  追跡しています — 評価実行ごとに、全ゲートが見逃した欠陥を独立に監査
+  します。19 シナリオを通してその監査が見つけたのはちょうど 1 件
+  （読み取り値の上を塗るアート。6 ゲートが緑）で、同日に新しい probe に
+  なりました（[S19 レポート](./reports/2026-07-31-s19-game-ui-occlusion-probe.md)）。
+  正直な主張は「完全」ではなく「敵対的に保守されている」です。
+  同じ姿勢で、2026-08-02 には**ゲート自身の欠陥**を 3 件見つけました:
+  一部のゲートが外部 CSS を読み込まずスタイル未適用の DOM を測っていた
+  （[レポート](./reports/2026-08-02-external-asset-load-defect.md)）、
+  finding の viewport 帰属が sweep の順序に依存していた、
+  そして一部のゲートがログインページを測って `status: ok` を返していた
+  （[3 軸監査](./reports/2026-08-02-differential-audit-three-axes.md)）。
+  いずれも回帰テスト付きで修正済みです。
+- **flow ゲートは歩いた経路だけを証明します。** 重要な振る舞いには
+  ステップを置いてください。
+- **認証付きページには、あなたが用意するセッションファイルが必要です。**
+  `npx playwright codegen --save-storage=auth.json <login-url>` で
+  取得（または既存の e2e スイートの `context.storageState()`）し、
+  `--storage-state auth.json` を渡します。vlmkit にログイン自動化は
+  ありません — セッションを**再生**しますが**取得**はしないので、
+  期限切れの state はあなたが再取得する問題です。失敗の仕方は少なくとも
+  読み取れます: 要求した URL からのリダイレクトは欠陥として報告され、
+  求めたページであるかのように静かに測られることはありません。
+- **フォントが決定論の境界です。** Chromium ビルドはピン留めされ、
+  ゲートは `document.fonts.ready` を待ちます（ネットワークアイドルだけでは
+  不十分 — `font-display: swap` はアイドル後にテキストを reflow させます）。
+  しかしフォント自体はマシンのものです: ブランドフォントが無い CI
+  コンテナはフォールバックして reflow し、suspect の床を大きく越え得ます。
+  フォントはページと一緒に配る（webfont）か CI イメージに入れてください。
+  前提条件を正確に言うと、移植可能とは: 同じフォント**ファイルとバージョン**、
+  同じラスタライザ設定、同じスクロールバーモード、同じロケール —
+  ロケールで書式化された数値の長さが変われば、行の折り返し位置が変わります。
+  Linux 上での実測（フォント置換・ヒンティング・dpr の 6 条件）では
+  衝突判定の床を跨いだペアは 0 件でしたが、**macOS 実機での確認は未実施**
+  です（1 コマンドで比較できる計測器は同梱してあります:
+  [レポート](./reports/2026-08-02-font-determinism-collision-floors.md)）。
+- **`verify markup` は単色塗りだけでなく、塗りのコントラストも必要です。**
+  述べた境界（平坦な comp は可、写真アートは不可）は全体ではありません:
+  分割は量子化するので、塗りがページ背景に非常に近いコンポーネントは
+  削除しても検出されずに生き延びます。ある監査実行では `#ffffff` の
+  ページから `#f4f4f4` のカード 2 枚を削除し、実際には 2.12% の
+  ピクセルが違っていたのに、ゲートは `pixel diff 0.01%` と `DONE` を
+  報告しました。同じカードを明確な青に変えれば正しく `missing 2` を
+  報告します。背景に低コントラストな領域はこのゲートの射程外として扱い、
+  layout contract で覆ってください。
+- **細片の衝突は既知の盲点です。** 衝突の床は**両軸** 6px + 小さい側の
+  面積 25% で、これがタイトな `line-height` や負マージンの行ボックスが
+  狼少年になるのを防いでいます。代償: 隣を横 3px かすめながら縦 18px
+  重なっているラベルは床の下で無報告になります。矩形はインクでもあり
+  ません — グリフインク範囲への移行は、それ自身の偽陽性監査の後ろに
+  積まれています。この床を緩めるのは、まさにゲートが無視され始める
+  経路なので。
+- **サードパーティ CSS は描画されたままで検査されます。** UI ライブラリが
+  375px でオーバーフローするなら、他の欠陥と同じように報告されます —
+  オリジンごとのスコープ指定はありません。
+- **よくある意図的パターン、具体的に**: ピン留め中にコンテンツを覆う
+  sticky/fixed バーはスクロールで逃げられると測定され免除されます。
+  画像上テキストのオーバーレイは、2 つのブロックのうち一方が positioned
+  （absolute/fixed）レイヤにあるとき免除されます — 意図的な重ね順であり
+  フローの衝突ではないので。動的コンテンツ（ティッカー、タイムスタンプ）は
+  integrity ではなく `snapshot --mask ".selector"` で扱います。
+  一時的な状態（開いたモーダル、hover 中のツールチップ）は、flow の
+  ステップが開いた場合のみ検査されます。
+
+## vlmkit ではないもの
+
+- **美的判断器ではありません** — 「正しいか、読めるか、操作できるか、
+  仕様に忠実か」が範囲です。趣味は人間に残ります。`check design` が
+  唯一これに近づきますが、測るのは趣味ではなく**自己一貫性**
+  （同じロールでスタイルが再利用されているか）で、どの値が正しいかは
+  判断しません。
+- **テストフレームワークではありません** — 中核ゲートにテストファイルは
+  ありません。あなたの Playwright スイートと並走します（スクリーンショット
+  アサーションはそのまま残してください — ゲートは別の問いに答えます）。
+  CI は終了コードと `diff-pr` で覆えます。
+- **AI サービスではありません** — すべてローカルで決定論的に動きます。
+  API キーを取るオプション機能はちょうど 3 つ: `heal markup`、
+  `check copy --vlm`、CSS fix-loop の実験群。
+
+vlmkit は MIT ライセンスです。そして若いプロジェクトです —
+`@mizchi/vlmkit` 0.8.x、メンテナ 1 人、ここで引用した評価レポートは
+互いに数週間以内の日付です。ゲートには上記の証跡がありますが、自分の
+ページで実行することの代わりにはなりません。導入の助言（advisory で
+パイロット、CI ゲートは後）はこの成熟度に合わせたものです。
+
+## 試す
 
 ```bash
-# 2ファイルを比較
-vrt compare before.html after.html
-
-# ディレクトリ指定 + 複数バリアント
-vrt compare --dir fixtures/migration/reset-css \
-  --baseline normalize.html \
-  --variants modern-normalize.html destyle.html
+npm install -D @mizchi/vlmkit
+npx playwright install chromium   # 一度だけ
+npx vlmkit check integrity http://localhost:3000/
 ```
 
-自動でレスポンシブブレイクポイントを検出し、境界値 ±1px を含む viewport セットを生成します。
-
-### 2. URL 比較 (`vrt compare --url`)
-
-ライブサーバーの URL を直接比較できます。
-
-```bash
-# 2つの URL を比較
-vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/
-
-# 動的コンテンツをマスク
-vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/ \
-  --mask ".marquee-container,.hero-badge"
-```
-
-### 3. スナップショット (`vrt snapshot`)
-
-URL を定期的にキャプチャし、前回の baseline と比較します。
-
-```bash
-# 初回: baseline を作成。2回目以降: baseline との差分を計測
-vrt snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
-
-# マスク指定
-vrt snapshot http://localhost:3000/ --mask ".animated-banner"
-```
-
-出力ディレクトリに PNG (desktop / mobile) と JSON レポートが保存されます。
-
-### 4. 要素単位比較 (`vrt elements`)
-
-フルページの比較ではヘッダの高さが変わるだけで全体がシフトし、大きな差分として検出されてしまいます。要素単位比較はこの問題を解決します。
-
-```bash
-# 要素ごとに個別比較（カスケードシフトの影響を排除）
-vrt elements --url http://localhost:3000/ --current-url http://localhost:8080/ \
-  --selectors "header,main,footer,.sidebar"
-
-# ファイルモード
-vrt elements before.html after.html --selectors "header,main,.content"
-
-# viewport 指定
-vrt elements --url http://localhost:3000/ --current-url http://localhost:8080/ \
-  --selectors "header,main" --viewport 375x812
-```
-
-**仕組み**: Playwright の `locator.screenshot()` で各要素を個別にキャプチャし、要素単位で pixelmatch を実行します。フルページ diff との比較により、カスケードシフトによるノイズをどれだけ除去できたかを表示します。
-
-### 5. スモークテスト (`vrt smoke`)
-
-アクセシビリティツリーを使って、ページ上のインタラクティブ要素をランダムに操作します。
-
-```bash
-# HTML ファイル
-vrt smoke page.html --max-actions 20 --seed 42
-
-# URL
-vrt smoke --url https://example.com --mode reasoning
-```
-
-コンソールエラー、未キャッチ例外、クラッシュを監視します。seed 指定で再現可能です。
-
-## マスク機能
-
-アニメーション、カウンタ、広告など動的コンテンツによる false positive を防ぐため、特定のセレクタを非表示にできます。
-
-```bash
-vrt snapshot http://localhost:3000/ --mask ".carousel,.ad-banner,.live-counter"
-```
-
-`visibility: hidden !important` を注入するため、レイアウトへの影響はありません。要素は非表示になりますが、占有するスペースは維持されます。
-
-## CSS チャレンジベンチマーク
-
-CSS プロパティやセレクタブロックを1つ削除し、各検出手法がその変更を検出できるかを計測します。
-
-```bash
-# プロパティ削除モード
-pkf run css-bench -- --fixture page --trials 30
-
-# セレクタブロック削除モード
-pkf run css-bench -- --fixture page --mode selector --trials 30
-
-# 全フィクスチャ横断
-pkf run css-bench -- --fixture all --trials 10
-
-# 検出率レポート
-pkf run css-report
-```
-
-現在の検出率: Chromium 96.7% (scoped)
-
-## AI Fix パイプライン
-
-CSS の破壊を検出し、AI が修正を生成して検証するループです。
-
-```bash
-# Fix ループ（CSS 破壊 → VLM 分析 → LLM 修正 → 検証）
-pkf run fix-loop -- --fixture page --seed 42
-
-# セレクタモード + VLM 指定
-VRT_VLM_MODEL="meta-llama/llama-4-scout" pkf run fix-loop -- --fixture page --seed 11 --mode selector
-```
-
-2段階パイプライン:
-1. **VLM** (安価): スクリーンショットから構造化された CHANGE レポートを生成
-2. **LLM** (高精度): CHANGE レポートから CSS 修正コードを生成
-
-修正は dry-run で検証し、改善しない場合はロールバックします。
-
-## API サーバー
-
-プログラムから vrt を利用するための HTTP API です。
-
-```bash
-# サーバー起動
-vrt serve --port 3456
-
-# ヘルスチェック
-vrt status --url http://localhost:3456
-```
-
-エンドポイント:
-- `POST /api/compare` — HTML/URL 比較
-- `POST /api/compare-renderers` — クロスレンダラ比較
-- `POST /api/smoke-test` — スモークテスト
-- `GET /api/status` — サーバーステータス
-
-TypeScript クライアント SDK (`src/api/client.ts`) も用意しています。
-
-## Crater 連携
-
-[Crater](https://github.com/mizchi/crater) は MoonBit で実装された CSS レイアウトエンジンです。vrt は WebSocket (BiDi プロトコル) 経由で Crater と連携し、以下の機能を提供します:
-
-- **Paint tree diff**: ピクセルではなくレイアウトツリーレベルで比較
-- **プリスキャナ**: Crater で事前スクリーニングし、差分がある場合のみ Chromium で詳細比較 (1.66x 高速化)
-- **ブレイクポイント検出**: CSS ルールの viewport マッピングによる正確なブレイクポイント発見
-
-```bash
-# Crater 起動（別ターミナル）
-cd ~/ghq/github.com/mizchi/crater && just build-bidi && just start-bidi-with-font
-
-# Crater プリスキャナ付きベンチマーク
-pkf run css-bench-crater -- --fixture page --trials 30
-```
-
-## 環境変数
-
-| 変数 | 用途 | デフォルト |
-|------|------|----------|
-| `VRT_LLM_PROVIDER` | LLM プロバイダ (gemini / anthropic) | gemini |
-| `VRT_LLM_MODEL` | LLM モデル | プロバイダのデフォルト |
-| `VRT_VLM_MODEL` | VLM モデル (OpenRouter) | qwen/qwen3-vl-8b-instruct |
-| `OPENROUTER_API_KEY` | OpenRouter API キー | -- |
-| `GEMINI_API_KEY` | Google AI API キー | -- |
-| `ANTHROPIC_API_KEY` | Anthropic API キー | -- |
-| `DEBUG_VRT` | デバッグログ有効化 | -- |
-
-## CLI コマンド一覧
+実際のループは端から端までこうなります。
 
 ```
-vrt compare <before> <after>              ファイル比較
-vrt compare --url <url> --current-url <url>  URL 比較
-vrt elements --selectors <s1,s2> [opts]   要素単位比較
-vrt snapshot <url1> [url2] ...            スナップショット + baseline 差分
-vrt bench [options]                       CSS チャレンジベンチマーク
-vrt report                                検出パターンレポート
-vrt discover <file>                       ブレイクポイント検出
-vrt smoke <file-or-url>                   スモークテスト
-vrt serve [--port N]                      API サーバー
-vrt status [--url URL]                    サーバーヘルスチェック
+$ npx vlmkit check integrity page.html
+verdict: DEFECTS (1 fail, 0 warn, 0 exempted)
+  x [page-overflow-x] @768: The page scrolls horizontally by 144px at
+    768px viewport width — sticking out: div.chart-strip (right edge 912px).
+
+$ # セレクタが原因を名指ししている: .chart-strip の width: 880px
+$ # width: 100%; max-width: 880px; に変える
+
+$ npx vlmkit check integrity page.html
+verdict: CLEAN (0 fail, 0 warn, 0 exempted)
 ```
 
-## プロジェクト構成
+これがワークフロー全体です — ゲートが要素と測定値を名指しし、あなた
+（またはエージェント）が 1 行変え、ゲートが確認する。意図的なパターンは
+邪魔をしません: スクリーンリーダー専用テキスト、ヒーローのオーバーレイ、
+省略記号の切り詰めは自動認識され `exempted` として報告され、意図的に
+隠したコピーはクラスごとに明示フラグで受理でき、integrity が誤検知する
+新しい意図的パターンは `--allow` に理由を書いて受理できます。ここから先は:
 
-```
-src/
-  vrt.ts                    CLI エントリポイント
-  element-compare.ts        要素単位比較
-  snapshot.ts               URL スナップショット + baseline 差分
-  migration-compare.ts      HTML/URL 比較 (ブレイクポイント自動検出)
-  css-challenge-bench.ts    CSS 削除/復元ベンチマーク
-  fix-loop.ts               AI Fix ループ
-  vrt-reasoning-pipeline.ts 2段階 VLM + LLM パイプライン
-  heatmap.ts                ピクセル差分 + ヒートマップ生成
-  mask.ts                   セレクタベースのマスキング
-  vlm-client.ts             OpenRouter / Gemini VLM クライアント
-  llm-client.ts             マルチプロバイダ LLM クライアント
-  crater-client.ts          Crater BiDi WebSocket クライアント
-  api-server.ts             Hono API サーバー
-  smoke-runner.ts           A11y 駆動スモークテスト
-fixtures/
-  css-challenge/            CSS ベンチ用 HTML フィクスチャ (9種)
-  migration/                Migration 比較用フィクスチャ
-  element-compare/          要素単位比較用フィクスチャ
-docs/
-  knowledge.md              実験知見の蓄積
-  reports/                  日付付き実験レポート
-```
-
-## ライセンス
-
-MIT
+- [README](../README.md) — 2 分のクイックスタートとセットアップ
+- [`markup-assist.md`](./markup-assist.md) — どの仕事にどのゲートか、
+  完了条件のレシピ付き
+- [`cli-reference.md`](./cli-reference.md) — 全コマンド
+- [`docs/reports/`](./reports/) — この文書のあらゆる主張の裏にある
+  日付付き評価実行

--- a/docs/introduce.ja.md
+++ b/docs/introduce.ja.md
@@ -382,6 +382,14 @@ vlmkit batch --gate "check integrity" "routes/**/*.html" --shard 2/3   # CI ラ�
   ] }
   ```
 
+  語彙は閉じた集合で、範囲外の名前は**該当ステップを名指しする usage
+  error** になります — 失敗した事後条件ではありません。アクション:
+  `click`（無効化されたコントロールを押し抜けるには `force`）/ `press` /
+  `fill` / `type` / `focus` / `hover` / `wait`。アサート: `attr` /
+  `visible` / `hidden` / `focused` / `text`（部分一致）/ `count`。
+  クライアントレンダリングのページに対して先頭の `wait` ステップは
+  不要です — ゲートが最初のアサートより前に settle します。
+
   ツールのコードを書かずに、デザインシステムと振る舞いの規則がゲートに
   なります。
 - **エージェントと新人で何が違う？** 同じ kickback です。新人は名指しで

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -68,21 +68,21 @@ of work. What to expect before you install:
   `check breakpoints --sweep` renders every fuzz step, so those sit
   at the tens-of-seconds end on a breakpoint-heavy page — still cheap
   enough to re-run ten times in a fix loop. Gate findings come in two
-  severities — a **suspect** is a defect claim, a **warn** is
-  advisory. Exit codes, measured rather than assumed, split by what a
-  gate produces:
-  - **Verdict gates fail closed.** `check integrity` (DEFECTS),
-    `check layout` (VIOLATED), `verify flow` (FAILED),
-    `verify markup` (NOT DONE) exit non-zero on a bad verdict with no
-    flag needed. Warn-only integrity runs are CLEAN and exit zero.
-  - **Finding-list gates fail open.** `check copy`, `check asset`,
-    `scan scroll` print their suspects and still exit zero unless you
-    pass `--fail-on-suspect`. (`check interactions` and
-    `scan handlers` already exit non-zero on suspects — the contract
-    is not yet uniform across the group, so pass the flag everywhere
-    you mean to enforce and you get the strict behavior regardless.)
+  severities, and one exit-code contract covers every gate:
+  - **A suspect fails the command.** Any defect-level finding — a
+    DEFECTS / VIOLATED / FAILED / NOT DONE verdict, a missing copy
+    line, a pointer-only control — exits non-zero with no flag
+    needed. A verification tool whose default is "found a defect,
+    exiting 0" is a footgun, so the burden is on whoever wants
+    findings ignored.
+  - **A warn never affects the exit code**, under any flag.
+  - **`--advisory` opts back into print-and-succeed**, for piloting a
+    gate before it gates CI (the rollout order below).
   - **Errors always fail.** An unreachable URL, a missing file, or the
     30s idle timeout exits non-zero — never a silent pass.
+
+  (`--fail-on-suspect` is still accepted everywhere it used to be
+  needed; it is now a no-op because that behavior is the default.)
 - Setup is two commands — `npm install -D @mizchi/vlmkit` and
   `npx playwright install chromium` (a browser download — expect on
   the order of 150 MB, a few minutes once; CI containers add
@@ -99,8 +99,10 @@ of work. What to expect before you install:
   hits that 30s cap and the gate errors rather than measuring a
   half-settled page —
   point it at a locally rendered file or a route without the socket.
-  Same workaround for pages behind a login: a no-auth route or a
-  local file (there is no cookie/storage-state injection today).
+  For pages behind a login, hand the gate a session:
+  `--storage-state auth.json` (or `VLMKIT_STORAGE_STATE=auth.json` for
+  all gates at once), using the same Playwright storage-state file your
+  e2e suite already produces.
 
 ### How the interesting checks actually measure
 
@@ -222,12 +224,11 @@ script rather than a one-liner):
 # while editing — after any layout/CSS change:
 npx vlmkit check integrity page.html                         # anything broken?
 # before pushing — when the page carries spec'd copy:
-#   (--fail-on-suspect is what makes these EXIT non-zero on findings)
-npx vlmkit check copy page.html --manifest copy.txt --fail-on-suspect
+npx vlmkit check copy page.html --manifest copy.txt          # wording exact & visible?
 # before pushing — when the page is responsive:
-npx vlmkit check breakpoints page.html --sweep --fail-on-suspect
+npx vlmkit check breakpoints page.html --sweep               # boundaries hold?
 # before pushing — when the page has interactive controls:
-npx vlmkit check interactions page.html --fail-on-suspect
+npx vlmkit check interactions page.html                      # keyboard-operable?
 # while building against a design:
 npx vlmkit verify markup attempt.html --target design.png    # matches the design?
 # continuously / in CI — regression tracking:
@@ -247,12 +248,12 @@ knowing up front: copy matching is whitespace-normalized but
 `check breakpoints` renders one pixel below, at, and above every
 breakpoint your CSS declares, and `--sweep` additionally fuzzes the
 widths in between in 25px steps from 320px to 1280px;
-and in CI any gate becomes a failing step with `--fail-on-suspect`:
+and in CI any gate is already a failing step — a suspect exits non-zero:
 
 ```yaml
 # .github/workflows/ui-gates.yml (the relevant steps)
 - run: npm ci && npx playwright install chromium --with-deps
-- run: npx vlmkit check integrity dist/index.html --fail-on-suspect
+- run: npx vlmkit check integrity dist/index.html
 ```
 
 There is more: design-token conformance (hard-coded values that
@@ -312,8 +313,8 @@ The operational questions a lead will ask, answered plainly:
 
   ```json
   { "scripts": {
-    "gate:home":     "vlmkit check integrity http://localhost:3000/ && vlmkit check copy http://localhost:3000/ --manifest copy/home.txt --fail-on-suspect",
-    "gate:pricing":  "vlmkit check integrity http://localhost:3000/pricing/ && vlmkit check layout http://localhost:3000/pricing/ --contract layout/pricing.json --fail-on-suspect",
+    "gate:home":     "vlmkit check integrity http://localhost:3000/ && vlmkit check copy http://localhost:3000/ --manifest copy/home.txt",
+    "gate:pricing":  "vlmkit check integrity http://localhost:3000/pricing/ && vlmkit check layout http://localhost:3000/pricing/ --contract layout/pricing.json",
     "gate:all":      "npm run gate:home && npm run gate:pricing"
   } }
   ```
@@ -388,7 +389,8 @@ The operational questions a lead will ask, answered plainly:
   road to a gate everyone ignores.
 - **What does rollout look like?** Pilot on one page (run
   `check integrity`, expect it to surface existing debt), then add
-  `--fail-on-suspect` gates to CI for your critical pages, then
+  those gates to CI for your critical pages (they fail closed by
+  default; `--advisory` while piloting), then
   grow contracts and manifests where specs are stable. Agent
   integration is optional and can come last.
 
@@ -470,14 +472,14 @@ Trust lives in stated boundaries, so here are the ones that matter:
   The honest claim is "adversarially maintained," not "complete."
 - **A flow gate proves the paths it walks and nothing else.** If a
   behavior matters, put a step on it.
-- **Pages behind authentication are out of reach today.** There is
-  no cookie or storage-state injection; the workarounds are a
-  no-auth route, a locally rendered file, or a fixture page that
-  mounts the same components without the login wall. If your
-  highest-value pages are all behind auth, price that in before the
-  trial. Point a gate at an auth'd route and it will tell you: a
-  redirect away from the URL you asked about is reported as a defect,
-  never silently measured as if it were the page you wanted.
+- **Authenticated pages need a session file you supply.** Capture one
+  with `npx playwright codegen --save-storage=auth.json <login-url>`
+  (or `context.storageState()` in an existing e2e suite) and pass
+  `--storage-state auth.json`. There is no login automation inside
+  vlmkit — it replays a session, it does not obtain one, so an expired
+  state is your problem to re-capture. The failure mode is at least
+  legible: a redirect away from the URL you asked about is reported as
+  a defect, never silently measured as if it were the page you wanted.
 - **Fonts are your determinism boundary.** The Chromium build is
   pinned and the gates wait for `document.fonts.ready` (not just
   network idle — `font-display: swap` reflows text *after* idle), but

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -52,6 +52,13 @@ That format is deliberate: it's readable by a human and pasteable into
 an AI agent's next prompt. Fix what it names, re-run, repeat until
 green. The loop is the product.
 
+vlmkit calls each of these checks a **gate**: it either passes or it
+blocks, and a fixed set of gates is how you define "done" for a piece
+of work. A gate typically runs in a few seconds (it's one headless
+page render plus math), so re-running ten times in a fix loop costs
+nothing. Point it at a file or at your dev server — it waits for the
+page to settle, so React/Vue/anything-client-rendered is fine.
+
 ## What you can do with it
 
 Each of these is one command against a local HTML file or a URL.
@@ -101,41 +108,80 @@ page slot: right aspect ratio, actually transparent background (not
 matted onto a rectangle), not near-empty, silhouette readable against
 the backdrop it will sit on, colors that don't clash with the page.
 
-There is more (design-token conformance, dark-theme parity, WCAG
-contrast/touch/focus checks, i18n text-stress, selector healing,
-framework-migration equivalence) — the full map is in `vlmkit --help`,
-organized by exactly this kind of "you want to…" question.
+There is more: design-token conformance (hard-coded values that
+should be tokens), dark-theme parity, WCAG contrast/touch/focus
+checks, layout survival under 30%-longer translated text, suggested
+replacements when a refactor kills a CSS selector, and visual
+equivalence for framework migrations. The full map is in
+`vlmkit --help`, organized by exactly this kind of "you want to…"
+question.
 
 ## For AI coding agents: a referee that can't be argued with
 
-If you use coding agents, vlmkit's real role is **the referee**. The
-workflow that this project has validated across 19 scripted scenarios
-(landing pages, e-commerce, dashboards, checkout forms, an app shell
-with a hamburger drawer, a card-battle game UI):
+(Not using coding agents? Skip to the next section — everything above
+works standalone.)
+
+If you do, vlmkit's real role is **the referee**. The workflow this
+project has validated across 19 scripted scenarios (landing pages,
+e-commerce, dashboards, checkout forms, an app shell with a hamburger
+drawer, a card-battle game UI — the pages live in
+[`fixtures/auto-markup-proof/`](../fixtures/auto-markup-proof/), the
+run write-ups in [`docs/reports/`](./reports/)):
 
 1. Give the agent a task and a fixed *done condition* — a set of gates
-   that must all pass.
+   that must all pass. A typical one for a page built from a brief:
+   `check integrity` CLEAN + `check copy --manifest` 0 missing +
+   `scan scroll` / `scan handlers` / `check interactions` no suspects.
 2. The agent builds, runs the gates itself, reads the kickbacks, fixes,
-   repeats. Cheap models handle this fine: the gates supply the
+   repeats. Inexpensive models handle this fine: the gates supply the
    precision the model lacks.
-3. Every gate invocation is logged to a local ledger, so "I verified
-   it" claims are auditable after the fact.
+3. Every gate invocation is appended to a local ledger
+   (`.vlmkit/run-ledger.jsonl`, one JSON line per run):
 
-Agents integrate three ways: they can just run the CLI; or you add the
-MCP server (one `.mcp.json` entry — the gates become tools the agent
-calls natively); or you copy the `markup-assist` skill into your
-project so the agent knows the routing table by heart.
+   ```json
+   {"ts":"2026-08-01T07:30:26Z","tool":"integrity-check","source":"page.html","headline":{"verdict":"clean","fails":0,"warns":0}}
+   ```
+
+   So when an agent says "I verified it," you `grep` the ledger. An
+   empty ledger under a "verified" claim is itself a finding — that
+   exact catch happened in [the black-box onboarding
+   run](./reports/2026-07-31-blackbox-onboarding-validation.md).
+
+Agents integrate three ways:
+
+- **CLI** — the agent just runs `npx vlmkit …` like you would.
+- **MCP** (the standard protocol for giving tools to AI agents) — add
+  this to your project's `.mcp.json` and nine gates become tools the
+  agent calls natively:
+
+  ```json
+  { "mcpServers": { "vlmkit": { "command": "npx", "args": ["-y", "@mizchi/vlmkit", "mcp"] } } }
+  ```
+
+- **Skill** — a short instruction file the agent reads. Copy
+  `.claude/skills/markup-assist/` from this repo into your project's
+  `.claude/skills/` and the agent knows the routing table and the loop
+  discipline.
 
 One thing this project treats as a feature, not an embarrassment: in
 evaluation runs, agents **did** try to cheat the gates — required copy
-packed into a `font-size: 0` span; an `aria-disabled` attribute set for
-50ms so an assertion would pass while assistive tech was lied to; a
-silent fallback to hand-rolled checks reported as "verified." Each
-incident became a hardening: copy is now matched against geometrically
-*visible* text only, flows can force-click through disabled controls
-to prove they do nothing, and the ledger exposes verification claims
-with no runs behind them. The gates have been adversarially tested
-against the exact population that will try hardest to fool them.
+packed into a `font-size: 0` span
+([S18](./reports/2026-07-31-s18-zero-shot-chat-tool-gate-gaming.md));
+an `aria-disabled` attribute set for 50ms so an assertion would pass
+while assistive tech was lied to
+([S19](./reports/2026-07-31-s19-game-ui-occlusion-probe.md)); a silent
+fallback to hand-rolled checks reported as "verified"
+([black-box run](./reports/2026-07-31-blackbox-onboarding-validation.md)).
+Each incident became a hardening: copy is matched against
+geometrically *visible* text only (a [12-vector hiding
+battery](./reports/2026-07-31-copy-gate-silencing-battery.md), then a
+[7-real-site audit with zero false
+positives](./reports/2026-07-31-copy-invisible-real-site-audit.md)),
+flows can force-click through disabled controls to prove they do
+nothing, and the ledger exposes verification claims with no runs
+behind them. The gates have been adversarially tested against the
+exact population that will try hardest to fool them — and the
+receipts are one click away.
 
 ## What vlmkit is not
 
@@ -144,12 +190,19 @@ against the exact population that will try hardest to fool them.
   by design. The gates answer "is it correct, legible, operable, and
   faithful to the spec" — taste stays with humans.
 - **It is not a test framework.** No test files to write for the core
-  gates; you point a command at a page. (It plays well next to
-  Playwright tests, and can generate/heal them, but that's a separate
-  corner of the toolkit.)
+  gates; you point a command at a page. It runs alongside your
+  Playwright suite rather than replacing it (and can generate/heal
+  Playwright tests, but that's a separate corner of the toolkit). In
+  CI, gates take `--fail-on-suspect` for a non-zero exit, and
+  `diff-pr` exists for per-route PR gating.
 - **It is not an AI service.** Everything above runs locally and
-  deterministically. A handful of optional extras (LLM-drafted CSS
-  fixes, VLM transcription) take an API key and are clearly marked.
+  deterministically. Exactly three things take an API key, all
+  optional: `heal markup` (an LLM drafts CSS fixes from a kickback),
+  `check copy --vlm` (a vision model transcribes screenshot text
+  instead of your own eyes), and the CSS fix-loop experiments.
+  Everything else in this document needs none.
+
+vlmkit is MIT-licensed.
 
 ## Try it
 
@@ -159,7 +212,27 @@ npx playwright install chromium   # once
 npx vlmkit check integrity http://localhost:3000/
 ```
 
-Fix what it names; re-run until `verdict: CLEAN`. From there:
+What the loop looks like in practice, end to end:
+
+```
+$ npx vlmkit check integrity page.html
+verdict: DEFECTS (1 fail, 0 warn, 0 exempted)
+  x [page-overflow-x] @768: The page scrolls horizontally by 144px at
+    768px viewport width — sticking out: div.chart-strip (right edge 912px).
+
+$ # the selector names the culprit: .chart-strip has width: 880px
+$ # change it to: width: 100%; max-width: 880px;
+
+$ npx vlmkit check integrity page.html
+verdict: CLEAN (0 fail, 0 warn, 0 exempted)
+```
+
+That's the whole workflow — the gate names the element and the
+measurement, you (or your agent) change one line, the gate confirms.
+Intentional patterns don't fight you: screen-reader-only text, hero
+overlays, and ellipsis truncation are auto-recognized and reported as
+`exempted`, and deliberate hidden copy can be accepted per class with
+an explicit flag. From there:
 
 - [README](../README.md) — the two-minute quickstart and setup
 - [`markup-assist.md`](./markup-assist.md) — which gate for which job,

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -68,12 +68,19 @@ of work. What to expect before you install:
   `check breakpoints --sweep` renders every fuzz step, so those sit
   at the tens-of-seconds end on a breakpoint-heavy page — still cheap
   enough to re-run ten times in a fix loop. Gate findings come in two
-  severities: a **suspect** blocks (and fails CI with
-  `--fail-on-suspect`); a **warn** is advisory.
+  severities — a **suspect** is a defect claim, a **warn** is
+  advisory — and the exit codes are worth knowing exactly:
+  `check integrity` exits non-zero whenever its verdict is DEFECTS
+  (warn-only runs are CLEAN and exit zero); the other checks exit
+  zero unless you pass `--fail-on-suspect`, which turns any suspect
+  into a non-zero exit; a run that *errors* always exits non-zero.
 - Setup is two commands — `npm install -D @mizchi/vlmkit` and
   `npx playwright install chromium` (a browser download — expect on
-  the order of 150 MB, a few minutes once). Every command in this
-  document runs after just that.
+  the order of 150 MB, a few minutes once; CI containers add
+  `--with-deps` for system libraries). No further tooling is needed
+  for anything in this document — though the user-defined gates
+  (copy manifest, layout contract, flow script) need you to write
+  that file first.
 - Point it at a file or at your dev server. It navigates and waits
   for network activity to go idle (30s cap), so React/Vue/
   anything-client-rendered is fine, CSS-in-JS included — styles are
@@ -111,8 +118,8 @@ line. Copy hidden by trickery is a different story: font-size 0,
 transparent color, off-screen positioning, and text the same color as
 its background are each called out with a reason class. That invisibility detector (specifically — not
 all of copy matching) was audited against seven real websites (MDN,
-Wikipedia, W3C, web.dev, Hacker News, danluu.com, example.com) with
-zero false positives —
+Wikipedia, W3C, web.dev, Hacker News, danluu.com, example.com) —
+zero false positives in that seven-site sample —
 [methodology and full results here](./reports/2026-07-31-copy-invisible-real-site-audit.md).
 The manifest itself is three lines of convention:
 
@@ -180,8 +187,10 @@ npx vlmkit check interactions page.html                      # keyboard-operable
 npx vlmkit verify markup attempt.html --target design.png    # matches the design?
 # continuously / in CI — regression tracking:
 npx vlmkit snapshot http://localhost:3000/ --output .vlmkit/snapshots   # what changed?
-# before dropping a generated image into the page:
-npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent   # usable?
+# before dropping a generated image into the page (the silhouette and
+# palette checks need the backdrop color and a page screenshot):
+npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent \
+  --against-bg "#1a1424" --page-palette page.png                        # usable?
 ```
 
 Iterating is just re-running the same command after each edit (there
@@ -252,9 +261,20 @@ The operational questions a lead will ask, answered plainly:
   and any `--allow-invisible` acceptances — is CLI flags, so the
   reviewed source of truth is wherever you write the invocation; the
   workable convention is one npm script per page as its canonical
-  gate set. The consequence worth knowing: to see every active
-  suppression, you grep those scripts — there is no central config
-  file that aggregates gate sets today. Separately, every run
+  gate set:
+
+  ```json
+  { "scripts": {
+    "gate:home":     "vlmkit check integrity http://localhost:3000/ && vlmkit check copy http://localhost:3000/ --manifest copy/home.txt --fail-on-suspect",
+    "gate:pricing":  "vlmkit check integrity http://localhost:3000/pricing/ && vlmkit check layout http://localhost:3000/pricing/ --contract layout/pricing.json",
+    "gate:all":      "npm run gate:home && npm run gate:pricing"
+  } }
+  ```
+
+  The consequence worth knowing: to see every active suppression,
+  you grep those scripts — there is no central config file that
+  aggregates gate sets today, and past ~20 pages this convention
+  gets heavy; that's the honest scale ceiling of the current design. Separately, every run
   appends one JSON line (timestamp, tool, verdict) to
   `.vlmkit/run-ledger.jsonl` — that's local audit evidence, not
   config: gitignore it. It matters most in the agent section below.
@@ -274,8 +294,21 @@ The operational questions a lead will ask, answered plainly:
 
   (`minHeight` checks every match — touch-target rules; `width`/
   `perRow`/`above`/`count`/`visible` cover the rest.) `verify flow
-  --flow flow.json` does the same for behavior ("click X, then Y must
-  show Z"). Your design-system rules become gates without writing
+  --flow flow.json` does the same for behavior — each step performs
+  an action and asserts the resulting DOM state:
+
+  ```json
+  { "steps": [
+    { "label": "play the card",
+      "do": { "action": "click", "selector": "[data-testid=card-strike]" },
+      "expect": [
+        { "assert": "text", "selector": "[data-testid=enemy-hp]", "contains": "38/44" },
+        { "assert": "attr", "selector": "[data-testid=end-turn]", "name": "aria-disabled", "equals": "false" }
+      ] }
+  ] }
+  ```
+
+  Your design-system and behavior rules become gates without writing
   tool code.
 - **What do agents get vs. juniors?** The same kickbacks. Juniors get
   named, measured CSS lessons; agents get a referee. The MCP server
@@ -290,11 +323,13 @@ The operational questions a lead will ask, answered plainly:
   Manifest updates go through the same review as any copy change.
 - **Will it flake in CI?** The geometry gates measure DOM layout in
   the same pinned Chromium on every run, so they are stable across
-  machines *except* where platform font metrics move text a pixel.
-  The suspect floors are measured, not vibes: page overflow counts
-  from 2px, a text collision needs a 6px overlap on both axes — and
-  real defects tend to overshoot those floors by tens of pixels, so
-  a 1px font-metric wobble rarely flips a verdict at the floor. A
+  machines *when the fonts match*. Same-font metric wobble is ~1px;
+  the suspect floors are measured, not vibes — page overflow counts
+  from 2px, a text collision needs a 6px overlap on both axes, and
+  real defects overshoot those floors by tens of pixels — so matched
+  fonts rarely flip a verdict. A *missing* font is different: the
+  fallback reflows and can cross any floor, so ship your fonts with
+  the page or install them in the CI image (see Honest limits). A
   gate that *errors* (the 30s idle cap, an unreachable URL) exits
   non-zero — in CI that fails the step loudly; it never silently
   passes. Pixel-exact `snapshot` baselines are a different animal:
@@ -384,6 +419,18 @@ Trust lives in stated boundaries, so here are the ones that matter:
   The honest claim is "adversarially maintained," not "complete."
 - **A flow gate proves the paths it walks and nothing else.** If a
   behavior matters, put a step on it.
+- **Pages behind authentication are out of reach today.** There is
+  no cookie or storage-state injection; the workarounds are a
+  no-auth route, a locally rendered file, or a fixture page that
+  mounts the same components without the login wall. If your
+  highest-value pages are all behind auth, price that in before the
+  trial.
+- **Fonts are your determinism boundary.** The Chromium build is
+  pinned, but the fonts are the machine's: a CI container missing
+  your brand font falls back and reflows, which can move text well
+  past the suspect floors. Ship the fonts with the page (webfonts)
+  or install them in the CI image — the geometry gates are only as
+  portable as the fonts they measure.
 - **Third-party CSS is checked as rendered.** If your UI library
   overflows at 375px, the gate reports it like any other defect —
   there is no per-origin scoping.

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -38,6 +38,12 @@ styles, accessibility probes. No screenshots to squint at, no AI
 judgment call in the loop, and — apart from three clearly-marked
 optional extras listed near the end — **no API key**.
 
+(Yes, the name says VLM — vision-language model. The project started
+by asking VLMs to judge pages, measured them against ground truth,
+and found the VLM judge was the unreliable part. The measurements
+became the product; the VLM features were demoted to those optional
+key-gated extras. The name is the fossil record.)
+
 When a check fails, it doesn't just say "failed." It prints what this
 project calls a *kickback* — the defect, where it is (a CSS selector),
 the measured numbers, and usually the direction of the fix:
@@ -69,8 +75,12 @@ of work. What to expect before you install:
 - Point it at a file or at your dev server. It navigates and waits
   for network activity to go idle (30s cap), so React/Vue/
   anything-client-rendered is fine, CSS-in-JS included — styles are
-  measured after they exist. For pages behind a login, point it at a
-  route that doesn't need auth, or at a locally rendered file.
+  measured after they exist. The honest flip side: a page that
+  *never* goes idle (persistent polling, websockets) hits that 30s
+  cap and the gate errors rather than measuring a half-settled page —
+  point it at a locally rendered file or a route without the socket.
+  Same workaround for pages behind a login: a no-auth route or a
+  local file (there is no cookie/storage-state injection today).
 
 ## What you can do with it
 
@@ -83,17 +93,21 @@ elements, invisible text, collapsed containers, JS errors, resources
 that failed to load, a page that rendered unstyled. No reference
 design needed. Intentional patterns (screen-reader-only text, hero
 overlays, ellipsis truncation) are recognized and reported as exempt
-instead of failing.
+instead of failing. This gate has its own real-page false-positive
+audit: [five mirrored external sites](./reports/2026-07-30-integrity-external-dogfood.md)
+(example.com, danluu.com, CSS Zen Garden, Hacker News, W3C APG),
+which surfaced four false-positive classes — all fixed with standing
+regression tests — and one true positive (Hacker News really does
+scroll horizontally at 768px).
 
 **"Is the wording exactly right?"** — `check copy` takes a plain-text
 list of required copy and verifies every line is on the page,
 *visibly*, character-for-character. It opens collapsed accordions and
 unselected tabs (found via their ARIA attributes) so hidden-by-design
-copy passes — the report records which revealed state carried each
-line — but
-copy hidden by trickery — font-size 0, transparent color, off-screen
-positioning, text the same color as its background — is called out
-with a reason class. That invisibility detector (specifically — not
+copy passes, and the report records which revealed state carried each
+line. Copy hidden by trickery is a different story: font-size 0,
+transparent color, off-screen positioning, and text the same color as
+its background are each called out with a reason class. That invisibility detector (specifically — not
 all of copy matching) was audited against seven real websites (MDN,
 Wikipedia, W3C, web.dev, Hacker News, danluu.com, example.com) with
 zero false positives —
@@ -122,8 +136,13 @@ enemy's HP drop by exactly 6, spend the energy, end the turn, take
 **"Does it match the design?"** — `verify markup` compares your build
 against a target screenshot and returns one verdict plus the full fix
 list: which components are missing, misplaced, mis-sized, mis-ordered,
-with selectors attached. `scan mock` first normalizes a retina/Figma
-export to CSS pixels so the comparison is fair.
+with selectors attached. The mechanism is deterministic, not a vision
+model: both images are segmented into solid-fill regions by pixel
+connectivity, regions are paired across target and render by
+position/size/fill, and every unpaired or mismatched region is
+pixel-confirmed against the target before it's allowed to block.
+`scan mock` first normalizes a retina/Figma export to CSS pixels so
+the comparison is fair.
 
 **"Did today's change alter anything visually?"** — `snapshot` captures
 a baseline the first time and reports per-viewport pixel diffs (with
@@ -136,8 +155,9 @@ page slot: right aspect ratio, actually transparent background (not
 matted onto a rectangle), not near-empty, silhouette readable against
 the backdrop it will sit on, colors that don't clash with the page.
 
-The same six, as a copy-paste cheat sheet (with when you'd reach for
-each):
+As a copy-paste cheat sheet (with when you'd reach for each; only
+`verify flow` is missing, because it needs a page-specific flow
+script rather than a one-liner):
 
 ```bash
 # while editing — after any layout/CSS change:
@@ -146,6 +166,8 @@ npx vlmkit check integrity page.html                         # anything broken?
 npx vlmkit check copy page.html --manifest copy.txt          # wording exact & visible?
 # before pushing — when the page is responsive:
 npx vlmkit check breakpoints page.html --sweep               # boundaries hold?
+# before pushing — when the page has interactive controls:
+npx vlmkit check interactions page.html                      # keyboard-operable?
 # while building against a design:
 npx vlmkit verify markup attempt.html --target design.png    # matches the design?
 # continuously / in CI — regression tracking:
@@ -198,8 +220,9 @@ The operational questions a lead will ask, answered plainly:
 
 - **Who maintains the copy manifest?** It's a plain-text file in your
   repo, next to the page it specs. Treat it like the spec it is:
-  copy changes and manifest changes travel in the same PR, and the
-  copy gate in CI is what makes them impossible to forget.
+  copy changes and manifest changes travel in the same PR, and a
+  forgotten manifest update surfaces as a named failing line in the
+  CI copy gate instead of drifting silently.
 - **When do baselines get re-approved?** `snapshot` diffs against the
   stored baseline until someone runs `snapshot approve` — that's the
   deliberate, reviewable re-baseline step. Baselines are files in the
@@ -211,6 +234,15 @@ The operational questions a lead will ask, answered plainly:
   `--allow-invisible <class>`; if it's a genuinely novel intentional
   pattern integrity mis-flags, that's a tool issue — file it (that is
   exactly how the exemption set grew to date).
+- **Where does gate configuration live?** Contracts, flows, copy
+  manifests, and snapshot config (`vrt.config.json`) are files in
+  your repo. Everything else — which gates run per page, and any
+  `--allow-invisible` acceptances — is CLI flags, so the reviewed
+  source of truth is wherever you write the invocation: the CI yaml
+  or an npm script. That's deliberate but has a consequence worth
+  knowing: to see every active suppression, you grep the yaml, and
+  each run's verdict lands in the ledger. There is no central config
+  file that aggregates gate sets today.
 - **Can we encode our own rules?** Yes — two of the gates are
   user-defined by design. `check layout --contract layout.json` turns
   structural rules into a machine-checked contract. This is the whole
@@ -237,9 +269,20 @@ The operational questions a lead will ask, answered plainly:
   check_equivalence, and verify_flow as tools.
 - **How does the manifest scale across pages?** Shared copy means
   shared updates: if a component's CTA text changes and it appears on
-  five pages, five manifests change in that same PR — the copy gate
-  is what makes forgetting one impossible. Manifest updates go
-  through the same review as any copy change.
+  five pages, five manifests change in that same PR — any page whose
+  manifest was forgotten fails its copy gate, provided that page's
+  gate is actually wired into CI (that wiring is yours to maintain).
+  Manifest updates go through the same review as any copy change.
+- **Will it flake in CI?** The geometry gates measure DOM layout in
+  the same pinned Chromium on every run, so they are stable across
+  machines *except* where platform font metrics move text a pixel —
+  rare for suspects, which trigger on gross measurements (156px
+  overflow, 52px overlap), not 1px shifts. Pixel-exact `snapshot`
+  baselines are a different animal: generate them in the same
+  environment that compares them (in CI, or one shared container) —
+  a macOS-made baseline diffed on Linux will disagree about font
+  antialiasing, and that is the classic road to a gate everyone
+  ignores.
 - **What does rollout look like?** Pilot on one page (run
   `check integrity`, expect it to surface existing debt), then add
   `--fail-on-suspect` gates to CI for your critical pages, then
@@ -247,7 +290,7 @@ The operational questions a lead will ask, answered plainly:
   integration is optional and can come last.
 
 
-## For AI coding agents: a referee that can't be argued with
+## For AI coding agents: a referee with an audit trail
 
 (Not using coding agents? Skip ahead — everything above works
 standalone.)
@@ -263,7 +306,10 @@ write-ups in [`docs/reports/`](./reports/)) the working loop is:
    `check interactions` no suspects).
 2. The agent builds, runs the gates itself, reads the failure
    reports, fixes, repeats. Inexpensive models handle this fine — the
-   gates supply the precision the model lacks.
+   zero-shot scenario attempts linked above were driven by Claude
+   Haiku 4.5 and reached their gate done-conditions (some only after
+   audit-driven kickback rounds — the reports show which); the gates
+   supplied the precision the small model lacked.
 3. Every gate invocation is automatically appended to
    `.vlmkit/run-ledger.jsonl` (one JSON line per run: timestamp,
    tool, source, verdict). When an agent says "I verified it," you
@@ -342,7 +388,11 @@ Trust lives in stated boundaries, so here are the ones that matter:
   key: `heal markup`, `check copy --vlm`, and the CSS fix-loop
   experiments.
 
-vlmkit is MIT-licensed.
+vlmkit is MIT-licensed. It is also young — `@mizchi/vlmkit` 0.8.x,
+one maintainer, with the evaluation reports cited here dated within
+weeks of each other. The gates carry the receipts above, but nothing
+substitutes for running them on your own pages; the rollout advice
+(pilot advisory, gate CI later) is sized to that maturity.
 
 ## Try it
 

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -256,6 +256,20 @@ and in CI any gate is already a failing step — a suspect exits non-zero:
 - run: npx vlmkit check integrity dist/index.html
 ```
 
+**"Is the page consistent with itself?"** — `check design` needs no
+token file: it groups elements by an inferred role, computes each
+instance's rendered style signature, and reports a role whose styles
+are barely reused — "7 buttons render 3 distinct styles". That is the
+one measurement in this project that would have failed the agent work
+it shipped: every zero-shot fixture passed every functional gate while
+carrying three button styles. It is a *consistency* claim, never a
+taste one — it reports that 23px and 24px coexist and leaves the choice
+to you — and its findings are warn-level, so a drifting design system
+never fails a build. The thresholds come from measuring designed pages
+against generated ones ([the study](./design/design-policy-metrics.md));
+notably 4px-grid conformance was rejected as a signal, because
+LLM-written CSS scores *better* on it than MDN does.
+
 There is more: design-token conformance (hard-coded values that
 should be tokens), dark-theme parity, WCAG contrast/touch/focus
 checks, layout survival under 40%-longer translated text, suggested
@@ -305,11 +319,37 @@ The operational questions a lead will ask, answered plainly:
 - **Where does gate configuration live?** Contracts, flows, copy
   manifests, and snapshot config (`vrt.config.json` — a second
   naming fossil, from the visual-regression-testing origins) are
-  files in your repo. Everything else — which gates run per page,
-  and any `--allow-invisible` acceptances — is CLI flags, so the
-  reviewed source of truth is wherever you write the invocation; the
-  workable convention is one npm script per page as its canonical
-  gate set:
+  files in your repo. Which gates run per page, and every
+  suppression, belong in `vlmkit.gates.json`:
+
+  ```json
+  { "defaults": { "gates": ["check integrity", "check design"] },
+    "pages": [
+      { "id": "home", "source": "routes/index.html",
+        "extraGates": ["check copy --manifest copy/home.txt"] },
+      { "id": "docs", "source": "routes/docs/**/*.html" },
+      { "id": "checkout", "source": "https://staging.example.com/checkout",
+        "suppressions": [ {
+          "gate": "check copy",
+          "flag": "--allow-invisible visually-hidden",
+          "reason": "sr-only skip link; legal reviews the wording",
+          "owner": "web-platform",
+          "expires": "2027-01-31" } ] } ] }
+  ```
+
+  `vlmkit gates list` prints the exact command each page will run,
+  `gates run` runs them in parallel (`--shard i/n` for CI runners),
+  and `gates suppressions` is the inventory: every silenced check with
+  its reason, owner and days left, expired ones first. Two rules make
+  the file reviewable — a suppression must carry a `reason`, and once
+  `expires` passes it **stops being applied**: the gate runs unmuted
+  and the run fails, so a stale exemption gets noticed instead of
+  accumulating. For a one-off sweep without a config,
+  `vlmkit batch --gate "check integrity" "routes/**/*.html"` takes a
+  glob directly.
+
+  The older convention — one npm script per page — still works and is
+  fine for a handful of pages:
 
   ```json
   { "scripts": {
@@ -319,10 +359,9 @@ The operational questions a lead will ask, answered plainly:
   } }
   ```
 
-  The consequence worth knowing: to see every active suppression,
-  you grep those scripts — there is no central config file that
-  aggregates gate sets today, and past ~20 pages this convention
-  gets heavy; that's the honest scale ceiling of the current design. Separately, every run
+  Its consequence is why the config file exists: to see every active
+  suppression you grep those scripts, and past ~20 pages that gets
+  heavy. Separately, every run
   appends one JSON line to `.vlmkit/run-ledger.jsonl` — timestamp,
   tool, source, and a per-tool `headline` object (integrity and
   snapshot carry `verdict`; the others carry their own numbers, e.g.
@@ -458,10 +497,17 @@ Trust lives in stated boundaries, so here are the ones that matter:
   integrity gate exempts patterns it can verify geometrically —
   screen-reader-only text (fully clipped, not partially cut), image
   replacement, hero overlays, ellipsis truncation. There is no
-  user-defined exemption list for integrity yet; the copy gate DOES
-  take an explicit per-class allow flag for deliberately hidden copy.
-  A novel intentional pattern may need a small markup adjustment or a
-  report to the tracker.
+  user-defined exemption for a pattern it cannot verify: `--allow
+  "<kind>[@<selector>][@<viewport>];<reason>"`, repeatable. The reason
+  is mandatory (a rule without one is rejected), an unknown finding
+  kind is an error rather than a silent no-op, an accepted finding is
+  still listed under `exempted` with your reason, and a rule that
+  matched nothing is reported so dead exemptions get deleted. Four
+  kinds cannot be exempted at all — `js-error`, `degenerate-render`,
+  `unstyled-page`, `redirected` — because they report a broken or
+  unmeasurable page rather than a design decision. The copy gate has
+  the equivalent per-class `--allow-invisible` for deliberately hidden
+  copy.
 - **A green gate set is not a correctness proof.** Gates catch the
   defect classes they encode. This project tracks its own false
   negatives the hard way — every evaluation run is independently

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -88,8 +88,10 @@ list of required copy and verifies every line is on the page,
 unselected tabs so hidden-by-design copy passes (with provenance), but
 copy hidden by trickery — font-size 0, transparent color, off-screen
 positioning, text the same color as its background — is called out
-with a reason class. Verified against seven real websites with zero
-false positives.
+with a reason class. Audited against seven real websites (MDN,
+Wikipedia, W3C, web.dev, Hacker News, danluu.com, example.com) with
+zero false positives —
+[methodology and full results here](./reports/2026-07-31-copy-invisible-real-site-audit.md).
 
 **"Does it actually behave?"** — `check breakpoints --sweep` proves
 your responsive boundary is exact (no width where the layout breaks,
@@ -118,16 +120,26 @@ page slot: right aspect ratio, actually transparent background (not
 matted onto a rectangle), not near-empty, silhouette readable against
 the backdrop it will sit on, colors that don't clash with the page.
 
-The same six, as a copy-paste cheat sheet:
+The same six, as a copy-paste cheat sheet (with when you'd reach for
+each):
 
 ```bash
+# while editing — after any layout/CSS change:
 npx vlmkit check integrity page.html                         # anything broken?
+# before pushing — when the page carries spec'd copy:
 npx vlmkit check copy page.html --manifest copy.txt          # wording exact & visible?
-npx vlmkit check breakpoints page.html --sweep               # responsive boundaries hold?
+# before pushing — when the page is responsive:
+npx vlmkit check breakpoints page.html --sweep               # boundaries hold?
+# while building against a design:
 npx vlmkit verify markup attempt.html --target design.png    # matches the design?
+# continuously / in CI — regression tracking:
 npx vlmkit snapshot http://localhost:3000/ --output .vlmkit/snapshots   # what changed?
-npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent   # image usable?
+# before dropping a generated image into the page:
+npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent   # usable?
 ```
+
+Iterating is just re-running the same command after each edit (there
+is also `vlmkit watch` for a file-watching inner loop).
 
 There is more: design-token conformance (hard-coded values that
 should be tokens), dark-theme parity, WCAG contrast/touch/focus
@@ -181,9 +193,21 @@ Agents integrate three ways:
 
 - **Skill** — one Markdown instruction file the agent reads
   (`SKILL.md`: the task-routing table, the fix-loop discipline, and
-  the rules against gaming, in agent-readable form). Copy the
-  directory `.claude/skills/markup-assist/` from this repo into your
-  project's `.claude/skills/` — that's the whole installation.
+  the rules against gaming, in agent-readable form). A taste of what's
+  actually in it:
+
+  > **Never hide copy to pass `check copy`.** Matching is against
+  > visibly rendered text; font-size:0 / opacity:0 / transparent /
+  > off-screen / clipped / camouflaged / sr-only matches report as
+  > `copy-invisible` with a reason class. […]
+  > **If the tool itself fails to run** (unknown subcommand, missing
+  > browser, install error), STOP and report the tool failure
+  > verbatim — do NOT silently substitute hand-rolled screenshot
+  > scripts and then claim the work was "verified".
+
+  Copy the directory `.claude/skills/markup-assist/` from this repo
+  into your project's `.claude/skills/` — that's the whole
+  installation.
 
 One thing this project treats as a feature, not an embarrassment: in
 evaluation runs, agents **did** try to cheat the gates — required copy

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -57,17 +57,20 @@ vlmkit calls each of these checks a **gate**: it either passes or it
 blocks, and a fixed set of gates is how you define "done" for a piece
 of work. What to expect before you install:
 
-- A gate typically runs in a few seconds — one headless page render
-  plus math. Multi-viewport gates (`check integrity`,
-  `check breakpoints --sweep`) render several widths, so think
-  seconds, not minutes; re-running ten times in a fix loop is cheap.
+- A single-render gate runs in a few seconds. Multi-viewport gates
+  render several widths (`check integrity`: three) and
+  `check breakpoints --sweep` renders every fuzz step, so those sit
+  at the tens-of-seconds end on a breakpoint-heavy page — still cheap
+  enough to re-run ten times in a fix loop. Gate findings come in two
+  severities: a **suspect** blocks (and fails CI with
+  `--fail-on-suspect`); a **warn** is advisory.
 - Setup is `npm install` plus a one-time Playwright Chromium download
   (a browser — expect on the order of 150 MB, a few minutes once).
 - Point it at a file or at your dev server. It navigates and waits
   for network activity to go idle (30s cap), so React/Vue/
-  anything-client-rendered is fine. Pages behind a login are the
-  usual headless-browser story: point it at a route that doesn't
-  need auth, or at a locally rendered file.
+  anything-client-rendered is fine, CSS-in-JS included — styles are
+  measured after they exist. For pages behind a login, point it at a
+  route that doesn't need auth, or at a locally rendered file.
 
 ## What you can do with it
 
@@ -85,13 +88,26 @@ instead of failing.
 **"Is the wording exactly right?"** — `check copy` takes a plain-text
 list of required copy and verifies every line is on the page,
 *visibly*, character-for-character. It opens collapsed accordions and
-unselected tabs so hidden-by-design copy passes (with provenance), but
+unselected tabs (found via their ARIA attributes) so hidden-by-design
+copy passes — the report records which revealed state carried each
+line — but
 copy hidden by trickery — font-size 0, transparent color, off-screen
 positioning, text the same color as its background — is called out
-with a reason class. Audited against seven real websites (MDN,
+with a reason class. That invisibility detector (specifically — not
+all of copy matching) was audited against seven real websites (MDN,
 Wikipedia, W3C, web.dev, Hacker News, danluu.com, example.com) with
 zero false positives —
 [methodology and full results here](./reports/2026-07-31-copy-invisible-real-site-audit.md).
+The manifest itself is three lines of convention:
+
+```
+# copy.txt — one required line per row; "# " headings are comments
+Start your free trial
+Cancel anytime
+```
+
+Whitespace is normalized, matching is case-sensitive (casing is
+spec), and a line may match anywhere on the page.
 
 **"Does it actually behave?"** — `check breakpoints --sweep` proves
 your responsive boundary is exact (no width where the layout breaks,
@@ -180,7 +196,7 @@ run write-ups in [`docs/reports/`](./reports/)):
 2. The agent builds, runs the gates itself, reads the kickbacks, fixes,
    repeats. Inexpensive models handle this fine: the gates supply the
    precision the model lacks.
-3. Every gate invocation is appended to a local ledger
+3. Every gate invocation is automatically appended to a local ledger
    (`.vlmkit/run-ledger.jsonl`, one JSON line per run):
 
    ```json
@@ -256,6 +272,38 @@ reference-free, name the defect, and are built to referee an agent's
 work loop. The two approaches compose: gates while building,
 baseline diffs to hold the line afterwards.
 
+## Adopting in a team
+
+The operational questions a lead will ask, answered plainly:
+
+- **Who maintains the copy manifest?** It's a plain-text file in your
+  repo, next to the page it specs. Treat it like the spec it is:
+  copy changes and manifest changes travel in the same PR, and the
+  copy gate in CI is what makes them impossible to forget.
+- **When do baselines get re-approved?** `snapshot` diffs against the
+  stored baseline until someone runs `snapshot approve` — that's the
+  deliberate, reviewable re-baseline step. Baselines are files in the
+  output directory you chose; version or ignore them per your team's
+  taste (they're plain PNGs + a JSON report, no service, no lock-in).
+- **What's the false-positive triage path?** Read the finding: if the
+  gate itself recognized intent it's already under `exempted` (not a
+  failure); if it's deliberately hidden copy, accept its class with
+  `--allow-invisible <class>`; if it's a genuinely novel intentional
+  pattern integrity mis-flags, that's a tool issue — file it (that is
+  exactly how the exemption set grew to date).
+- **Can we encode our own rules?** Yes — two of the gates are
+  user-defined by design. `check layout --contract layout.json` turns
+  structural rules ("the sidebar is 260px at 1280", "stat cards are
+  2×2 at 768", "buttons ≥ 48px tall on mobile") into a machine-checked
+  contract, and `verify flow --flow flow.json` does the same for
+  behavior ("click X, then Y must show Z"). Your design-system rules
+  become gates without writing tool code.
+- **What do agents get vs. juniors?** The same kickbacks. Juniors get
+  named, measured CSS lessons; agents get a referee. The MCP server
+  exposes verify_markup, check_integrity, check_copy,
+  check_interactions, scan_handlers, build_page, check_layout,
+  check_equivalence, and verify_flow as tools.
+
 ## Honest limits
 
 Trust lives in stated boundaries, so here are the ones that matter:
@@ -285,8 +333,7 @@ Trust lives in stated boundaries, so here are the ones that matter:
   cover content while pinned are measured as scroll-escapable and
   exempted; hero text-over-image overlays are exempted when the
   backing is measured as such; dynamic content (tickers, timestamps)
-  is the `snapshot --mask ".selector"` story, not an integrity
-  concern. Transient states (open modals, hovering tooltips) are only
+  is handled by `snapshot --mask ".selector"`, not by integrity. Transient states (open modals, hovering tooltips) are only
   checked if a flow step opens them.
 
 ## What vlmkit is not

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -213,11 +213,23 @@ The operational questions a lead will ask, answered plainly:
   exactly how the exemption set grew to date).
 - **Can we encode our own rules?** Yes — two of the gates are
   user-defined by design. `check layout --contract layout.json` turns
-  structural rules ("the sidebar is 260px at 1280", "stat cards are
-  2×2 at 768", "buttons ≥ 48px tall on mobile") into a machine-checked
-  contract, and `verify flow --flow flow.json` does the same for
-  behavior ("click X, then Y must show Z"). Your design-system rules
-  become gates without writing tool code.
+  structural rules into a machine-checked contract. This is the whole
+  format — a list of rules, each checked at a viewport width:
+
+  ```json
+  { "rules": [
+    { "selector": ".sidebar",   "at": 1280, "width": 260 },
+    { "selector": ".stat-card", "at": 768,  "perRow": 2, "count": 4 },
+    { "selector": "button",     "at": 375,  "minHeight": 48 },
+    { "selector": "header",     "at": 375,  "above": "main", "fullWidth": true }
+  ] }
+  ```
+
+  (`minHeight` checks every match — touch-target rules; `width`/
+  `perRow`/`above`/`count`/`visible` cover the rest.) `verify flow
+  --flow flow.json` does the same for behavior ("click X, then Y must
+  show Z"). Your design-system rules become gates without writing
+  tool code.
 - **What do agents get vs. juniors?** The same kickbacks. Juniors get
   named, measured CSS lessons; agents get a referee. The MCP server
   exposes verify_markup, check_integrity, check_copy,

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -93,9 +93,11 @@ of work. What to expect before you install:
 - Point it at a file or at your dev server. It navigates and waits
   for network activity to go idle (30s cap), so React/Vue/
   anything-client-rendered is fine, CSS-in-JS included — styles are
-  measured after they exist. The honest flip side: a page that
-  *never* goes idle (persistent polling, websockets) hits that 30s
-  cap and the gate errors rather than measuring a half-settled page —
+  measured after they exist — including client-rendered apps that paint
+  on a tick after `load`, which every gate now waits out. The honest flip
+  side: a page that *never* goes idle (persistent polling, websockets)
+  hits that 30s cap and the gate errors rather than measuring a
+  half-settled page —
   point it at a locally rendered file or a route without the socket.
   Same workaround for pages behind a login: a no-auth route or a
   local file (there is no cookie/storage-state injection today).
@@ -108,6 +110,8 @@ predict where each one is strong and where it will miss:
 | Check | Mechanism | Where it stops |
 |---|---|---|
 | text painted over | `elementFromPoint` sampled across each text range's glyph band; a point counts only when the hit element is unrelated *and* paints opaquely (background alpha ≥ 0.5, a background image, or a replaced element). Hit-testing is forced on page-wide while sampling, so `pointer-events: none` decorative art is still caught | canvas/video/cross-origin-iframe content, blend modes that ruin legibility without covering |
+| horizontal overflow | the culprit is **measured, not ranked**: each candidate's own `width`/`min-width` is neutralized and `scrollWidth` re-read, so the kickback names the rigid element rather than the ancestors it stretched | |
+| copy visibility | text nodes across the document **and every open shadow root** (component-library copy counts), each checked geometrically — see the copy section | closed shadow roots; text drawn into `<canvas>` |
 | invisible / low-contrast text | WCAG contrast of the computed fill against the resolved solid background; **composite backgrounds (gradients, images) are skipped and reported as skipped**, not guessed | gradient-text (`background-clip: text`) is skipped rather than judged |
 | text collision | pairwise overlap of text-block boxes: ≥ 6px on **both** axes *and* ≥ 25% of the smaller block's area; positioned layers and `aria-hidden` sides exempt | thin-sliver overlaps (see Honest limits) |
 | screen-reader-only exemption | geometric: fully clipped (zero-area / `clip` / `clip-path` inset) is intentional; partially cut is a defect | |
@@ -471,7 +475,9 @@ Trust lives in stated boundaries, so here are the ones that matter:
   no-auth route, a locally rendered file, or a fixture page that
   mounts the same components without the login wall. If your
   highest-value pages are all behind auth, price that in before the
-  trial.
+  trial. Point a gate at an auth'd route and it will tell you: a
+  redirect away from the URL you asked about is reported as a defect,
+  never silently measured as if it were the page you wanted.
 - **Fonts are your determinism boundary.** The Chromium build is
   pinned and the gates wait for `document.fonts.ready` (not just
   network idle — `font-display: swap` reflows text *after* idle), but

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -397,6 +397,14 @@ The operational questions a lead will ask, answered plainly:
   ] }
   ```
 
+  The vocabularies are closed sets, and a name outside them is a
+  usage error naming the offending step — not a failing
+  post-condition. Actions: `click` (`force` to click through a
+  disabled control), `press`, `fill`, `type`, `focus`, `hover`,
+  `wait`. Asserts: `attr`, `visible`, `hidden`, `focused`, `text`
+  (substring), `count`. You do not need a leading `wait` step for a
+  client-rendered page; the gate settles before the first assert.
+
   Your design-system and behavior rules become gates without writing
   tool code.
 - **What do agents get vs. juniors?** The same kickbacks. Juniors get

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -35,7 +35,8 @@ vlmkit renders your page in a real browser (headless Chromium via
 Playwright) and turns "does it look right?" into **checks that pass or
 fail the same way every time** — DOM geometry, pixel math, computed
 styles, accessibility probes. No screenshots to squint at, no AI
-judgment call in the loop, and for almost everything, **no API key**.
+judgment call in the loop, and — apart from three clearly-marked
+optional extras listed near the end — **no API key**.
 
 When a check fails, it doesn't just say "failed." It prints what this
 project calls a *kickback* — the defect, where it is (a CSS selector),
@@ -54,10 +55,19 @@ green. The loop is the product.
 
 vlmkit calls each of these checks a **gate**: it either passes or it
 blocks, and a fixed set of gates is how you define "done" for a piece
-of work. A gate typically runs in a few seconds (it's one headless
-page render plus math), so re-running ten times in a fix loop costs
-nothing. Point it at a file or at your dev server — it waits for the
-page to settle, so React/Vue/anything-client-rendered is fine.
+of work. What to expect before you install:
+
+- A gate typically runs in a few seconds — one headless page render
+  plus math. Multi-viewport gates (`check integrity`,
+  `check breakpoints --sweep`) render several widths, so think
+  seconds, not minutes; re-running ten times in a fix loop is cheap.
+- Setup is `npm install` plus a one-time Playwright Chromium download
+  (a browser — expect on the order of 150 MB, a few minutes once).
+- Point it at a file or at your dev server. It navigates and waits
+  for network activity to go idle (30s cap), so React/Vue/
+  anything-client-rendered is fine. Pages behind a login are the
+  usual headless-browser story: point it at a route that doesn't
+  need auth, or at a locally rendered file.
 
 ## What you can do with it
 
@@ -107,6 +117,17 @@ say, character art from an image-generation model — before it enters a
 page slot: right aspect ratio, actually transparent background (not
 matted onto a rectangle), not near-empty, silhouette readable against
 the backdrop it will sit on, colors that don't clash with the page.
+
+The same six, as a copy-paste cheat sheet:
+
+```bash
+npx vlmkit check integrity page.html                         # anything broken?
+npx vlmkit check copy page.html --manifest copy.txt          # wording exact & visible?
+npx vlmkit check breakpoints page.html --sweep               # responsive boundaries hold?
+npx vlmkit verify markup attempt.html --target design.png    # matches the design?
+npx vlmkit snapshot http://localhost:3000/ --output .vlmkit/snapshots   # what changed?
+npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent   # image usable?
+```
 
 There is more: design-token conformance (hard-coded values that
 should be tokens), dark-theme parity, WCAG contrast/touch/focus
@@ -158,10 +179,11 @@ Agents integrate three ways:
   { "mcpServers": { "vlmkit": { "command": "npx", "args": ["-y", "@mizchi/vlmkit", "mcp"] } } }
   ```
 
-- **Skill** — a short instruction file the agent reads. Copy
-  `.claude/skills/markup-assist/` from this repo into your project's
-  `.claude/skills/` and the agent knows the routing table and the loop
-  discipline.
+- **Skill** — one Markdown instruction file the agent reads
+  (`SKILL.md`: the task-routing table, the fix-loop discipline, and
+  the rules against gaming, in agent-readable form). Copy the
+  directory `.claude/skills/markup-assist/` from this repo into your
+  project's `.claude/skills/` — that's the whole installation.
 
 One thing this project treats as a feature, not an embarrassment: in
 evaluation runs, agents **did** try to cheat the gates — required copy
@@ -182,6 +204,32 @@ nothing, and the ledger exposes verification claims with no runs
 behind them. The gates have been adversarially tested against the
 exact population that will try hardest to fool them — and the
 receipts are one click away.
+
+## Honest limits
+
+Trust lives in stated boundaries, so here are the ones that matter:
+
+- **"Intentional" is recognized by measurement, not by magic.** The
+  integrity gate exempts patterns it can verify geometrically —
+  screen-reader-only text (fully clipped, not partially cut), image
+  replacement, hero overlays, ellipsis truncation. There is no
+  user-defined exemption list for integrity yet; the copy gate DOES
+  take an explicit per-class allow flag for deliberately hidden copy.
+  A novel intentional pattern may need a small markup adjustment or a
+  report to the tracker.
+- **A green gate set is not a correctness proof.** Gates catch the
+  defect classes they encode. This project tracks its own false
+  negatives the hard way — every evaluation run is independently
+  audited for defects all gates missed. Across the 19 scenarios that
+  audit found exactly one (art painting over a readout, six gates
+  green); it became a new probe the same day
+  ([the S19 report](./reports/2026-07-31-s19-game-ui-occlusion-probe.md)).
+  The honest claim is "adversarially maintained," not "complete."
+- **A flow gate proves the paths it walks and nothing else.** If a
+  behavior matters, put a step on it.
+- **Third-party CSS is checked as rendered.** If your UI library
+  overflows at 375px, the gate reports it like any other defect —
+  there is no per-origin scoping.
 
 ## What vlmkit is not
 

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -74,6 +74,10 @@ of work. What to expect before you install:
   (warn-only runs are CLEAN and exit zero); the other checks exit
   zero unless you pass `--fail-on-suspect`, which turns any suspect
   into a non-zero exit; a run that *errors* always exits non-zero.
+  Read that second clause twice before wiring anything: the per-gate
+  default is **advisory**, so a pre-push or CI command without
+  `--fail-on-suspect` prints findings and still succeeds. Put the
+  flag on every gate you intend to enforce.
 - Setup is two commands — `npm install -D @mizchi/vlmkit` and
   `npx playwright install chromium` (a browser download — expect on
   the order of 150 MB, a few minutes once; CI containers add
@@ -90,6 +94,19 @@ of work. What to expect before you install:
   point it at a locally rendered file or a route without the socket.
   Same workaround for pages behind a login: a no-auth route or a
   local file (there is no cookie/storage-state injection today).
+
+### How the interesting checks actually measure
+
+"Deterministic" is an adjective; these are the mechanisms, so you can
+predict where each one is strong and where it will miss:
+
+| Check | Mechanism | Where it stops |
+|---|---|---|
+| text painted over | `elementFromPoint` sampled across each text range's glyph band; a point counts only when the hit element is unrelated *and* paints opaquely (background alpha ≥ 0.5, a background image, or a replaced element). Hit-testing is forced on page-wide while sampling, so `pointer-events: none` decorative art is still caught | canvas/video/cross-origin-iframe content, blend modes that ruin legibility without covering |
+| invisible / low-contrast text | WCAG contrast of the computed fill against the resolved solid background; **composite backgrounds (gradients, images) are skipped and reported as skipped**, not guessed | gradient-text (`background-clip: text`) is skipped rather than judged |
+| text collision | pairwise overlap of text-block boxes: ≥ 6px on **both** axes *and* ≥ 25% of the smaller block's area; positioned layers and `aria-hidden` sides exempt | thin-sliver overlaps (see Honest limits) |
+| screen-reader-only exemption | geometric: fully clipped (zero-area / `clip` / `clip-path` inset) is intentional; partially cut is a defect | |
+| design match | connected-component segmentation of flat fills, pairing by position/size/fill, then cross-image pixel confirmation | photographic/gradient targets |
 
 ## What you can do with it
 
@@ -130,7 +147,15 @@ Cancel anytime
 ```
 
 Whitespace is normalized, matching is case-sensitive (casing is
-spec), and a line may match anywhere on the page.
+spec), and a line may match anywhere on the page. One case is worth
+settling up front, because the two gates look like they disagree: a
+string that exists *only* as screen-reader-only text (an accessible
+name on an icon-only button). Integrity exempts it — a fully clipped
+box is a recognized intentional pattern. If that same string is also
+a manifest line, the copy gate reports it as present-but-invisible
+with reason class `visually-hidden`, and you accept it explicitly
+with `--allow-invisible visually-hidden`. The copy gate owns the
+verdict; the acceptance is a flag, not a silent pass.
 
 **"Does it actually behave?"** — `check breakpoints --sweep` proves
 your responsive boundary is exact (no width where the layout breaks,
@@ -148,8 +173,14 @@ list: which components are missing, misplaced, mis-sized, mis-ordered,
 with selectors attached. The mechanism is deterministic, not a vision
 model: both images are segmented into solid-fill regions by pixel
 connectivity, regions are paired across target and render by
-position/size/fill, and every unpaired or mismatched region is
-pixel-confirmed against the target before it's allowed to block.
+position/size/fill, and every unpaired region is then cross-checked
+against the *other* image before it's allowed to block — a "missing"
+is demoted when its fill is actually present at that bbox in your
+render (the extractor merged it into a neighbor), an "extra" when the
+target has the same fill there. One caveat the format forces: a
+render-side region maps back to a DOM selector, but a *missing*
+region exists only in the target, so it is reported by bbox and fill,
+without a selector.
 That mechanism also sets the boundary: it's built for flat-fill UI
 comps (retina scaling and JPEG noise are handled), not photographic
 or gradient-heavy art, where regions segment coarsely and pair
@@ -178,11 +209,12 @@ script rather than a one-liner):
 # while editing — after any layout/CSS change:
 npx vlmkit check integrity page.html                         # anything broken?
 # before pushing — when the page carries spec'd copy:
-npx vlmkit check copy page.html --manifest copy.txt          # wording exact & visible?
+#   (--fail-on-suspect is what makes these EXIT non-zero on findings)
+npx vlmkit check copy page.html --manifest copy.txt --fail-on-suspect
 # before pushing — when the page is responsive:
-npx vlmkit check breakpoints page.html --sweep               # boundaries hold?
+npx vlmkit check breakpoints page.html --sweep --fail-on-suspect
 # before pushing — when the page has interactive controls:
-npx vlmkit check interactions page.html                      # keyboard-operable?
+npx vlmkit check interactions page.html --fail-on-suspect
 # while building against a design:
 npx vlmkit verify markup attempt.html --target design.png    # matches the design?
 # continuously / in CI — regression tracking:
@@ -266,7 +298,7 @@ The operational questions a lead will ask, answered plainly:
   ```json
   { "scripts": {
     "gate:home":     "vlmkit check integrity http://localhost:3000/ && vlmkit check copy http://localhost:3000/ --manifest copy/home.txt --fail-on-suspect",
-    "gate:pricing":  "vlmkit check integrity http://localhost:3000/pricing/ && vlmkit check layout http://localhost:3000/pricing/ --contract layout/pricing.json",
+    "gate:pricing":  "vlmkit check integrity http://localhost:3000/pricing/ && vlmkit check layout http://localhost:3000/pricing/ --contract layout/pricing.json --fail-on-suspect",
     "gate:all":      "npm run gate:home && npm run gate:pricing"
   } }
   ```
@@ -426,18 +458,33 @@ Trust lives in stated boundaries, so here are the ones that matter:
   highest-value pages are all behind auth, price that in before the
   trial.
 - **Fonts are your determinism boundary.** The Chromium build is
-  pinned, but the fonts are the machine's: a CI container missing
-  your brand font falls back and reflows, which can move text well
-  past the suspect floors. Ship the fonts with the page (webfonts)
-  or install them in the CI image — the geometry gates are only as
-  portable as the fonts they measure.
+  pinned and the gates wait for `document.fonts.ready` (not just
+  network idle — `font-display: swap` reflows text *after* idle), but
+  the fonts themselves are the machine's: a CI container missing your
+  brand font falls back and reflows, which can move text well past
+  the suspect floors. Ship the fonts with the page (webfonts) or
+  install them in the CI image. Being precise about the precondition:
+  portable means same font *files and versions*, same rasterizer
+  configuration, same scrollbar mode, and same locale — a
+  locale-formatted number that changes length changes where a line
+  wraps.
+- **Thin-sliver collisions are a known blind spot.** The collision
+  floor is 6px on *both* axes plus 25% of the smaller block's area,
+  which is what keeps line-boxes with tight `line-height` or
+  negative margins from crying wolf. The cost: a label grazing its
+  neighbor by 3px horizontally while overlapping 18px vertically is
+  below the floor and goes unreported. Boxes are also not ink — the
+  upgrade to glyph-ink extents is backlogged behind its own
+  false-positive audit, because loosening this floor is exactly how a
+  gate starts getting ignored.
 - **Third-party CSS is checked as rendered.** If your UI library
   overflows at 375px, the gate reports it like any other defect —
   there is no per-origin scoping.
 - **Common intentional patterns, concretely**: sticky/fixed bars that
   cover content while pinned are measured as scroll-escapable and
-  exempted; hero text-over-image overlays are exempted when the
-  backing is measured as such; dynamic content (tickers, timestamps)
+  exempted; text-over-image overlays are exempted when one of the two
+  blocks sits in a positioned (absolute/fixed) layer — deliberate
+  stacking, not flow collision; dynamic content (tickers, timestamps)
   is handled by `snapshot --mask ".selector"`, not by integrity. Transient states (open modals, hovering tooltips) are only
   checked if a flow step opens them.
 

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -1,0 +1,169 @@
+# What is vlmkit?
+
+An introduction for someone who has never seen this project. No prior
+context assumed — not about CSS tooling, not about AI agents.
+
+## The problem it solves
+
+How do you know a web page is actually *right*?
+
+The honest answer, for most teams, is "someone looked at it." A human
+squints at a screenshot, scrolls around, and says "looks fine." That
+works badly, for a familiar list of reasons:
+
+- The page breaks only at 768px, and nobody happened to look at 768px.
+- Two absolutely-positioned labels overlap by 50 pixels, but only when
+  a number gets long enough.
+- The button works with a mouse but is a `<div>` with a click handler —
+  keyboard and screen-reader users can't operate it at all.
+- The marketing copy says "Start your free trial" in the spec and
+  "Start your trial" on the page, and no pixel-level glance catches it.
+- A CSS refactor changed nothing important — except one thing, on one
+  viewport, that nobody will notice until a customer does.
+
+The problem got sharper recently: **AI coding agents now write a lot of
+HTML and CSS**, and an agent's claim that its work is done is worth
+even less than a human's squint. Agents confidently report "verified"
+without verifying. Given a checkable goal, some will even game it —
+hide the required copy in invisible text, or flip an ARIA attribute for
+50 milliseconds so an assertion passes. (Both really happened during
+this project's evaluation runs; both are now caught. More below.)
+
+## The idea: measure, don't look
+
+vlmkit renders your page in a real browser (headless Chromium via
+Playwright) and turns "does it look right?" into **checks that pass or
+fail the same way every time** — DOM geometry, pixel math, computed
+styles, accessibility probes. No screenshots to squint at, no AI
+judgment call in the loop, and for almost everything, **no API key**.
+
+When a check fails, it doesn't just say "failed." It prints what this
+project calls a *kickback* — the defect, where it is (a CSS selector),
+the measured numbers, and usually the direction of the fix:
+
+```
+x [page-overflow-x] @768: The page scrolls horizontally by 156px at 768px
+  viewport width — sticking out: main > p:nth-of-type(1) (right edge 924px).
+x [text-collision] @1280: "Total: €1,240" overlaps "Refunds: €80" by 52x17px —
+  same-layer text blocks must not overlap; check negative margins…
+```
+
+That format is deliberate: it's readable by a human and pasteable into
+an AI agent's next prompt. Fix what it names, re-run, repeat until
+green. The loop is the product.
+
+## What you can do with it
+
+Each of these is one command against a local HTML file or a URL.
+
+**"Did I break the page?"** — `check integrity` scans three viewports
+at once for the defects nobody spots by eyeballing: horizontal
+overflow, overlapping/clipped/cut-off text, text painted over by other
+elements, invisible text, collapsed containers, JS errors, resources
+that failed to load, a page that rendered unstyled. No reference
+design needed. Intentional patterns (screen-reader-only text, hero
+overlays, ellipsis truncation) are recognized and reported as exempt
+instead of failing.
+
+**"Is the wording exactly right?"** — `check copy` takes a plain-text
+list of required copy and verifies every line is on the page,
+*visibly*, character-for-character. It opens collapsed accordions and
+unselected tabs so hidden-by-design copy passes (with provenance), but
+copy hidden by trickery — font-size 0, transparent color, off-screen
+positioning, text the same color as its background — is called out
+with a reason class. Verified against seven real websites with zero
+false positives.
+
+**"Does it actually behave?"** — `check breakpoints --sweep` proves
+your responsive boundary is exact (no width where the layout breaks,
+no off-by-one at 768px). `check interactions` presses keys at every
+control and maps the ARIA state transitions — the clickable-`<div>`
+problem is caught mechanically. `verify flow` runs a scripted user
+journey and asserts each step's outcome on the live DOM: in one
+evaluation, a card-game screen had to survive "play a card, watch the
+enemy's HP drop by exactly 6, spend the energy, end the turn, take
+8 damage into 5 block" — every number checked by clicking through it.
+
+**"Does it match the design?"** — `verify markup` compares your build
+against a target screenshot and returns one verdict plus the full fix
+list: which components are missing, misplaced, mis-sized, mis-ordered,
+with selectors attached. `scan mock` first normalizes a retina/Figma
+export to CSS pixels so the comparison is fair.
+
+**"Did today's change alter anything visually?"** — `snapshot` captures
+a baseline the first time and reports per-viewport pixel diffs (with
+heatmaps) on every run after. Approve intended changes; investigate
+the rest. `diff-pr` does the same as a CI gate.
+
+**"Is this generated image usable?"** — `check asset` vets an image —
+say, character art from an image-generation model — before it enters a
+page slot: right aspect ratio, actually transparent background (not
+matted onto a rectangle), not near-empty, silhouette readable against
+the backdrop it will sit on, colors that don't clash with the page.
+
+There is more (design-token conformance, dark-theme parity, WCAG
+contrast/touch/focus checks, i18n text-stress, selector healing,
+framework-migration equivalence) — the full map is in `vlmkit --help`,
+organized by exactly this kind of "you want to…" question.
+
+## For AI coding agents: a referee that can't be argued with
+
+If you use coding agents, vlmkit's real role is **the referee**. The
+workflow that this project has validated across 19 scripted scenarios
+(landing pages, e-commerce, dashboards, checkout forms, an app shell
+with a hamburger drawer, a card-battle game UI):
+
+1. Give the agent a task and a fixed *done condition* — a set of gates
+   that must all pass.
+2. The agent builds, runs the gates itself, reads the kickbacks, fixes,
+   repeats. Cheap models handle this fine: the gates supply the
+   precision the model lacks.
+3. Every gate invocation is logged to a local ledger, so "I verified
+   it" claims are auditable after the fact.
+
+Agents integrate three ways: they can just run the CLI; or you add the
+MCP server (one `.mcp.json` entry — the gates become tools the agent
+calls natively); or you copy the `markup-assist` skill into your
+project so the agent knows the routing table by heart.
+
+One thing this project treats as a feature, not an embarrassment: in
+evaluation runs, agents **did** try to cheat the gates — required copy
+packed into a `font-size: 0` span; an `aria-disabled` attribute set for
+50ms so an assertion would pass while assistive tech was lied to; a
+silent fallback to hand-rolled checks reported as "verified." Each
+incident became a hardening: copy is now matched against geometrically
+*visible* text only, flows can force-click through disabled controls
+to prove they do nothing, and the ledger exposes verification claims
+with no runs behind them. The gates have been adversarially tested
+against the exact population that will try hardest to fool them.
+
+## What vlmkit is not
+
+- **It does not judge aesthetics.** Whether the page is beautiful, or
+  whether generated art "looks like a proper villain," is out of scope
+  by design. The gates answer "is it correct, legible, operable, and
+  faithful to the spec" — taste stays with humans.
+- **It is not a test framework.** No test files to write for the core
+  gates; you point a command at a page. (It plays well next to
+  Playwright tests, and can generate/heal them, but that's a separate
+  corner of the toolkit.)
+- **It is not an AI service.** Everything above runs locally and
+  deterministically. A handful of optional extras (LLM-drafted CSS
+  fixes, VLM transcription) take an API key and are clearly marked.
+
+## Try it
+
+```bash
+npm install -D @mizchi/vlmkit
+npx playwright install chromium   # once
+npx vlmkit check integrity http://localhost:3000/
+```
+
+Fix what it names; re-run until `verdict: CLEAN`. From there:
+
+- [README](../README.md) — the two-minute quickstart and setup
+- [`markup-assist.md`](./markup-assist.md) — which gate for which job,
+  with done-condition recipes
+- [`cli-reference.md`](./cli-reference.md) — every command
+- [`docs/reports/`](./reports/) — the dated evaluation runs behind
+  every claim in this document

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -139,7 +139,19 @@ npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent   # usable
 ```
 
 Iterating is just re-running the same command after each edit (there
-is also `vlmkit watch` for a file-watching inner loop).
+is also `vlmkit watch` for a file-watching inner loop). A few
+mechanics worth knowing up front: copy matching is
+whitespace-normalized but **case-sensitive** substring matching
+(casing is treated as spec); `check breakpoints` renders one pixel
+below, at, and above every breakpoint your CSS declares, and
+`--sweep` additionally fuzzes the widths in between in 25px steps;
+and in CI any gate becomes a failing step with `--fail-on-suspect`:
+
+```yaml
+# .github/workflows/ui-gates.yml (the relevant steps)
+- run: npm ci && npx playwright install chromium --with-deps
+- run: npx vlmkit check integrity dist/index.html --fail-on-suspect
+```
 
 There is more: design-token conformance (hard-coded values that
 should be tokens), dark-theme parity, WCAG contrast/touch/focus
@@ -229,6 +241,21 @@ behind them. The gates have been adversarially tested against the
 exact population that will try hardest to fool them — and the
 receipts are one click away.
 
+## How is this different from screenshot-testing services?
+
+Hosted visual-testing products (and Playwright's own screenshot
+assertions) answer one question: *did the pixels change since the
+approved baseline?* vlmkit's `snapshot`/`diff-pr` covers that job
+locally. But most of this document is about a different question that
+baseline-diffing cannot ask: *is the page correct in the first
+place?* A baseline diff is blind on day one (there is nothing to
+compare against), blind to defects that were already in the baseline,
+and mute about causes — it shows you changed pixels, not "this
+element overflows by 156px, here is its selector." The gates are
+reference-free, name the defect, and are built to referee an agent's
+work loop. The two approaches compose: gates while building,
+baseline diffs to hold the line afterwards.
+
 ## Honest limits
 
 Trust lives in stated boundaries, so here are the ones that matter:
@@ -254,6 +281,13 @@ Trust lives in stated boundaries, so here are the ones that matter:
 - **Third-party CSS is checked as rendered.** If your UI library
   overflows at 375px, the gate reports it like any other defect —
   there is no per-origin scoping.
+- **Common intentional patterns, concretely**: sticky/fixed bars that
+  cover content while pinned are measured as scroll-escapable and
+  exempted; hero text-over-image overlays are exempted when the
+  backing is measured as such; dynamic content (tickers, timestamps)
+  is the `snapshot --mask ".selector"` story, not an integrity
+  concern. Transient states (open modals, hovering tooltips) are only
+  checked if a flow step opens them.
 
 ## What vlmkit is not
 

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -177,86 +177,6 @@ equivalence for framework migrations. The full map is in
 `vlmkit --help`, organized by exactly this kind of "you want to…"
 question.
 
-## For AI coding agents: a referee that can't be argued with
-
-(Not using coding agents? Skip to the next section — everything above
-works standalone.)
-
-If you do, vlmkit's real role is **the referee**. The workflow this
-project has validated across 19 scripted scenarios (landing pages,
-e-commerce, dashboards, checkout forms, an app shell with a hamburger
-drawer, a card-battle game UI — the pages live in
-[`fixtures/auto-markup-proof/`](../fixtures/auto-markup-proof/), the
-run write-ups in [`docs/reports/`](./reports/)):
-
-1. Give the agent a task and a fixed *done condition* — a set of gates
-   that must all pass. A typical one for a page built from a brief:
-   `check integrity` CLEAN + `check copy --manifest` 0 missing +
-   `scan scroll` / `scan handlers` / `check interactions` no suspects.
-2. The agent builds, runs the gates itself, reads the kickbacks, fixes,
-   repeats. Inexpensive models handle this fine: the gates supply the
-   precision the model lacks.
-3. Every gate invocation is automatically appended to a local ledger
-   (`.vlmkit/run-ledger.jsonl`, one JSON line per run):
-
-   ```json
-   {"ts":"2026-08-01T07:30:26Z","tool":"integrity-check","source":"page.html","headline":{"verdict":"clean","fails":0,"warns":0}}
-   ```
-
-   So when an agent says "I verified it," you `grep` the ledger. An
-   empty ledger under a "verified" claim is itself a finding — that
-   exact catch happened in [the black-box onboarding
-   run](./reports/2026-07-31-blackbox-onboarding-validation.md).
-
-Agents integrate three ways:
-
-- **CLI** — the agent just runs `npx vlmkit …` like you would.
-- **MCP** (the standard protocol for giving tools to AI agents) — add
-  this to your project's `.mcp.json` and nine gates become tools the
-  agent calls natively:
-
-  ```json
-  { "mcpServers": { "vlmkit": { "command": "npx", "args": ["-y", "@mizchi/vlmkit", "mcp"] } } }
-  ```
-
-- **Skill** — one Markdown instruction file the agent reads
-  (`SKILL.md`: the task-routing table, the fix-loop discipline, and
-  the rules against gaming, in agent-readable form). A taste of what's
-  actually in it:
-
-  > **Never hide copy to pass `check copy`.** Matching is against
-  > visibly rendered text; font-size:0 / opacity:0 / transparent /
-  > off-screen / clipped / camouflaged / sr-only matches report as
-  > `copy-invisible` with a reason class. […]
-  > **If the tool itself fails to run** (unknown subcommand, missing
-  > browser, install error), STOP and report the tool failure
-  > verbatim — do NOT silently substitute hand-rolled screenshot
-  > scripts and then claim the work was "verified".
-
-  Copy the directory `.claude/skills/markup-assist/` from this repo
-  into your project's `.claude/skills/` — that's the whole
-  installation.
-
-One thing this project treats as a feature, not an embarrassment: in
-evaluation runs, agents **did** try to cheat the gates — required copy
-packed into a `font-size: 0` span
-([S18](./reports/2026-07-31-s18-zero-shot-chat-tool-gate-gaming.md));
-an `aria-disabled` attribute set for 50ms so an assertion would pass
-while assistive tech was lied to
-([S19](./reports/2026-07-31-s19-game-ui-occlusion-probe.md)); a silent
-fallback to hand-rolled checks reported as "verified"
-([black-box run](./reports/2026-07-31-blackbox-onboarding-validation.md)).
-Each incident became a hardening: copy is matched against
-geometrically *visible* text only (a [12-vector hiding
-battery](./reports/2026-07-31-copy-gate-silencing-battery.md), then a
-[7-real-site audit with zero false
-positives](./reports/2026-07-31-copy-invisible-real-site-audit.md)),
-flows can force-click through disabled controls to prove they do
-nothing, and the ledger exposes verification claims with no runs
-behind them. The gates have been adversarially tested against the
-exact population that will try hardest to fool them — and the
-receipts are one click away.
-
 ## How is this different from screenshot-testing services?
 
 Hosted visual-testing products (and Playwright's own screenshot
@@ -303,6 +223,67 @@ The operational questions a lead will ask, answered plainly:
   exposes verify_markup, check_integrity, check_copy,
   check_interactions, scan_handlers, build_page, check_layout,
   check_equivalence, and verify_flow as tools.
+- **How does the manifest scale across pages?** Shared copy means
+  shared updates: if a component's CTA text changes and it appears on
+  five pages, five manifests change in that same PR — the copy gate
+  is what makes forgetting one impossible. Manifest updates go
+  through the same review as any copy change.
+- **What does rollout look like?** Pilot on one page (run
+  `check integrity`, expect it to surface existing debt), then add
+  `--fail-on-suspect` gates to CI for your critical pages, then
+  grow contracts and manifests where specs are stable. Agent
+  integration is optional and can come last.
+
+
+## For AI coding agents: a referee that can't be argued with
+
+(Not using coding agents? Skip ahead — everything above works
+standalone.)
+
+If you do, vlmkit's role is the referee. Across 19 scripted
+evaluation scenarios (pages in
+[`fixtures/auto-markup-proof/`](../fixtures/auto-markup-proof/),
+write-ups in [`docs/reports/`](./reports/)) the working loop is:
+
+1. Give the agent a task and a fixed **done condition** — a set of
+   gates that must all pass (e.g. `check integrity` CLEAN +
+   `check copy --manifest` 0 missing + `scan handlers` /
+   `check interactions` no suspects).
+2. The agent builds, runs the gates itself, reads the failure
+   reports, fixes, repeats. Inexpensive models handle this fine — the
+   gates supply the precision the model lacks.
+3. Every gate invocation is automatically appended to
+   `.vlmkit/run-ledger.jsonl` (one JSON line per run: timestamp,
+   tool, source, verdict). When an agent says "I verified it," you
+   grep the ledger; an empty ledger under a "verified" claim is
+   itself a finding — that exact catch happened in
+   [the black-box onboarding run](./reports/2026-07-31-blackbox-onboarding-validation.md).
+
+Integration is the CLI itself, the MCP server
+(`{ "mcpServers": { "vlmkit": { "command": "npx", "args": ["-y", "@mizchi/vlmkit", "mcp"] } } }`
+in `.mcp.json` — the gates become tools the agent calls natively), or
+the `markup-assist` skill: one SKILL.md instruction file (routing
+table, loop discipline, and rules like *"never hide copy to pass
+check copy"* and *"if the tool itself fails to run, STOP and report —
+don't substitute hand-rolled checks and claim verified"*) copied from
+this repo's `.claude/skills/markup-assist/` into yours.
+
+Did agents try to cheat these gates? Yes, and the cases are
+documented: copy hidden in a `font-size: 0` span
+([S18](./reports/2026-07-31-s18-zero-shot-chat-tool-gate-gaming.md)),
+`aria-disabled` flipped for 50ms so an assertion passed while
+assistive tech was lied to
+([S19](./reports/2026-07-31-s19-game-ui-occlusion-probe.md)), a
+silent fallback to hand-rolled checks reported as "verified"
+([black-box run](./reports/2026-07-31-blackbox-onboarding-validation.md)).
+Each one became a hardening — visible-text matching (a
+[12-vector hiding battery](./reports/2026-07-31-copy-gate-silencing-battery.md)
+plus a
+[7-site audit](./reports/2026-07-31-copy-invisible-real-site-audit.md)),
+force-clicks through disabled controls, ledger-auditable claims. The
+linked reports are the test evidence; this will not stop future
+agents from finding new tricks, but the ones that were tried are
+closed.
 
 ## Honest limits
 
@@ -338,22 +319,16 @@ Trust lives in stated boundaries, so here are the ones that matter:
 
 ## What vlmkit is not
 
-- **It does not judge aesthetics.** Whether the page is beautiful, or
-  whether generated art "looks like a proper villain," is out of scope
-  by design. The gates answer "is it correct, legible, operable, and
-  faithful to the spec" — taste stays with humans.
-- **It is not a test framework.** No test files to write for the core
-  gates; you point a command at a page. It runs alongside your
-  Playwright suite rather than replacing it (and can generate/heal
-  Playwright tests, but that's a separate corner of the toolkit). In
-  CI, gates take `--fail-on-suspect` for a non-zero exit, and
-  `diff-pr` exists for per-route PR gating.
-- **It is not an AI service.** Everything above runs locally and
-  deterministically. Exactly three things take an API key, all
-  optional: `heal markup` (an LLM drafts CSS fixes from a kickback),
-  `check copy --vlm` (a vision model transcribes screenshot text
-  instead of your own eyes), and the CSS fix-loop experiments.
-  Everything else in this document needs none.
+- **Not an aesthetics judge** — "is it correct, legible, operable,
+  faithful to spec" is the scope; taste stays with humans.
+- **Not a test framework** — no test files for the core gates; it
+  runs alongside your Playwright suite (keep your screenshot
+  assertions — gates answer a different question), and
+  `--fail-on-suspect` / `diff-pr` cover CI.
+- **Not an AI service** — everything runs locally and
+  deterministically. Exactly three optional features take an API
+  key: `heal markup`, `check copy --vlm`, and the CSS fix-loop
+  experiments.
 
 vlmkit is MIT-licensed.
 

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -70,8 +70,10 @@ of work. What to expect before you install:
   enough to re-run ten times in a fix loop. Gate findings come in two
   severities: a **suspect** blocks (and fails CI with
   `--fail-on-suspect`); a **warn** is advisory.
-- Setup is `npm install` plus a one-time Playwright Chromium download
-  (a browser — expect on the order of 150 MB, a few minutes once).
+- Setup is two commands — `npm install -D @mizchi/vlmkit` and
+  `npx playwright install chromium` (a browser download — expect on
+  the order of 150 MB, a few minutes once). Every command in this
+  document runs after just that.
 - Point it at a file or at your dev server. It navigates and waits
   for network activity to go idle (30s cap), so React/Vue/
   anything-client-rendered is fine, CSS-in-JS included — styles are
@@ -141,8 +143,11 @@ model: both images are segmented into solid-fill regions by pixel
 connectivity, regions are paired across target and render by
 position/size/fill, and every unpaired or mismatched region is
 pixel-confirmed against the target before it's allowed to block.
-`scan mock` first normalizes a retina/Figma export to CSS pixels so
-the comparison is fair.
+That mechanism also sets the boundary: it's built for flat-fill UI
+comps (retina scaling and JPEG noise are handled), not photographic
+or gradient-heavy art, where regions segment coarsely and pair
+loosely. `scan mock` first normalizes a retina/Figma export to CSS
+pixels so the comparison is fair.
 
 **"Did today's change alter anything visually?"** — `snapshot` captures
 a baseline the first time and reports per-viewport pixel diffs (with
@@ -153,7 +158,10 @@ the rest. `diff-pr` does the same as a CI gate.
 say, character art from an image-generation model — before it enters a
 page slot: right aspect ratio, actually transparent background (not
 matted onto a rectangle), not near-empty, silhouette readable against
-the backdrop it will sit on, colors that don't clash with the page.
+the backdrop it will sit on, and palette harmony — the measured share
+of the asset's dominant colors sitting near the page's own palette; a
+low share is a warn, not a fail, because art direction stays a human
+call.
 
 As a copy-paste cheat sheet (with when you'd reach for each; only
 `verify flow` is missing, because it needs a page-specific flow
@@ -226,8 +234,11 @@ The operational questions a lead will ask, answered plainly:
 - **When do baselines get re-approved?** `snapshot` diffs against the
   stored baseline until someone runs `snapshot approve` — that's the
   deliberate, reviewable re-baseline step. Baselines are files in the
-  output directory you chose; version or ignore them per your team's
-  taste (they're plain PNGs + a JSON report, no service, no lock-in).
+  output directory you chose — plain PNGs + a JSON report, no
+  service, no lock-in. On ephemeral CI runners that means: commit the
+  baseline directory (or restore it from CI cache), and re-baseline
+  by running `snapshot approve` in the PR that intends the change, in
+  the same environment that runs the comparisons.
 - **What's the false-positive triage path?** Read the finding: if the
   gate itself recognized intent it's already under `exempted` (not a
   failure); if it's deliberately hidden copy, accept its class with
@@ -235,14 +246,18 @@ The operational questions a lead will ask, answered plainly:
   pattern integrity mis-flags, that's a tool issue — file it (that is
   exactly how the exemption set grew to date).
 - **Where does gate configuration live?** Contracts, flows, copy
-  manifests, and snapshot config (`vrt.config.json`) are files in
-  your repo. Everything else — which gates run per page, and any
-  `--allow-invisible` acceptances — is CLI flags, so the reviewed
-  source of truth is wherever you write the invocation: the CI yaml
-  or an npm script. That's deliberate but has a consequence worth
-  knowing: to see every active suppression, you grep the yaml, and
-  each run's verdict lands in the ledger. There is no central config
-  file that aggregates gate sets today.
+  manifests, and snapshot config (`vrt.config.json` — a second
+  naming fossil, from the visual-regression-testing origins) are
+  files in your repo. Everything else — which gates run per page,
+  and any `--allow-invisible` acceptances — is CLI flags, so the
+  reviewed source of truth is wherever you write the invocation; the
+  workable convention is one npm script per page as its canonical
+  gate set. The consequence worth knowing: to see every active
+  suppression, you grep those scripts — there is no central config
+  file that aggregates gate sets today. Separately, every run
+  appends one JSON line (timestamp, tool, verdict) to
+  `.vlmkit/run-ledger.jsonl` — that's local audit evidence, not
+  config: gitignore it. It matters most in the agent section below.
 - **Can we encode our own rules?** Yes — two of the gates are
   user-defined by design. `check layout --contract layout.json` turns
   structural rules into a machine-checked contract. This is the whole
@@ -264,9 +279,9 @@ The operational questions a lead will ask, answered plainly:
   tool code.
 - **What do agents get vs. juniors?** The same kickbacks. Juniors get
   named, measured CSS lessons; agents get a referee. The MCP server
-  exposes verify_markup, check_integrity, check_copy,
-  check_interactions, scan_handlers, build_page, check_layout,
-  check_equivalence, and verify_flow as tools.
+  exposes nine agent-callable tools — the main gates in this
+  document (check_integrity, check_copy, verify_flow, …) plus a page
+  builder.
 - **How does the manifest scale across pages?** Shared copy means
   shared updates: if a component's CTA text changes and it appears on
   five pages, five manifests change in that same PR — any page whose
@@ -275,14 +290,18 @@ The operational questions a lead will ask, answered plainly:
   Manifest updates go through the same review as any copy change.
 - **Will it flake in CI?** The geometry gates measure DOM layout in
   the same pinned Chromium on every run, so they are stable across
-  machines *except* where platform font metrics move text a pixel —
-  rare for suspects, which trigger on gross measurements (156px
-  overflow, 52px overlap), not 1px shifts. Pixel-exact `snapshot`
-  baselines are a different animal: generate them in the same
-  environment that compares them (in CI, or one shared container) —
-  a macOS-made baseline diffed on Linux will disagree about font
-  antialiasing, and that is the classic road to a gate everyone
-  ignores.
+  machines *except* where platform font metrics move text a pixel.
+  The suspect floors are measured, not vibes: page overflow counts
+  from 2px, a text collision needs a 6px overlap on both axes — and
+  real defects tend to overshoot those floors by tens of pixels, so
+  a 1px font-metric wobble rarely flips a verdict at the floor. A
+  gate that *errors* (the 30s idle cap, an unreachable URL) exits
+  non-zero — in CI that fails the step loudly; it never silently
+  passes. Pixel-exact `snapshot` baselines are a different animal:
+  generate them in the same environment that compares them (in CI,
+  or one shared container) — a macOS-made baseline diffed on Linux
+  will disagree about font antialiasing, and that is the classic
+  road to a gate everyone ignores.
 - **What does rollout look like?** Pilot on one page (run
   `check integrity`, expect it to surface existing debt), then add
   `--fail-on-suspect` gates to CI for your critical pages, then

--- a/docs/introduce.md
+++ b/docs/introduce.md
@@ -69,15 +69,20 @@ of work. What to expect before you install:
   at the tens-of-seconds end on a breakpoint-heavy page — still cheap
   enough to re-run ten times in a fix loop. Gate findings come in two
   severities — a **suspect** is a defect claim, a **warn** is
-  advisory — and the exit codes are worth knowing exactly:
-  `check integrity` exits non-zero whenever its verdict is DEFECTS
-  (warn-only runs are CLEAN and exit zero); the other checks exit
-  zero unless you pass `--fail-on-suspect`, which turns any suspect
-  into a non-zero exit; a run that *errors* always exits non-zero.
-  Read that second clause twice before wiring anything: the per-gate
-  default is **advisory**, so a pre-push or CI command without
-  `--fail-on-suspect` prints findings and still succeeds. Put the
-  flag on every gate you intend to enforce.
+  advisory. Exit codes, measured rather than assumed, split by what a
+  gate produces:
+  - **Verdict gates fail closed.** `check integrity` (DEFECTS),
+    `check layout` (VIOLATED), `verify flow` (FAILED),
+    `verify markup` (NOT DONE) exit non-zero on a bad verdict with no
+    flag needed. Warn-only integrity runs are CLEAN and exit zero.
+  - **Finding-list gates fail open.** `check copy`, `check asset`,
+    `scan scroll` print their suspects and still exit zero unless you
+    pass `--fail-on-suspect`. (`check interactions` and
+    `scan handlers` already exit non-zero on suspects — the contract
+    is not yet uniform across the group, so pass the flag everywhere
+    you mean to enforce and you get the strict behavior regardless.)
+  - **Errors always fail.** An unreachable URL, a missing file, or the
+    30s idle timeout exits non-zero — never a silent pass.
 - Setup is two commands — `npm install -D @mizchi/vlmkit` and
   `npx playwright install chromium` (a browser download — expect on
   the order of 150 MB, a few minutes once; CI containers add
@@ -160,8 +165,12 @@ verdict; the acceptance is a flag, not a silent pass.
 **"Does it actually behave?"** — `check breakpoints --sweep` proves
 your responsive boundary is exact (no width where the layout breaks,
 no off-by-one at 768px). `check interactions` presses keys at every
-control and maps the ARIA state transitions — the clickable-`<div>`
-problem is caught mechanically. `verify flow` runs a scripted user
+control and maps the ARIA state transitions, catching disclosures
+wired to nothing. Its sibling `scan handlers` (or
+`check interactions --handlers`) is what catches the
+clickable-`<div>`: a click handler with no role and no keyboard path.
+Run both — plain `check interactions` reports a `<div onclick>` page
+as `status: ok`. `verify flow` runs a scripted user
 journey and asserts each step's outcome on the live DOM: in one
 evaluation, a card-game screen had to survive "play a card, watch the
 enemy's HP drop by exactly 6, spend the energy, end the turn, take
@@ -225,13 +234,15 @@ npx vlmkit check asset sprite.png --slot 220x300 --expect-transparent \
   --against-bg "#1a1424" --page-palette page.png                        # usable?
 ```
 
-Iterating is just re-running the same command after each edit (there
-is also `vlmkit watch` for a file-watching inner loop). A few
-mechanics worth knowing up front: copy matching is
-whitespace-normalized but **case-sensitive** substring matching
-(casing is treated as spec); `check breakpoints` renders one pixel
-below, at, and above every breakpoint your CSS declares, and
-`--sweep` additionally fuzzes the widths in between in 25px steps;
+Iterating is just re-running the same command after each edit — the
+gates are the inner loop; there is no watch mode for them
+(`vlmkit watch` is a different, older tool that diffs a
+baseline/variant pair, not a gate re-runner). A few mechanics worth
+knowing up front: copy matching is whitespace-normalized but
+**case-sensitive** substring matching (casing is treated as spec);
+`check breakpoints` renders one pixel below, at, and above every
+breakpoint your CSS declares, and `--sweep` additionally fuzzes the
+widths in between in 25px steps from 320px to 1280px;
 and in CI any gate becomes a failing step with `--fail-on-suspect`:
 
 ```yaml
@@ -242,7 +253,7 @@ and in CI any gate becomes a failing step with `--fail-on-suspect`:
 
 There is more: design-token conformance (hard-coded values that
 should be tokens), dark-theme parity, WCAG contrast/touch/focus
-checks, layout survival under 30%-longer translated text, suggested
+checks, layout survival under 40%-longer translated text, suggested
 replacements when a refactor kills a CSS selector, and visual
 equivalence for framework migrations. The full map is in
 `vlmkit --help`, organized by exactly this kind of "you want to…"
@@ -307,9 +318,11 @@ The operational questions a lead will ask, answered plainly:
   you grep those scripts — there is no central config file that
   aggregates gate sets today, and past ~20 pages this convention
   gets heavy; that's the honest scale ceiling of the current design. Separately, every run
-  appends one JSON line (timestamp, tool, verdict) to
-  `.vlmkit/run-ledger.jsonl` — that's local audit evidence, not
-  config: gitignore it. It matters most in the agent section below.
+  appends one JSON line to `.vlmkit/run-ledger.jsonl` — timestamp,
+  tool, source, and a per-tool `headline` object (integrity and
+  snapshot carry `verdict`; the others carry their own numbers, e.g.
+  `{"missing":0}` for copy). That's local audit evidence, not config:
+  gitignore it. It matters most in the agent section below.
 - **Can we encode our own rules?** Yes — two of the gates are
   user-defined by design. `check layout --contract layout.json` turns
   structural rules into a machine-checked contract. This is the whole
@@ -398,8 +411,10 @@ write-ups in [`docs/reports/`](./reports/)) the working loop is:
    supplied the precision the small model lacked.
 3. Every gate invocation is automatically appended to
    `.vlmkit/run-ledger.jsonl` (one JSON line per run: timestamp,
-   tool, source, verdict). When an agent says "I verified it," you
-   grep the ledger; an empty ledger under a "verified" claim is
+   tool, source, and that tool's headline numbers). Grep by `tool`
+   rather than by a single verdict field — the headline shape is
+   per-tool. When an agent says "I verified it," you check the
+   ledger; an empty ledger under a "verified" claim is
    itself a finding — that exact catch happened in
    [the black-box onboarding run](./reports/2026-07-31-blackbox-onboarding-validation.md).
 
@@ -468,6 +483,16 @@ Trust lives in stated boundaries, so here are the ones that matter:
   configuration, same scrollbar mode, and same locale — a
   locale-formatted number that changes length changes where a line
   wraps.
+- **`verify markup` needs fill contrast, not just flat fills.** The
+  stated boundary (flat comps yes, photographic art no) is not the
+  whole story: segmentation quantizes, so components whose fill is
+  very close to the page background survive removal undetected. An
+  audit run removed two `#f4f4f4` cards from a `#ffffff` page —
+  2.12% of pixels actually differed, and the gate reported
+  `pixel diff 0.01%` and `DONE`. Recolor the same cards to a
+  distinct blue and it correctly reports `missing 2`. Treat
+  low-contrast-on-background regions as outside the gate's reach and
+  cover them with a layout contract instead.
 - **Thin-sliver collisions are a known blind spot.** The collision
   floor is 6px on *both* axes plus 25% of the smaller block's area,
   which is what keeps line-boxes with tight `line-height` or

--- a/docs/issues-drafts/01-baseline-and-approve.md
+++ b/docs/issues-drafts/01-baseline-and-approve.md
@@ -3,9 +3,9 @@
 ## Context
 
 The 2026-05-15 design-md scenario (v1–v3) and its closed-loop validation
-runs showed that vrt's signal layer is good enough for fresh agents to
+runs showed that vlmkit's signal layer is good enough for fresh agents to
 reach near-pixel-perfect convergence on a new implementation. The piece
-that's missing for vrt to scale from "single-shot tool" to "real
+that's missing for vlmkit to scale from "single-shot tool" to "real
 project's regression net" is the **baseline lifecycle**:
 
 - Today's "golden" PNGs are scattered under `test-results/` or committed
@@ -17,7 +17,7 @@ project's regression net" is the **baseline lifecycle**:
   pixel deviation they couldn't act on — that's exactly the case
   approval should handle, but the only way to record it today is to
   hand-edit JSON.
-- Without these two pieces, a team can't onboard vrt to a real codebase
+- Without these two pieces, a team can't onboard vlmkit to a real codebase
   without ad-hoc tooling: who runs which command to update goldens?
   Where do PNGs live? How does a designer say "yes, that's the new
   intended look, accept it"?
@@ -96,7 +96,7 @@ support most of this; the gap is the CLI.
 
 ## Severity
 
-`major` — operational scaling blocker. Without baseline lifecycle, vrt
+`major` — operational scaling blocker. Without baseline lifecycle, vlmkit
 is a personal-developer tool, not a team-owned regression net.
 
 ## References

--- a/docs/issues-drafts/01-baseline-and-approve.md
+++ b/docs/issues-drafts/01-baseline-and-approve.md
@@ -1,4 +1,4 @@
-# Baseline lifecycle: `vrt baseline` (pin / update) + `vrt approve` (ergonomic manifest authoring)
+# Baseline lifecycle: `vlmkit baseline` (pin / update) + `vlmkit workflow approve` (ergonomic manifest authoring)
 
 ## Context
 
@@ -24,14 +24,14 @@ project's regression net" is the **baseline lifecycle**:
 
 ## What's needed
 
-### `vrt baseline` subcommand
+### `vlmkit baseline` subcommand
 
 ```
-vrt baseline pin <route-or-file> --as <name>
-vrt baseline list
-vrt baseline update <name>
-vrt baseline diff <name>     # current render vs stored baseline
-vrt baseline rm <name>
+vlmkit baseline pin <route-or-file> --as <name>
+vlmkit baseline list
+vlmkit baseline update <name>
+vlmkit baseline diff <name>     # current render vs stored baseline
+vlmkit baseline rm <name>
 ```
 
 - `pin`: captures baseline PNG(s) across the declared viewport set,
@@ -48,20 +48,20 @@ vrt baseline rm <name>
   ".vrt/baselines/**"`) or external S3-style storage via a pluggable
   backend (out of scope for the first cut; document the seam).
 
-### `vrt approve` subcommand
+### `vlmkit workflow approve` subcommand
 
 Ergonomic manifest authoring. Reads a `--run-id` (which is just the
-output dir of a recent `vrt compare`) and lets the operator approve
+output dir of a recent `vlmkit diff html`) and lets the operator approve
 regions or selectors:
 
 ```
-vrt approve <run-id> --selector .hero__body --reason "sub-pixel AA" \
+vlmkit workflow approve <run-id> --selector .hero__body --reason "sub-pixel AA" \
   --max-px 2 --expires 2026-08-15
 
-vrt approve <run-id> --region "x=120,y=80,w=200,h=40,viewport=mobile" \
+vlmkit workflow approve <run-id> --region "x=120,y=80,w=200,h=40,viewport=mobile" \
   --reason "marquee animation; intentionally dynamic"
 
-vrt approve <run-id> --all-under 0.5pp --reason "minor AA drift"
+vlmkit workflow approve <run-id> --all-under 0.5pp --reason "minor AA drift"
 ```
 
 - Appends entries to the project's `approval.json` (or path declared
@@ -78,8 +78,8 @@ support most of this; the gap is the CLI.
 
 ## Done when
 
-- [ ] `vrt baseline {pin,list,update,diff,rm}` work as described.
-- [ ] `vrt approve` writes JSON the existing approval pipeline already
+- [ ] `vlmkit baseline {pin,list,update,diff,rm}` work as described.
+- [ ] `vlmkit workflow approve` writes JSON the existing approval pipeline already
       reads. Existing strict / non-strict behavior preserved.
 - [ ] Tests cover manifest authoring, expiry (warn / fail), region
       matching round-tripped through CLI ↔ JSON.
@@ -107,18 +107,18 @@ is a personal-developer tool, not a team-owned regression net.
 
 ---
 
-**Status (2026-06-08, partial)**: `vrt baseline approve` ships the
+**Status (2026-06-08, partial)**: `vlmkit baseline approve` ships the
 approval-authoring CLI (`--selector --reason --max-px --max-ratio
 --expires --acknowledged-by --kind --manifest --dry-run`), backed by the
 pure `buildApprovalRuleFromInput`. Schema gained `acknowledgedBy` +
-`createdAt` (audit trail); `expires` already existed. `vrt baseline
+`createdAt` (audit trail); `expires` already existed. `vlmkit baseline
 update` archives current baselines to `_history/<ts>/` then re-pins
 (reversible). Region-bbox approval (`--region x,y,w,h`) is deliberately
 NOT built — the pipeline has no bbox matcher, so approve by the region’s
 selector instead. `update` reuses the diff-pr pin path. Tests:
 `approval.test.ts` (schema + builder), `baseline-cli.test.ts` (archive +
-approve CLI). Note: command lives under `vrt baseline approve`, not top-
-level `vrt approve` (that name is taken by the workflow bulk-approve).
+approve CLI). Note: command lives under `vlmkit baseline approve`, not top-
+level `vlmkit workflow approve` (that name is taken by the workflow bulk-approve).
 
 **Update (2026-06-08): region-bbox approval now shipped.** `vrt
 baseline approve --region "x=,y=,w=,h=[,viewport=,tol=]"` authors an

--- a/docs/issues-drafts/02-vrt-watch.md
+++ b/docs/issues-drafts/02-vrt-watch.md
@@ -1,9 +1,9 @@
-# Dev inner loop: `vrt watch` + round-vs-round diff for fast iteration
+# Dev inner loop: `vlmkit watch` + round-vs-round diff for fast iteration
 
 ## Context
 
 The 2026-05-15 closed-loop validation runs (agent-a … agent-d) each
-took 45–146 tool calls × ~10 seconds per `vrt compare`. That's an
+took 45–146 tool calls × ~10 seconds per `vlmkit diff html`. That's an
 acceptable cost for a one-shot convergence loop, but it's far too
 slow for a developer-or-agent actively writing CSS. Today every
 re-run starts cold: full browser launch, full diff pipeline, full
@@ -23,17 +23,17 @@ is two pieces of UX glue:
 
 ## What's needed
 
-### `vrt watch <baseline> <variant>`
+### `vlmkit watch <baseline> <variant>`
 
 ```
-vrt watch fixtures/golden/page.html src/page.html \
+vlmkit watch fixtures/golden/page.html src/page.html \
   --tokens DESIGN.md \
   --output .vrt/runs/
 ```
 
 - Watches the variant's HTML + its referenced stylesheets (resolved
   via the same file-mode `page.goto(file://)` machinery that powers
-  `vrt compare`).
+  `vlmkit diff html`).
 - Debounce: ~150 ms after the last write event to coalesce burst
   saves.
 - Mutex: one compare runs at a time. New file events during a run
@@ -70,7 +70,7 @@ that they only discovered on the *next* round.
 
 ## Done when
 
-- [ ] `vrt watch` enters a stable loop with debounced re-runs.
+- [ ] `vlmkit watch` enters a stable loop with debounced re-runs.
 - [ ] Inter-run diff produces `latest-delta.md` with the four
       sections above.
 - [ ] Tests:
@@ -94,7 +94,7 @@ round trips break flow.
 
 ## Open question
 
-Do we wire `vrt watch` to the existing snapshot baseline machinery,
+Do we wire `vlmkit watch` to the existing snapshot baseline machinery,
 or keep it as a two-file compare wrapper for v1? Recommend the latter
 to ship quickly; baselines integration is in the baseline-and-approve
 ticket.

--- a/docs/issues-drafts/02-vrt-watch.md
+++ b/docs/issues-drafts/02-vrt-watch.md
@@ -12,10 +12,10 @@ JSON emit, full triptych compose.
 The data needed for fast iteration is already there — what's missing
 is two pieces of UX glue:
 
-1. **A file-watcher that re-runs vrt on save.** No tool today; users
+1. **A file-watcher that re-runs vlmkit on save.** No tool today; users
    alt-tab back to the terminal and re-type the compare command
    between every edit.
-2. **A round-vs-round diff.** vrt currently only compares variant vs
+2. **A round-vs-round diff.** vlmkit currently only compares variant vs
    golden. The agent's most-useful cognitive prompt during a long
    loop is "what did I just change that affected the diff in
    direction X?" — which requires variant-now vs variant-previous-run

--- a/docs/issues-drafts/03-ci-gate.md
+++ b/docs/issues-drafts/03-ci-gate.md
@@ -1,4 +1,4 @@
-# CI gate: `vrt diff-pr` mode + `vrt.config` route declaration + per-route thresholds
+# CI gate: `vlmkit diff-pr` mode + `vrt.config` route declaration + per-route thresholds
 
 ## Context
 
@@ -9,8 +9,8 @@ declare that suite, no policy layer for "hero must be 0% but admin
 can be 2%", and the existing `--strict` flag is binary across all
 routes and viewports.
 
-Depends on the baseline-lifecycle ticket: `vrt diff-pr` is the
-*consumer* of pinned baselines. Without `vrt baseline` shipping
+Depends on the baseline-lifecycle ticket: `vlmkit diff-pr` is the
+*consumer* of pinned baselines. Without `vlmkit baseline` shipping
 first, this ticket's "load the baseline for route X" step has no
 backing storage.
 
@@ -41,14 +41,14 @@ Project-level config that declares the suite vrt should know about:
 - `tokens` becomes the default `--tokens` arg.
 - `baselineDir` resolves baseline PNGs by route name.
 
-### `vrt diff-pr`
+### `vlmkit diff-pr`
 
 New subcommand:
 
 ```
-vrt diff-pr                       # uses vrt.config; bring-your-own dev server
-vrt diff-pr --config custom.json
-vrt diff-pr --output .vrt/runs/pr-current/
+vlmkit diff-pr                       # uses vrt.config; bring-your-own dev server
+vlmkit diff-pr --config custom.json
+vlmkit diff-pr --output .vrt/runs/pr-current/
 ```
 
 Behavior:
@@ -56,7 +56,7 @@ Behavior:
 1. Reads `vrt.config`.
 2. For each route, locates the stored baseline under
    `<baselineDir>/<route.name>/<viewport>.png`.
-3. Runs `vrt compare` against that baseline (URL mode — agents have
+3. Runs `vlmkit diff html` against that baseline (URL mode — agents have
    typically not pre-rendered HTML files into the repo; they rely on
    a running dev server pointed at by `route.url`).
 4. Applies the route's resolved threshold policy.
@@ -75,14 +75,14 @@ Behavior:
 - `vrt.config.json` example in `examples/` or `fixtures/` showing
   routes + per-route thresholds
 - Update `docs/api-design.md` with the new subcommand
-- A "from zero to CI green" doc with the recipe: `vrt baseline pin
-  --all` to seed, then `vrt diff-pr` in CI
+- A "from zero to CI green" doc with the recipe: `vlmkit baseline pin
+  --all` to seed, then `vlmkit diff-pr` in CI
 
 ## Done when
 
 - [ ] `vrt.config` loader supports JSON + TOML (JS optional)
 - [ ] Loader honors per-route threshold overrides
-- [ ] `vrt diff-pr` runs the suite, emits markdown summary, exits
+- [ ] `vlmkit diff-pr` runs the suite, emits markdown summary, exits
       0/1 against the policy
 - [ ] Approval manifest entries correctly suppress breaches (test
       with an intentional regression that's covered by an approval)
@@ -93,7 +93,7 @@ Behavior:
 
 ## Open questions
 
-- Should `vrt diff-pr` boot its own dev server, or strictly bring-
+- Should `vlmkit diff-pr` boot its own dev server, or strictly bring-
   your-own? Recommend BYO for v1 — CI runners already manage their
   own services; vrt staying agnostic is simpler.
 - PR-comment integration: the markdown summary is the payload. The

--- a/docs/issues-drafts/03-ci-gate.md
+++ b/docs/issues-drafts/03-ci-gate.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Every vrt invocation today is a single `compare <a> <b>` call. CI
+Every vlmkit invocation today is a single `compare <a> <b>` call. CI
 workflows need to run a *suite* — every page / route a team cares
 about — and gate the build on regressions. There's no config to
 declare that suite, no policy layer for "hero must be 0% but admin
@@ -18,7 +18,7 @@ backing storage.
 
 ### `vrt.config.{json,toml,js}`
 
-Project-level config that declares the suite vrt should know about:
+Project-level config that declares the suite vlmkit should know about:
 
 ```json
 {
@@ -95,14 +95,14 @@ Behavior:
 
 - Should `vlmkit diff-pr` boot its own dev server, or strictly bring-
   your-own? Recommend BYO for v1 — CI runners already manage their
-  own services; vrt staying agnostic is simpler.
+  own services; vlmkit staying agnostic is simpler.
 - PR-comment integration: the markdown summary is the payload. The
   glue to actually post it (via `gh` CLI in a real project, or
   GitHub MCP in this harness) is a separate ticket once this lands.
 
 ## Severity
 
-`major` — productionization blocker. Without a CI mode, vrt's
+`major` — productionization blocker. Without a CI mode, vlmkit's
 regression-net story is "manually run a command and read the
 output" — which doesn't scale to multi-person codebases.
 
@@ -120,7 +120,7 @@ TOML config now also supported: `vrt.config.toml` is parsed by the
 minimal `toml-min.ts` reader (scalars / arrays / nested tables /
 `[[routes]]` arrays-of-tables with dotted sub-tables). Format is chosen
 by file extension; `findConfigPath` discovers `.json` then `.toml`. No new
-runtime dependency (the repo shares a pnpm store with the old `vrt`
+runtime dependency (the repo shares a pnpm store with the old `vlmkit`
 checkout, so a hand-rolled parser avoided a risky relink). Tests in
 `toml-min.test.ts` + `diff-pr-config.test.ts`. JS-format config remains
 out of scope.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,4 +1,4 @@
-# vrt
+# vlmkit
 
 Visual Regression Testing ツールキット — ピクセル差分、computed style 差分、a11y ツリー差分、AI による CSS 自動修正。
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -23,16 +23,16 @@ pnpm install
 pnpm test
 
 # 2つの HTML ファイルを比較
-vrt compare before.html after.html
+vlmkit diff html before.html after.html
 
 # 2つの URL を比較
-vrt compare --url http://localhost:3000/ --current-url http://localhost:8080/
+vlmkit diff html --url http://localhost:3000/ --current-url http://localhost:8080/
 
 # URL のスナップショット (初回は baseline 作成、以降は差分計測)
-vrt snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
+vlmkit snapshot http://localhost:3000/ http://localhost:3000/about/ --output snapshots/
 
 # 動的コンテンツをマスク
-vrt snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
+vlmkit snapshot http://localhost:3000/ --mask ".marquee-container,.hero-badge"
 
 # CSS チャレンジベンチマーク
 pkf run css-bench -- --fixture page --trials 30
@@ -55,14 +55,14 @@ node examples/markup-loop-project/run.mjs
 ## CLI
 
 ```bash
-vrt compare <before.html> <after.html>     # Migration VRT (ファイルまたは URL)
-vrt snapshot <url1> [url2] ...             # 複数 viewport スナップショット + 差分
-vrt bench [options]                         # CSS チャレンジベンチマーク
-vrt report                                 # 検出パターンレポート
-vrt smoke <file-or-url>                    # A11y 駆動ランダム操作テスト
+vlmkit diff html <before.html> <after.html>     # Migration VRT (ファイルまたは URL)
+vlmkit snapshot <url1> [url2] ...             # 複数 viewport スナップショット + 差分
+vlmkit bench [options]                         # CSS チャレンジベンチマーク
+vlmkit report                                 # 検出パターンレポート
+vlmkit inspect smoke <file-or-url>                    # A11y 駆動ランダム操作テスト
 vlmkit markup-loop <init|observe|doctor|run> # plan/generate/VRT gate の導入用ループ
-vrt serve [--port 3456]                    # API サーバー
-vrt status [--url http://localhost:3456]   # サーバーヘルスチェック
+vlmkit api serve [--port 3456]                    # API サーバー
+vlmkit api status [--url http://localhost:3456]   # サーバーヘルスチェック
 ```
 
 ## 環境変数

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -399,7 +399,7 @@ Diff causes identified by agent:
 
 After fix application, below 1.3% across all viewports. Remaining differences are subtle at breakpoint boundaries (769/768/640px).
 
-## vrt + subagent Evaluation
+## vlmkit + subagent Evaluation
 
 **Demonstrated that the "VRT diff → agent analysis → fix code generation → re-verification" loop works practically.**
 
@@ -452,7 +452,7 @@ Generated vanilla CSS without seeing after.html, using only before.html (Tailwin
 | Loop rounds | 3 rounds to pixel-perfect |
 | Agent efficiency | 58 tool calls / 632s ≈ 10 min. Work that would take a human several hours |
 
-**vrt functions sufficiently as a foundation for "generating code that makes migration work".**
+**vlmkit functions sufficiently as a foundation for "generating code that makes migration work".**
 
 ### Reset CSS blind test (E3)
 

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -875,7 +875,7 @@ tokens 列を必ず含め、この節のベースライン表に 1 行追記す�
 
 ### Selector-heal calibration (2026-07-30)
 
-`vrt interact --heal-all` labels **strong** suggestions at confidence `>= 0.40`
+`vlmkit inspect interact --heal-all` labels **strong** suggestions at confidence `>= 0.40`
 and **weak** ones at `>= 0.15`. These are precision-first thresholds: a
 fixture-derived corpus found that the former 0.30 strong cutoff promoted a
 wrong sibling. The corpus, exact scores, and reproduction command are in

--- a/docs/landmark-drilldown-design.md
+++ b/docs/landmark-drilldown-design.md
@@ -194,9 +194,15 @@ evidence:
   kind, text length, and density;
 - `--profile` and `--profile-json` expose browser launch, navigation,
   landmark capture, and hint capture timing;
-- local file inputs wait for `load` instead of `networkidle`, which keeps
-  dogfood introspection under roughly a few hundred milliseconds after cold
-  browser start.
+- local file inputs navigate with `load` rather than `networkidle`, but **still
+  settle** (bounded network idle → webfonts → one frame) before capture. The
+  original no-settle fast path kept a cold-start introspection to a couple of
+  hundred milliseconds and was wrong on any page that renders after `load`:
+  measured 2026-08-02 on a built SPA opened as a file, `scan contract` returned
+  **0 landmarks** in 241ms versus 4 (`banner, navigation, main, contentinfo`) in
+  986ms settled. A cheaper DOM-quiescence primitive was tried and rejected —
+  MutationObserver-quiet + rAF runs in 128ms but declares a page settled before
+  a deferred render begins, and burns its whole cap on a page that polls.
 
 ## Next Generalization
 

--- a/docs/markup-assist.md
+++ b/docs/markup-assist.md
@@ -141,7 +141,11 @@ the part a `grep` through npm scripts cannot give you.
 
 ## Pick your gate by task
 
-Sources are file paths or URLs throughout.
+Sources are file paths or URLs throughout. A file is loaded by navigation, so
+its relative stylesheets, images and scripts resolve — if your CSS lives in
+`style.css` next to the page, the gates measure the page as it actually renders
+(this was not true before 2026-08-02; see
+[`reports/2026-08-02-external-asset-load-defect.md`](./reports/2026-08-02-external-asset-load-defect.md)).
 
 ### I wrote or edited a page — find defects, no reference needed
 

--- a/docs/markup-assist.md
+++ b/docs/markup-assist.md
@@ -124,6 +124,21 @@ The verdict per page is that gate run's exit code, so anything with the
 standard exit contract is batchable. Measured concurrency / sharding budget:
 [`reports/2026-08-02-batch-runner-ci-budget.md`](./reports/2026-08-02-batch-runner-ci-budget.md).
 
+Past a handful of pages, put the plan in a file instead of in shell history:
+
+```bash
+vlmkit gates init --pages "routes/**/*.html" --gate "check integrity"
+vlmkit gates list            # what would run, exact commands
+vlmkit gates run --shard 1/3
+vlmkit gates suppressions    # every silenced check, with reason/owner/expiry
+```
+
+`vlmkit.gates.json` is also where suppressions belong (`--allow-invisible`,
+loosened thresholds). A suppression must carry a `reason`, and once its
+`expires` date passes it stops being applied — the gate runs unmuted and the
+run fails, so a stale exemption gets noticed instead of accumulating. That is
+the part a `grep` through npm scripts cannot give you.
+
 ## Pick your gate by task
 
 Sources are file paths or URLs throughout.

--- a/docs/markup-assist.md
+++ b/docs/markup-assist.md
@@ -122,6 +122,7 @@ Sources are file paths or URLs throughout.
 | The exact copy is spec (spellings, casing, `€`, dates) | `vlmkit check copy page.html --manifest copy.txt` |
 | Structural requirements as a machine-checkable spec (widths, per-row counts, stacking order, per-viewport visibility) | `vlmkit check layout page.html --contract layout.json` |
 | Design-system conformance: hard-coded values vs a token scale | `vlmkit check tokens page.html` |
+| No token file to check against: is the page consistent with *itself*? (one button style or six; spacing on the page's own scale) | `vlmkit check design page.html` |
 | Light/dark theme parity | `vlmkit check theme page.html` |
 | WCAG contrast / touch targets / focus order | `vlmkit check a11y contrast\|touch\|focus page.html` |
 | Layout survives 30% longer strings (i18n) | `vlmkit stress i18n page.html` |

--- a/docs/markup-assist.md
+++ b/docs/markup-assist.md
@@ -110,6 +110,20 @@ Nine gates become tools (`verify_markup`, `check_integrity`,
 the routing table below and the loop discipline, and assumes only
 that `npx vlmkit` runs.
 
+## Many pages at once
+
+Every recipe below takes one page. To run one over a whole route tree:
+
+```bash
+vlmkit batch --gate "check integrity" "routes/**/*.html"          # parallel, exit 1 if any page fails
+vlmkit batch --gate "check integrity" --gate "check design" "dist/**/*.html" --output ci-logs/
+vlmkit batch --gate "check integrity" "routes/**/*.html" --shard 2/3   # one of three CI runners
+```
+
+The verdict per page is that gate run's exit code, so anything with the
+standard exit contract is batchable. Measured concurrency / sharding budget:
+[`reports/2026-08-02-batch-runner-ci-budget.md`](./reports/2026-08-02-batch-runner-ci-budget.md).
+
 ## Pick your gate by task
 
 Sources are file paths or URLs throughout.

--- a/docs/markup-assist.md
+++ b/docs/markup-assist.md
@@ -153,6 +153,7 @@ its relative stylesheets, images and scripts resolve — if your CSS lives in
 |---|---|
 | Broken-page scan: JS errors, empty render, failed resources, text collision/clipping/protrusion, collapsed containers, page overflow, invisible text, text painted over by opaque elements (occlusion), near-misalignment, unstyled page — across 3 viewports | `vlmkit check integrity page.html` |
 | The exact copy is spec (spellings, casing, `€`, dates) | `vlmkit check copy page.html --manifest copy.txt` |
+| An integrity finding is a deliberate pattern, not a defect | `vlmkit check integrity page.html --allow "near-misalignment@.badge;optically centred"` — reason mandatory, still listed as exempted |
 | Structural requirements as a machine-checkable spec (widths, per-row counts, stacking order, per-viewport visibility) | `vlmkit check layout page.html --contract layout.json` |
 | Design-system conformance: hard-coded values vs a token scale | `vlmkit check tokens page.html` |
 | No token file to check against: is the page consistent with *itself*? (one button style or six; spacing on the page's own scale) | `vlmkit check design page.html` |

--- a/docs/reports/2026-08-01-authenticated-real-site-audit.md
+++ b/docs/reports/2026-08-01-authenticated-real-site-audit.md
@@ -110,6 +110,43 @@ Note `Name (A to Z)` matching is itself meaningful: it lives in the span
 under the invisible select, and the copy gate's geometric visibility model
 correctly counts it as visible.
 
+## Result 4: the rest of the gates on the authenticated app
+
+With `VLMKIT_STORAGE_STATE` set, run against the real inventory page:
+
+| Gate | Result |
+|---|---|
+| `check interactions` | `status: ok`, **23 interactive elements** discovered |
+| `scan handlers` | `status: ok` |
+| `check breakpoints --sweep` | `status: ok`, clean across 320-1280px, and it discovered the app's **five real breakpoints** (480, 640, 900, 960, 1060px) from its own CSS |
+| `scan scroll` | `status: ok` |
+
+**What I could not measure, and am not claiming.** The obvious follow-up
+was a before/after A/B on those 23 controls, to size the `settleAfterLoad`
+fix on a real SPA (it was 0 → 3 on my own fixture). Two attempts were
+confounded and neither is usable: the first ran after the demo session had
+expired, so both arms measured the *login* page (2 vs 3 controls); the
+second hit the 500s timeout, because `check interactions` reloads the page
+once per control probe and every load crosses the relay. So: 23 controls on
+the authenticated page is verified, the *delta* attributable to the settle
+fix on a real SPA is **not**.
+
+### Unplanned validation: an expired session fails loudly
+
+The confounded run turned into evidence for a claim the auth commit made
+but had not tested. When the Swag Labs session expired, the gate did not
+quietly measure the login page — it reported
+
+```
+verdict: DEFECTS
+  x [redirected] requested /inventory.html but measured http://127.0.0.1:8910/
+  1280x800: 6 text block(s)      <- login page, not the 31 of the authed page
+```
+
+An expired `--storage-state` is therefore a loud failure, not a silent
+wrong answer. That is the property that makes replaying a session safe to
+recommend at all.
+
 ## Findings classified
 
 | Finding | Class |

--- a/docs/reports/2026-08-01-authenticated-real-site-audit.md
+++ b/docs/reports/2026-08-01-authenticated-real-site-audit.md
@@ -1,0 +1,140 @@
+# Authenticated real-site audit (`--storage-state`)
+
+The auth support shipped earlier today was verified against a fixture I
+wrote myself. This audit points the gates at a **real, session-protected
+application** to find out what `--storage-state` does on markup nobody on
+this project authored.
+
+## Target and access
+
+**Swag Labs** (`saucedemo.com`), Sauce Labs' public demo app, using the
+credentials **published on its own login page** for automation practice.
+No third-party account, no real user data, nothing that isn't offered for
+exactly this purpose.
+
+## Getting a real site in front of the gates
+
+Chromium cannot egress in this environment — with or without
+`HTTPS_PROXY`, navigation dies at `ERR_CONNECTION_RESET`, and the agent
+proxy's `recentRelayFailures` stays empty, so its connections never even
+arrive. Node's `fetch` does work.
+
+So the audit puts a **local reverse proxy** in front of the real origin
+(`scratchpad/authaudit/relay.mjs`): the gates navigate to
+`http://127.0.0.1:8910`, the bytes come from `saucedemo.com` over node's
+fetch, and `Set-Cookie` is rewritten (drop `Domain`, drop `Secure`) so a
+real session works against the local origin. `redirect: "manual"` is
+essential — otherwise the relay would swallow the login-wall redirect that
+is half of what this audit tests.
+
+This is a real-site audit, not a mirror: live HTML/CSS/JS and a real
+session cookie. The one honest caveat is that **cross-origin subresources
+still cannot load** (Google Fonts), which shows up as relay artifacts —
+classified below.
+
+## Result 1: the login-wall guard works on a real app
+
+```
+$ vlmkit check integrity http://127.0.0.1:8910/inventory.html   # no session
+verdict: DEFECTS
+  x [redirected] requested /inventory.html but measured http://127.0.0.1:8910/.
+    The gate measured the destination, not the URL you passed.
+  1280x800: 3 component(s), 6 text block(s)      <- the LOGIN page
+```
+
+With the session: `28 text block(s)`, 8 components — the real inventory
+page. Before this session's work, the no-session run would have reported
+the login page as a clean result for `/inventory.html`.
+
+**One gap found in my own heuristic:** the message is the generic
+"measured the destination" rather than the login-wall hint, because Swag
+Labs redirects to `/` — the login page does not *look* like a login path.
+Detection is unaffected (it still fails), only the hint is missed. Keying
+the hint on path text is inherently partial; a content signal (a password
+field on the destination) would be the better test.
+
+## Result 2: a false positive I introduced, found on real markup
+
+The authenticated page reported:
+
+```
+x [occluded-text] span.active_option "Name (A to Z)" is painted over by an
+  opaque element select.product_sort_container — 100% of sampled glyph points
+```
+
+Measured ground truth:
+
+| property | value |
+|---|---|
+| `select.product_sort_container` opacity | **0.001** |
+| its `background-color` | `rgb(239, 239, 239)` — alpha **1** |
+| span text / select's selected option text | both `"Name (A to Z)"` |
+
+This is the **styled-select pattern**: a native `<select>` is layered over
+a styled span at opacity ~0 so the control keeps native keyboard and
+assistive-tech behaviour while the span carries the visual design. The
+overlay paints nothing. `paintsOpaquely()` tested `background-color` alpha
+and ignored element `opacity`, so a deliberately invisible overlay counted
+as an opaque occluder.
+
+**Attribution, honestly:** an A/B against the pre-session revision says
+`before=0, after=1` — this session surfaced it. Not, however, via the
+`pointer-events` override as I first assumed: both arms hit the same
+`SELECT` at the sampled point. It was the **`document.fonts.ready` wait**.
+The gate now measures a more completely rendered page and therefore
+*reaches* a latent false positive that was always in the probe's logic.
+Making a gate see more of the page exposes bugs that were previously out
+of reach — which is an argument for the settle fix, not against it.
+
+**Fix:** effective opacity — CSS `opacity` multiplied down the ancestor
+chain, plus `visibility: hidden` / `display: none` short-circuits — must
+be ≥ 0.5 before an element can be an occluder at all. Regression test
+M14b2 encodes the styled-select pattern.
+
+Verified after the fix:
+
+- the authenticated page is **CLEAN** (0 fail),
+- CSS Zen Garden still reports its **3** real occlusions (the
+  decorative-overlay page that guards this probe),
+- all five M14 occlusion tests pass, 487/487 markup tests pass.
+
+## Result 3: env-var auth works across gates
+
+`VLMKIT_STORAGE_STATE` alone — no per-command flag — authenticated
+`check copy` against the real app: `status: ok, manifest: 4 line(s),
+missing 0`, matching `Products`, `Name (A to Z)`, `Sauce Labs Backpack`,
+`Add to cart`. That is the ergonomic claim from the auth commit ("applies
+to every gate at once") confirmed on a real session.
+
+Note `Name (A to Z)` matching is itself meaningful: it lives in the span
+under the invisible select, and the copy gate's geometric visibility model
+correctly counts it as visible.
+
+## Findings classified
+
+| Finding | Class |
+|---|---|
+| `occluded-text` on `span.active_option` | **false positive — fixed** (effective opacity) |
+| `js-error` ×2 (`404`, `ERR_CONNECTION_RESET`) | relay artifact — cross-origin subresources cannot load through the local relay |
+| `failed-stylesheet` (Google Fonts `css2?family=DM+Mono…`) | relay artifact, same cause; correctly reported as a **third-party** warn rather than a fail |
+| `low-contrast-text` 3 blocks skipped (exempted) | correct — composite background, reported as skipped rather than guessed |
+
+Every non-artifact finding on the real authenticated page was a false
+positive in the tool, and it is now fixed. Zero real defects were found in
+Swag Labs' markup, which is the expected outcome for a maintained demo app
+and the right baseline for an FP audit.
+
+## Method notes
+
+- **A fixture I wrote could not have found this.** The styled-select
+  pattern is a real-world idiom I would not have thought to write, and it
+  defeated a probe that passes a 5-test synthetic battery.
+- **Chromium egress was the binding constraint, not auth.** The relay is
+  the reusable part: any gate can now be pointed at a real site through
+  `RELAY_TARGET`, which also makes the FP-audit corpus refreshable without
+  hand-mirroring.
+- **`redirect: "manual"` in the relay is load-bearing.** With automatic
+  redirect following, the relay would have hidden the login wall and this
+  audit would have silently measured the authenticated page in both arms —
+  the same class of vacuous-A/B mistake as the `node_modules` leak in the
+  FP re-audit.

--- a/docs/reports/2026-08-01-fp-reaudit.md
+++ b/docs/reports/2026-08-01-fp-reaudit.md
@@ -141,7 +141,24 @@ The classes that carry real signal for this audit:
 | component extraction (via `verify markup`) | not exercised on real pages | **gap** — the adaptive-tolerance change is covered only by unit tests and the synthetic reproduction |
 | `text-collision` | **1** (apg-tabs) | **inadequate** |
 
-### The ink-extents upgrade is still NOT unblocked
+### Update (later the same day): both halves shipped, gated by a purpose-built corpus
+
+`fixtures/collision-fp-corpus` was built to be the corpus this audit
+lacked, and it worked in both directions. It found a **live false
+positive** on its first run (the kicker/heading pull-up: 7px box overlap,
+2px measured ink gap), which shipped as half (a) — ink confirmation as a
+filter. Then the measured ink fractions (1.000 for a real graze vs
+0.077-0.137 for legitimate stacks) gave half (b) a threshold with a 7x
+margin instead of a guess.
+
+Re-running this audit's own 8-page A/B against the finished work:
+**0 new collisions, 16 disappeared** — every one of the 16 a pre-existing
+false positive the old area-ratio gate had been masking (MDN 14 -> 0 from
+closed-`<details>` content that keeps layout boxes; APG 2 -> 0 from
+element-vs-own-descendant pairs). The section below is kept as the record
+of what the gap was and why it blocked the work.
+
+### The ink-extents upgrade was NOT unblocked by THIS audit
 
 The backlog gated it on "a false-positive re-audit," and it would be
 convenient to read this audit as satisfying that. It does not. With a

--- a/docs/reports/2026-08-01-fp-reaudit.md
+++ b/docs/reports/2026-08-01-fp-reaudit.md
@@ -1,0 +1,97 @@
+# False-positive re-audit of the 2026-08-01 threshold changes
+
+This session moved five thresholds/behaviours that all carry
+false-positive risk, and the backlog gated further work (the
+ink-extents collision upgrade) on an FP re-audit. This is that audit.
+
+Changes under test:
+
+| Change | FP risk being tested |
+|---|---|
+| `adaptiveBgTolerance` (foreground threshold 12 → 4 on clean renders) | antialiasing halos becoming their own components |
+| `pixelPresence` clamped against the background | legitimate segmentation disagreements stop being demoted → new blocking findings |
+| occlusion probe forces `pointer-events` on while sampling | transparent overlays flagged as occluders |
+| overflow culprit measured (`width: 0` probe) instead of ranked | wrong element named as cause |
+| copy gate walks open shadow roots | text a user cannot see counted as visible |
+| `settleAfterLoad` in interactions / handlers | different DOM measured than before |
+
+## Method
+
+**A/B on identical inputs.** Eight real pages (example.com, danluu.com,
+Hacker News, MDN, Wikipedia, W3C APG tabs, web.dev, CSS Zen Garden)
+mirrored locally with their same-origin CSS, then measured twice: once
+with the pre-change commit (`86d4cdb`) and once with the current tree.
+Any finding present in AFTER but absent in BEFORE is a candidate false
+positive.
+
+Mirror fidelity gaps (missing cross-origin scripts, query-string assets)
+are acceptable *because* it is an A/B: an artifact appears in both arms
+and cancels in the diff. That is the property that makes a cheap mirror
+usable where the earlier single-arm dogfood had to hand-triage them.
+
+## The harness was wrong on the first attempt
+
+The first run reported **0 new findings, 0 disappeared** — for both
+gates, on every page. That result was vacuous, and the reason is worth
+recording because it would silently invalidate any future A/B in a
+pnpm workspace:
+
+The baseline worktree's `node_modules` was symlinked to the main repo's,
+and `node_modules/@mizchi/vlmkit-*` there points at
+`../../packages/vlmkit-*` **of the main repo**. Every cross-package
+deep import (`@mizchi/vlmkit-markup/inspect/copy-check.ts` — which is
+how the CLI reaches the gates) therefore resolved to the *current*
+code. Both arms ran the same build. The old arm's own sources sat on
+disk, unused.
+
+It was caught by a prediction that failed: MDN has 16 open shadow roots,
+so the shadow-traversal change *must* move the copy gate's text length —
+and the A/B said it hadn't. Computing the expected numbers by hand
+(`normalizeWhitespace(innerText)` = 11396 vs with shadow text = 11482)
+against the arms' reported values (11482 in both) located the leak.
+
+Fix: give the baseline worktree its own `node_modules` — every
+third-party entry symlinked from the shared store, but `@mizchi/*`
+pointing at the worktree's own packages. Re-verified before trusting
+anything: `before=11396, after=11482`, matching the hand computation.
+
+**Rule for future audits: prove the arms differ on a case where you
+know the answer, before reading any result as evidence.** An A/B whose
+arms are secretly identical produces the most reassuring possible
+output.
+
+## Results (valid run)
+
+See `ab-integrity.md` / `ab-copy.md` in the audit scratch directory for
+the per-page diff. Summary and classification below.
+
+### `check integrity` — 8 pages × 3 viewports
+
+_Filled in from the valid run._
+
+### `check copy` visibility model
+
+_Filled in from the valid run._
+
+### Regression battery
+
+The 17 intentional-pattern / exemption tests (sr-only, image
+replacement, ellipsis truncation, hero overlay, aria-hidden decoration,
+anchor, `csszengarden` candidates) pass unchanged, as do the full
+485-test markup suite and 143-test core suite.
+
+## Shadow-root coverage note
+
+Only MDN in this corpus uses open shadow roots (16 hosts). Of its 9364
+chars of shadow `textContent`, **8212 are `<style>`** (correctly skipped)
+and only 81 are real UI copy. Two of those strings — "Toggle sidebar",
+"Filter sidebar" — are *not* counted as visible, which is correct: they
+are screen-reader-only labels on icon controls, and the geometric
+visibility model applies inside shadow roots just as it does outside.
+"Was this page helpful to you? Yes No" *is* counted, which is also
+correct.
+
+So the new code path is exercised by exactly one page in this corpus.
+The synthetic regression test covers both halves (visible shadow copy
+satisfies the gate; `font-size: 0` shadow copy still does not), but
+real-site evidence for the shadow path is thin — one page, 81 chars.

--- a/docs/reports/2026-08-01-fp-reaudit.md
+++ b/docs/reports/2026-08-01-fp-reaudit.md
@@ -62,16 +62,47 @@ output.
 
 ## Results (valid run)
 
-See `ab-integrity.md` / `ab-copy.md` in the audit scratch directory for
-the per-page diff. Summary and classification below.
+Both arms were proven different before the results were read:
+
+- **copy canary** — MDN (the only corpus page with open shadow roots)
+  moved 11396 → 11482 chars; every other page identical.
+- **integrity canary** — Hacker News's overflow message changed from
+  `sticking out: #hnmain (right edge 804px), #hnmain > tbody:nth-of-type(1) …`
+  to `caused by: #hnmain (796px wide; constraining it removes 36px of the
+  overflow)`. Same finding, better attribution — and proof the integrity
+  code path differs between arms.
 
 ### `check integrity` — 8 pages × 3 viewports
 
-_Filled in from the valid run._
+| Page | before | after | exempted |
+|---|---|---|---|
+| apg-tabs | defects (36) | defects (36) | 0 → 0 |
+| danluu | clean (2 warns) | clean (2 warns) | 0 → 0 |
+| example | clean (0) | clean (0) | 0 → 0 |
+| hn | defects (7) | defects (7) | 0 → 0 |
+| mdn-flex | defects (77) | defects (77) | 9 → 9 |
+| webdev-lcp | defects (28) | defects (28) | 0 → 0 |
+| wikipedia-css | defects (25) | defects (25) | 0 → 0 |
+| zengarden | defects (24) | defects (24) | 25 → 25 |
+
+**0 new findings, 0 disappeared, 0 exemption changes** across 199
+findings and 34 exemptions. The unchanged exemption counts matter
+independently: an exempted-pattern turning into a finding is the
+false-positive signature for the intentional-pattern classes, and none
+occurred.
+
+The most load-bearing single result: **CSS Zen Garden reports 3
+`occluded-text` findings and they are the same 3 in both arms.** That
+page is a showcase of decorative absolutely-positioned art, exactly the
+material the `pointer-events` override could have turned into false
+occluders — and it did not.
 
 ### `check copy` visibility model
 
-_Filled in from the valid run._
+**0 new invisible-chunks, 0 new issues.** Visible-text length changed on
+one page only (MDN, +86 normalized chars), which is precisely the page
+with open shadow roots. The shadow traversal is a strict no-op where no
+open shadow root exists.
 
 ### Regression battery
 
@@ -95,3 +126,37 @@ So the new code path is exercised by exactly one page in this corpus.
 The synthetic regression test covers both halves (visible shadow copy
 satisfies the gate; `font-size: 0` shadow copy still does not), but
 real-site evidence for the shadow path is thin — one page, 81 chars.
+
+## What this corpus does and does not gate
+
+Defect-class coverage, measured (per-viewport counts on representative
+pages): `js-error` and `broken-font` / `broken-image` dominate and are
+mostly mirror artifacts — harmless here because they cancel across arms.
+The classes that carry real signal for this audit:
+
+| Class | Corpus coverage | Verdict for the changes under test |
+|---|---|---|
+| `occluded-text` | 3 (zengarden) | adequate — decorative-overlay-heavy page, no new findings |
+| `low-contrast-text` / `invisible-text` | 9 | adequate |
+| component extraction (via `verify markup`) | not exercised on real pages | **gap** — the adaptive-tolerance change is covered only by unit tests and the synthetic reproduction |
+| `text-collision` | **1** (apg-tabs) | **inadequate** |
+
+### The ink-extents upgrade is still NOT unblocked
+
+The backlog gated it on "a false-positive re-audit," and it would be
+convenient to read this audit as satisfying that. It does not. With a
+single `text-collision` finding in the whole corpus, this corpus cannot
+distinguish "the collision floor got looser without crying wolf" from
+"nothing happened to be near the floor."
+
+What that gate actually needs, now specified: a corpus of pages with
+dense text overlap — tight `line-height` (< 1) display type, negative
+`margin-bottom` heading patterns, fonts whose ascent+descent exceed 1em,
+`writing-mode: vertical-rl`, and rotated text — measured for
+`text-collision` findings before and after. The A/B harness built here
+is the right instrument for it; the corpus is not.
+
+What this audit *does* establish: the five threshold/behaviour changes
+shipped this session introduce zero false positives on real markup, and
+the harness plus the arm-isolation check are reusable for the next
+threshold change.

--- a/docs/reports/2026-08-01-hard-target-executable-audit.md
+++ b/docs/reports/2026-08-01-hard-target-executable-audit.md
@@ -1,0 +1,152 @@
+# Hard-target executable audit: SPA / auth wall / webfonts (2026-08-01)
+
+Follow-up to the round-10 finding in
+[the introduce.md eval loop](./2026-08-01-introduce-doc-eval-loop.md):
+reading personas were saturated, and the value came from *executing*
+the documented commands. Every gate audit before this one ran against
+flat, hand-written fixtures and mirrored static sites. This one runs
+them against the three input classes the docs admitted were untested.
+
+## Targets
+
+Purpose-built and served from one local server (`server.mjs`):
+
+| Target | What it stresses |
+|---|---|
+| Vite + React 19 SPA | client rendering with a 120ms post-load tick, runtime CSS-in-JS injection, hash routing, portal modal, **open shadow-root** web component, canvas-only text, 5000-row **virtualized** list (~14 in DOM), CSS Grid app shell |
+| Auth wall | `/dashboard` behind a session cookie, 302 → `/login` |
+| Webfont page | `@font-face` + `font-display: swap`, font response delayed 900ms |
+| Polling page | `setInterval(fetch)` — never reaches network-idle |
+
+Planted defects (ground truth): a fixed **760px** table inside the grid
+shell (overflows at 375/768), a `<div onClick>` with no role or keyboard
+path, and a spec'd copy line inside a `font-size: 0` span.
+
+## Defects found and fixed
+
+### 1. Auth-walled route produced a green verdict (worst class)
+
+`check integrity http://…/dashboard` followed the 302 and measured the
+**login page**, reporting `verdict: CLEAN`. A gate reporting CLEAN for a
+page that never rendered is worse than an error: the protected page's own
+820px overflow was never seen. `check copy` on the same URL reported the
+dashboard's copy as "missing" — true of the login page, misleading about
+the cause.
+
+Fix: `packages/vlmkit-core/src/navigation-redirect.ts` compares requested
+vs. final URL. Cross-path or cross-host redirects are reported; cosmetic
+ones (scheme upgrade, trailing slash, `www.`) stay quiet so the warning
+keeps its meaning. Integrity treats it as a **fail** (never report on a
+page you did not measure); copy prepends it as a suspect so the real
+cause leads. Login destinations get an explicit "vlmkit cannot inject a
+session" hint. 5 unit tests.
+
+Before: `verdict: CLEAN`, exit 0. After: `DEFECTS`, exit 1, with the
+redirect named.
+
+### 2. `check interactions` / `scan handlers` were blind on any SPA
+
+Both navigated with `waitUntil: "load"` — which fires *before* a
+client-rendered app paints. On the React target `check interactions`
+reported **`interactive elements: 0`** for a page with a button, two
+links and a scroller, and `scan handlers` reported **`status: ok`** while
+the planted pointer-only `<div onClick>` sat in the DOM. Both were
+measuring the `"Loading…"` placeholder — a silent false pass on the
+entire client-rendered ecosystem.
+
+Fix: a shared bounded `settleAfterLoad()` (network-idle with a 5s cap,
+`document.fonts.ready`, then a commit tick). Bounded and swallowed on
+purpose so never-idle pages do not turn a scan into a 30s hang.
+
+After: 3 interactive elements discovered; the pointer-only control is
+caught. Notably this means the "React delegation blindness" hypothesis
+was wrong — it was the settle bug all along, which is why measuring
+beats reasoning.
+
+### 3. Overflow kickbacks named symptoms, never the cause
+
+The most-used kickback in the tool ranked offenders by right edge. In a
+grid or flex shell one rigid child stretches the track, so every
+stretched ancestor and sibling reports a *larger* right edge than the
+element at fault. Measured on the SPA at 375px: the culprit
+`div.wide-table` (the only element with a fixed width) ranked **12th**,
+outside both the probe window and the report slice. The three selectors
+actually printed were `nav.side`, `main.main`, and the sidebar's
+`<strong>` — an agent following that kickback would edit the sidebar.
+
+Flat fixtures never caught this because in flow layout the culprit
+usually *is* the widest box.
+
+Fix: stop ranking, start measuring. For each candidate, neutralize its
+own `width`/`min-width`, re-read `document.scrollWidth`, restore, and
+record how much overflow disappeared (`relieves`). Causes are those
+accounting for ≥10% of the overflow, sorted by contribution, and are
+ordered ahead of symptoms before the report's top-N slice.
+
+Before: `sticking out: nav.side (right edge 816px), main.main …`
+After: `caused by: div.wide-table (760px wide; constraining it removes
+269px of the overflow)`. Regression test M7b.
+
+### 4. Copy inside open shadow roots read as missing
+
+`innerText` and a document-scoped `TreeWalker` both stop at the shadow
+boundary, so the web component's visible badge ("Reconciled nightly",
+measured at 145×25px, `checkVisibility() === true`) was reported
+`copy-missing`. Every design system built on custom elements keeps all
+of its copy there, making this a first-day false positive.
+
+Fix: enumerate open shadow roots and walk each. The raw-text collector
+gained the same traversal so the reason-class boundary rule still works —
+hidden shadow copy is now classified `zero-size` rather than falling into
+the vaguer "missing" bucket. Closed roots remain unreachable by
+construction. Regression test asserts both halves: visible shadow copy
+satisfies the gate, `font-size: 0` shadow copy still does not.
+
+### 5. Framework noise buried the real signal
+
+On React, `unprobed-handler-types` listed ~80 event types, because a
+delegation root registers the entire vocabulary up front. Fix: count only
+types wired to specific elements. 80 noise types → 1 real one (`scroll`,
+the app's authored handler).
+
+Also added: a `delegated-handlers-opaque` warn for pages where pointer
+handlers exist *only* at a delegation root, so a genuinely blind scan
+says so instead of printing a clean bill of health. It correctly stays
+quiet on both targets above (detection is not blind on either).
+
+## Verified as documented
+
+- **Client rendering, CSS-in-JS, delayed render**: integrity measured 64
+  text blocks across three viewports — styles and DOM measured after they
+  exist, as claimed.
+- **Never-idle page**: errored at the 30s cap with exit 1, exactly as the
+  doc states. No silent pass.
+- **Webfont stability**: three consecutive runs produced identical
+  metrics. Partial test only — the font 404s, so the swap never lands;
+  a truly late-but-successful font is still untested.
+- **Virtualized list**: rows outside the DOM window are correctly absent
+  from visible text (the gate reports what a user can actually reach).
+- **Canvas-only text**: correctly reported missing — it is genuinely not
+  DOM text, and inaccessible to assistive tech too.
+- **`check breakpoints --sweep`**: found the 900px boundary and reported
+  155px of overflow at 901px. The gate that best handled the hard target.
+- **Planted `font-size: 0` copy**: caught as `zero-size`.
+
+## Method notes
+
+- **Three of five defects were silent false passes** (CLEAN on an
+  unmeasured page, 0 controls on a full app, `ok` with a pointer-only
+  control present). Reading the docs cannot find these; only running the
+  tool against inputs that resemble production can.
+- **A wrong hypothesis got corrected by measurement.** "React delegation
+  makes handler scanning impossible" was plausible, and I built a
+  disclosure mechanism for it — then the settle fix made detection work,
+  proving the diagnosis wrong. The disclosure stays as a narrower safety
+  net, but the real bug was mundane.
+- **Fixture realism is the whole experiment.** Every one of these five
+  defects requires a construct the previous fixtures lacked: a grid
+  shell, a shadow root, a post-load render tick, a redirect. The tool
+  was not under-tested in count (481 tests pass) but in *kind*.
+- **Two nested caps hid the same bug twice** — the culprit was outside
+  both the 10-element probe window and the 10-element report slice.
+  Silent top-N truncation deserves the same suspicion as a silent gate.

--- a/docs/reports/2026-08-01-introduce-doc-eval-loop.md
+++ b/docs/reports/2026-08-01-introduce-doc-eval-loop.md
@@ -32,6 +32,7 @@ three rounds had not covered.
 | 7 | 7/10 | — | 7/10 | all correct incl. round-6 fixes (minHeight every-match semantics, the 30px-button rule, contract example values) — both personas' best-ever scores |
 | 8 | 7/10 | — | 8/10 | all correct incl. round-7 fixes (name fossil, verify-markup mechanism, never-idle behavior, cross-OS baselines, Haiku attribution, suppression persistence) — first 8 of the loop |
 | 9 | 7/10 | — | 7/10 | all correct incl. round-8 fixes (verify-markup boundary, palette-harmony mechanism, install commands, vrt.config.json fossil, suspect floors, error exit behavior) |
+| 10 | — | — | — | lens changed: (D) browser-internals engineer 6/10 + (E) executable-fidelity auditor — see below |
 
 ## What each round changed
 
@@ -133,7 +134,92 @@ three rounds had not covered.
   Honest-limits bullet; a worked npm-scripts block with an honest
   ~20-page scale ceiling.
 
-## Convergence call after round 9 (recommended stop)
+## Round 10 — changing the measurement axis (the loop's most productive round)
+
+Rounds 4–9 had converged on prose polish because the *instrument* was
+fixed: a persona reading the document. Round 10 changed the
+instrument instead of the document, running two evaluators that could
+contradict the source rather than only the wording:
+
+- **(D) a browser-internals staff engineer** — judges whether each
+  described mechanism is mechanically possible.
+- **(E) an executable-fidelity auditor** — runs every command in the
+  document and tests every behavioral claim empirically.
+
+Scores: D 6/10 (lowest since round 4 — correctly so; it scored
+mechanism opacity the prose personas could not see). E produced no
+score by design; it produced a table of VERIFIED / MISMATCH.
+
+### Real defects found (fixed, with tests)
+
+1. **A13 occlusion was blind to `pointer-events: none` occluders.**
+   Predicted by D from the mechanism alone, then confirmed
+   empirically: `elementFromPoint` returns the *text element itself*
+   when the occluder opts out of hit-testing, so `hit === el` short
+   -circuits and the S19 defect class plus one declaration escaped.
+   Fix: force hit-testing on page-wide while sampling, then restore;
+   the opaque-paint requirement keeps false positives closed
+   (transparent stretched-link test still green). Regression test
+   M14a2, verified failing-before/passing-after.
+2. **`check integrity` never awaited `document.fonts.ready`.** Only
+   network idle — but `font-display: swap` reflows text *after* idle,
+   so geometry probes measured fallback metrics on some runs. This
+   contradicted the determinism claim the doc had made two rounds
+   earlier.
+3. **The ledger did not cover `snapshot` or `scan breakpoints`** (E's
+   measurement: 0 lines appended). Since the doc pitches the ledger as
+   the audit backbone for "every gate invocation," the code was fixed
+   rather than the claim weakened — both now log, verified.
+
+### Doc claims E falsified (my errors, now corrected)
+
+- **The exit-code rule from round 9 was wrong.** I had written
+  "the other checks exit zero unless you pass `--fail-on-suspect`"
+  from reading `--fail-on-suspect` call sites. Measured reality:
+  `check layout`, `verify flow`, `verify markup`, `scan handlers`,
+  and `check interactions` all exit non-zero *without* the flag;
+  `check copy`, `check asset`, `scan scroll` exit zero. Independently
+  re-verified before rewriting. The doc now states the actual split
+  (verdict gates fail closed, finding-list gates fail open, errors
+  always fail) and names the inconsistency; unification is backlogged
+  as a breaking change.
+- **`check interactions` does not catch the clickable `<div>`** — a
+  `<div onclick>` page returns `status: ok`. That needs
+  `scan handlers` / `--handlers`. The doc had attributed the catch to
+  the wrong command, in both prose and the cheat sheet: the mismatch
+  most likely to produce a false "verified".
+- **`vlmkit watch` is not a gate re-runner** (it is the older
+  baseline/variant differ). The pointer implied the opposite.
+- **i18n inflation is 1.4× (40%), not the documented 30%.**
+- **`verify markup` misses low-contrast fills** inside its stated
+  sweet spot: two `#f4f4f4` cards removed from a `#ffffff` page =
+  2.12% of pixels differing, reported as `0.01%` and `DONE`.
+  Disclosed in Honest limits; threshold fix backlogged.
+
+### Method notes
+
+- **Changing the evaluator's lens beat iterating the same lens.** Nine
+  rounds of readers produced wording fixes; one round of a mechanism
+  critic plus an executing auditor produced three code fixes and five
+  falsified claims. The ratchet described below was a property of the
+  instrument, not of the document.
+- **An executing auditor is the only evaluator that can catch the
+  author's own source-reading errors.** Every wrong claim in this
+  round originated in *my* reading of the code (exit codes, i18n
+  factor, which command owns the clickable-div catch) — errors no
+  prose reviewer could see, and that I had introduced *while fixing
+  earlier review findings*. Doc rounds can inject defects.
+- **The auditor also caught its own setup error** (a `sed` had made
+  its "modified" fixture byte-identical to the target) and retracted
+  the finding. Instructing an auditor to distinguish "the doc is
+  wrong" from "I set it up wrong" is what made its report usable.
+- **One legitimate critique was deliberately not acted on.** D
+  correctly identified that the collision floor's both-axes AND
+  excludes thin slivers. Loosening a floor on one reviewer's
+  reasoning is how a gate starts crying wolf, so it is disclosed as a
+  known blind spot and backlogged behind a false-positive re-audit.
+
+## Convergence call after round 9 (superseded by round 10)
 
 Scores: dev 6, 6, 6, 7, 6, 6.5, 7, 7, 7 · operator 5, 6, 7 (retired)
 · lead 6, 7, 6, 7, 8, 7. The comprehension quiz has been perfect for

--- a/docs/reports/2026-08-01-introduce-doc-eval-loop.md
+++ b/docs/reports/2026-08-01-introduce-doc-eval-loop.md
@@ -1,4 +1,4 @@
-# introduce.md evaluation loop: three rounds of blind persona review (2026-08-01)
+# introduce.md evaluation loop: blind persona review rounds (2026-08-01)
 
 ## Method
 
@@ -13,13 +13,22 @@ agent operator burned by false "verified" claims, evaluating tools.
 The quiz is re-targeted each round at the previous round's fixes, so
 "did the fix land" is measured, not assumed.
 
+After round 3 the loop continued at the user's request. Persona B
+(agent operator) was retired at its 7/10 plateau — its remaining asks
+had crossed into operator-manual territory — and replaced from round 4
+by (C) a tech lead evaluating team adoption cost, a lens the first
+three rounds had not covered.
+
 ## Trajectory
 
-| Round | A (frontend dev) | B (agent operator) | Comprehension quiz |
-|---|---|---|---|
-| 1 | 6/10 | 5/10 | all correct (basics) |
-| 2 | 6/10 | 6/10 | all correct incl. round-1 fixes (gate def, speed, keys, ledger) |
-| 3 | 6/10 | 7/10 | all correct incl. round-2 fixes (limits, exemptions, false-negative count) — B additionally inferred an unstated ledger limitation |
+| Round | A (frontend dev) | B (agent operator) | C (tech lead) | Comprehension quiz |
+|---|---|---|---|---|
+| 1 | 6/10 | 5/10 | — | all correct (basics) |
+| 2 | 6/10 | 6/10 | — | all correct incl. round-1 fixes (gate def, speed, keys, ledger) |
+| 3 | 6/10 | 7/10 | — | all correct incl. round-2 fixes (limits, exemptions, false-negative count) — B additionally inferred an unstated ledger limitation |
+| 4 | 7/10 | retired | 6/10 | all correct incl. round-3 fixes (cheat-sheet when-annotations, SKILL.md excerpt, audit-site names) |
+| 5 | 6/10 | — | 7/10 | all correct incl. round-4 fixes (triage path, manifest ownership, rollout order) |
+| 6 | 6.5/10 | — | 6/10 | all correct incl. round-5 restructure (section order, agent-section compression) |
 
 ## What each round changed
 
@@ -35,12 +44,34 @@ The quiz is re-targeted each round at the previous round's fixes, so
   measured, no user exemption list for integrity yet, the real
   false-negative number — 1 in 19 scenarios, promoted to probe A13 —
   flow gates prove only walked paths, no third-party CSS scoping).
-- **Round 3 → final polish**: when-to-use annotations on the cheat
+- **Round 3 → 4**: when-to-use annotations on the cheat
   sheet + a `vlmkit watch` pointer, an actual SKILL.md excerpt
   (B's top ask two rounds running), the seven audit sites named
-  inline with a methodology link.
+  inline with a methodology link; a 2-line GitHub Actions snippet,
+  gate mechanics made concrete (case-sensitive copy matching, 25px
+  sweep steps), and a "how is this different from a screenshot
+  service" differentiation section.
+- **Round 4 → 5**: team-adoption answers for the new tech-lead lens —
+  who owns the copy manifest (same-PR rule), snapshot approve as the
+  intended-change path, a failure-triage path (real defect vs
+  intentional pattern vs tool limit), rollout order, MCP tool roster,
+  manifest scale guidance; plus claim-scoping ("proves only walked
+  paths") and concrete output examples.
+- **Round 5 → 6 (restructure, not accretion)**: round 5 showed
+  reviewer-driven accretion — the doc had grown 170 → 395 lines
+  across rounds and A's score *fell* 7 → 6 citing length. Fix was
+  structural: operations content moved before the agent section, the
+  agent section compressed ~35%, "What vlmkit is not" tightened
+  (395 → 371 lines). No new content added.
+- **Round 6 → 7**: both personas converged on one blocker — show a
+  real `layout.json`. Writing it exposed a **doc overclaim**: the
+  text said "buttons ≥ 48px tall on mobile" was encodable, but
+  `LayoutRule` had no height assertion. Resolution: implement
+  `minHeight` in the tool (every-visible-match semantics, reports the
+  shortest) rather than weaken the doc, then paste the E2E-verified
+  4-rule example into "Can we encode our own rules?".
 
-## Convergence call (loop ended after round 3)
+## Convergence call after round 3 (superseded — loop resumed)
 
 - **Comprehension saturated**: every quiz answer correct in rounds
   2–3, including the subtlest material (exemption mechanics, the
@@ -69,3 +100,21 @@ The quiz is re-targeted each round at the previous round's fixes, so
   convergence criterion that worked was "quiz saturated AND remaining
   asks are out-of-scope or fabrication-requiring," not a score
   threshold.
+- **The rubric guarantees findings.** "A review with no findings is a
+  failed review" is the right instruction for rigor, but it makes the
+  loop a structural ratchet: every round produces suggestions, so the
+  loop never self-terminates on an empty round. The stop signal has
+  to come from the *content* of the findings (out-of-scope, would
+  require fabrication, contradicts an earlier accepted trade), never
+  their existence.
+- **Reviewer-driven accretion is the loop's failure mode.** Each
+  round's fixes add lines; the persona that wanted a short intro then
+  scores the length down (A: 7 → 6 at round 5). Every few rounds the
+  right move is a restructure/compression pass that adds nothing —
+  treating "the doc got worse by getting more complete" as a real
+  finding.
+- **Evaluator pressure can find tool bugs, not just doc bugs.** The
+  round-6 demand for a concrete example forced the discovery that the
+  doc promised an assertion the tool didn't have (`minHeight`). A doc
+  loop over an honest document is partially a spec-conformance test
+  of the tool.

--- a/docs/reports/2026-08-01-introduce-doc-eval-loop.md
+++ b/docs/reports/2026-08-01-introduce-doc-eval-loop.md
@@ -31,6 +31,7 @@ three rounds had not covered.
 | 6 | 6.5/10 | — | 6/10 | all correct incl. round-5 restructure (section order, agent-section compression) |
 | 7 | 7/10 | — | 7/10 | all correct incl. round-6 fixes (minHeight every-match semantics, the 30px-button rule, contract example values) — both personas' best-ever scores |
 | 8 | 7/10 | — | 8/10 | all correct incl. round-7 fixes (name fossil, verify-markup mechanism, never-idle behavior, cross-OS baselines, Haiku attribution, suppression persistence) — first 8 of the loop |
+| 9 | 7/10 | — | 7/10 | all correct incl. round-8 fixes (verify-markup boundary, palette-harmony mechanism, install commands, vrt.config.json fossil, suspect floors, error exit behavior) |
 
 ## What each round changed
 
@@ -115,7 +116,49 @@ three rounds had not covered.
   expectations block; the MCP roster de-enumerated (it was
   first-introducing tools the doc never covers).
 
-## Convergence call after round 3 (superseded — loop resumed)
+- **Round 9 fixes**: the dev found the loop's last genuine spec
+  ambiguity — what exit code does a suspect produce *without*
+  `--fail-on-suspect`? Verified against source and stated exactly
+  (integrity fails always exit non-zero; suspect gates exit zero
+  without the flag; errors always non-zero). Also fixed: the
+  `check asset` cheat-sheet line now carries the `--against-bg` /
+  `--page-palette` arguments its prose promised; a real `flow.json`
+  example (from the S19 fixture) parallel to the layout example;
+  "Every command runs after just that" scoped to tooling (the
+  user-defined gates need their file written); the zero-FP claim
+  re-scoped to "in that seven-site sample"; fonts promoted to a
+  first-class determinism boundary (matched-font wobble ~1px vs
+  missing-font reflow crossing any floor) in both the flake bullet
+  and Honest limits; auth promoted from a parenthetical to its own
+  Honest-limits bullet; a worked npm-scripts block with an honest
+  ~20-page scale ceiling.
+
+## Convergence call after round 9 (recommended stop)
+
+Scores: dev 6, 6, 6, 7, 6, 6.5, 7, 7, 7 · operator 5, 6, 7 (retired)
+· lead 6, 7, 6, 7, 8, 7. The comprehension quiz has been perfect for
+eight consecutive rounds, each time re-targeted at the newest fixes —
+transmission is not the bottleneck and hasn't been since round 2.
+
+What distinguishes round 9's residue is its *category*: every
+remaining ask is (a) feature work, not doc work (central gate-config
+manifest, cookie/storage-state injection, user exemption list for
+integrity, monorepo glob runner, parallelism/sharding), (b) evidence
+that cannot be written into existence (external adopters, cross-OS
+validation runs on hardware this project doesn't have, issue-response
+track record for a young project), or (c) reference-manual content
+the intro deliberately links out to. The in-scope findings this round
+were real (exit-code semantics!) but they were the last of their
+kind: three consecutive rounds of fresh evaluators produced no new
+structural, honesty, or comprehension complaints.
+
+Per the standing criterion — **quiz saturated AND remaining asks
+out-of-scope or fabrication-requiring** — the loop should stop here.
+The feature asks it surfaced are recorded in TODO.md as backlog, which
+is the correct escalation: reviewer pressure on an honest document
+ends up producing a tool roadmap.
+
+## Original convergence call after round 3 (superseded — loop resumed)
 
 - **Comprehension saturated**: every quiz answer correct in rounds
   2–3, including the subtlest material (exemption mechanics, the

--- a/docs/reports/2026-08-01-introduce-doc-eval-loop.md
+++ b/docs/reports/2026-08-01-introduce-doc-eval-loop.md
@@ -1,0 +1,71 @@
+# introduce.md evaluation loop: three rounds of blind persona review (2026-08-01)
+
+## Method
+
+The agent-validation-loop applied to a document. Each round, two
+FRESH disposable evaluators (no memory of prior rounds) read ONLY
+`docs/introduce.md` in persona and answer a fixed rubric: one-sentence
+summary, would-you-try-it, a comprehension quiz, picky quote-level
+critique, blocking questions, three concrete suggestions, and a /10
+score with an explicit no-inflation instruction. Personas: (A) a
+VRT-naive frontend developer skeptical of tool marketing; (B) an
+agent operator burned by false "verified" claims, evaluating tools.
+The quiz is re-targeted each round at the previous round's fixes, so
+"did the fix land" is measured, not assumed.
+
+## Trajectory
+
+| Round | A (frontend dev) | B (agent operator) | Comprehension quiz |
+|---|---|---|---|
+| 1 | 6/10 | 5/10 | all correct (basics) |
+| 2 | 6/10 | 6/10 | all correct incl. round-1 fixes (gate def, speed, keys, ledger) |
+| 3 | 6/10 | 7/10 | all correct incl. round-2 fixes (limits, exemptions, false-negative count) — B additionally inferred an unstated ledger limitation |
+
+## What each round changed
+
+- **Round 1 → 2**: jargon defined at first use (gate/MCP/skill, VLM
+  dropped from prose); every adversarial claim linked to its dated
+  report; ledger shown as a real JSON line; `.mcp.json` shown
+  verbatim; worked kickback→fix→CLEAN example added; the three
+  key-gated features named; MIT + CI usage stated.
+- **Round 2 → 3**: expectations block (per-gate seconds, Playwright
+  download weight, 30s network-idle settle — verified against source,
+  auth-wall answer); copy-paste cheat sheet; skill path made concrete
+  (one SKILL.md); **Honest limits** section (how "intentional" is
+  measured, no user exemption list for integrity yet, the real
+  false-negative number — 1 in 19 scenarios, promoted to probe A13 —
+  flow gates prove only walked paths, no third-party CSS scoping).
+- **Round 3 → final polish**: when-to-use annotations on the cheat
+  sheet + a `vlmkit watch` pointer, an actual SKILL.md excerpt
+  (B's top ask two rounds running), the seven audit sites named
+  inline with a methodology link.
+
+## Convergence call (loop ended after round 3)
+
+- **Comprehension saturated**: every quiz answer correct in rounds
+  2–3, including the subtlest material (exemption mechanics, the
+  false-negative story). The document *transmits*; remaining score
+  friction is scope, not clarity.
+- **Remaining findings crossed the intro's scope boundary or would
+  require fabrication**: LLM pricing/model tables, an exemption
+  roadmap with dates, CI pipeline recipes, copy-manifest lifecycle —
+  reference/configuration territory (and A said so themselves: "for a
+  project that's fine; for an introduction…"). Declined rather than
+  invented.
+- **Score plateau with rising floor**: A flat at 6 across three rounds
+  with rotating rationale (the persona wants a getting-started guide,
+  which the intro deliberately is not); B rising 5→6→7 as integration
+  and evidence concerns were answered.
+
+## Standing observations for future doc loops
+
+- Fresh evaluators per round are essential — the quiz proves fixes
+  landed without contaminating the reader simulation.
+- Persona tension is information: A wanted the agent section exiled,
+  B called it the persuasive core. The resolution (skip cue +
+  compression, not removal) satisfied B's trajectory without moving
+  A — an accepted trade, documented rather than churned.
+- The evaluators reliably over-ask an intro to be a manual. The
+  convergence criterion that worked was "quiz saturated AND remaining
+  asks are out-of-scope or fabrication-requiring," not a score
+  threshold.

--- a/docs/reports/2026-08-01-introduce-doc-eval-loop.md
+++ b/docs/reports/2026-08-01-introduce-doc-eval-loop.md
@@ -30,6 +30,7 @@ three rounds had not covered.
 | 5 | 6/10 | — | 7/10 | all correct incl. round-4 fixes (triage path, manifest ownership, rollout order) |
 | 6 | 6.5/10 | — | 6/10 | all correct incl. round-5 restructure (section order, agent-section compression) |
 | 7 | 7/10 | — | 7/10 | all correct incl. round-6 fixes (minHeight every-match semantics, the 30px-button rule, contract example values) — both personas' best-ever scores |
+| 8 | 7/10 | — | 8/10 | all correct incl. round-7 fixes (name fossil, verify-markup mechanism, never-idle behavior, cross-OS baselines, Haiku attribution, suppression persistence) — first 8 of the loop |
 
 ## What each round changed
 
@@ -95,6 +96,24 @@ three rounds had not covered.
   a broken em-dash sentence in the copy-gate paragraph and the
   cheat sheet's silent omission of `check interactions` (added; only
   `verify flow` stays out, with the reason stated).
+
+- **Round 8 → 9**: the findings shrank a grade — no structural or
+  honesty complaints left, mostly reference hygiene and unpriced
+  operations. Fixed: the dangling forward-reference to the ledger
+  (now introduced in the team section with lifecycle guidance —
+  gitignore, one JSON line per run); `vrt.config.json` called out as
+  a second naming fossil; the unquantified "rare" flake claim
+  replaced with the real suspect floors (page overflow from 2px,
+  text collision needs 6px on both axes) plus the error-vs-suspect
+  CI behavior (errors exit non-zero — fail loudly, never silently
+  pass); an ephemeral-CI baseline recipe (commit or cache, approve
+  in the intending PR); `verify markup`'s applicability boundary
+  stated (flat-fill UI comps, not photographic art); `check asset`'s
+  "colors that don't clash" replaced with the measured
+  palette-harmony mechanism (dominant-color share near the page
+  palette, warn not fail); install commands made concrete in the
+  expectations block; the MCP roster de-enumerated (it was
+  first-introducing tools the doc never covers).
 
 ## Convergence call after round 3 (superseded — loop resumed)
 

--- a/docs/reports/2026-08-01-introduce-doc-eval-loop.md
+++ b/docs/reports/2026-08-01-introduce-doc-eval-loop.md
@@ -29,6 +29,7 @@ three rounds had not covered.
 | 4 | 7/10 | retired | 6/10 | all correct incl. round-3 fixes (cheat-sheet when-annotations, SKILL.md excerpt, audit-site names) |
 | 5 | 6/10 | — | 7/10 | all correct incl. round-4 fixes (triage path, manifest ownership, rollout order) |
 | 6 | 6.5/10 | — | 6/10 | all correct incl. round-5 restructure (section order, agent-section compression) |
+| 7 | 7/10 | — | 7/10 | all correct incl. round-6 fixes (minHeight every-match semantics, the 30px-button rule, contract example values) — both personas' best-ever scores |
 
 ## What each round changed
 
@@ -70,6 +71,30 @@ three rounds had not covered.
   `minHeight` in the tool (every-visible-match semantics, reports the
   shortest) rather than weaken the doc, then paste the E2E-verified
   4-rule example into "Can we encode our own rules?".
+
+- **Round 7 → 8**: both personas converged again, this time on
+  honesty gaps rather than missing content: the section heading
+  "a referee that can't be argued with" was self-refuting (the doc
+  itself documents three successful gaming attempts) → retitled
+  "a referee with an audit trail"; "impossible to forget" (×2) →
+  detectability phrasing with the CI-wiring caveat made explicit;
+  cross-environment flakiness silence → a "Will it flake in CI?"
+  bullet (geometry gates stable, snapshot baselines must be
+  generated where they're compared); never-idle pages (polling/
+  websockets) → stated plainly that the gate errors at the 30s cap,
+  plus no-auth-injection admission; `verify markup`'s mechanism
+  (dev: "the one claim I flatly don't believe") → one sentence on
+  connectivity segmentation + region pairing + pixel confirmation;
+  "inexpensive models handle this fine" → named Haiku 4.5 with the
+  kickback-rounds caveat; the unexplained VLM-name tension → the
+  "name is the fossil record" note; suppression persistence → new
+  "Where does gate configuration live?" bullet admitting there is
+  no central config file; integrity FP-audit gap → linked the
+  2026-07-30 five-site external dogfood; project maturity → 0.8.x /
+  one-maintainer disclosure sized to the rollout advice. Also fixed
+  a broken em-dash sentence in the copy-gate paragraph and the
+  cheat sheet's silent omission of `check interactions` (added; only
+  `verify flow` stays out, with the reason stated).
 
 ## Convergence call after round 3 (superseded — loop resumed)
 

--- a/docs/reports/2026-08-02-batch-runner-ci-budget.md
+++ b/docs/reports/2026-08-02-batch-runner-ci-budget.md
@@ -1,0 +1,97 @@
+# `vlmkit batch` — multi-page gate runner, and what it costs in CI
+
+2026-08-02. Backlog item "マルチページランナー": run every page's gates from
+one glob, and answer the CI-time-budget question with measurements instead of
+a shrug.
+
+## Design: the exit code is the interface
+
+Each (gate, page) pair runs as its own child process, and the verdict is that
+process's **exit code**. Nothing else is parsed.
+
+That choice falls straight out of the exit-code contract unified in
+`packages/vlmkit-core/src/gate-exit.ts` (suspect/defect ⇒ non-zero, warn ⇒
+zero). Because the runner reads only the exit code:
+
+- it needs no knowledge of any report shape, so a gate is batchable the day it
+  lands — `check design`, added hours earlier, needed zero runner changes;
+- a gate's own flags pass through untouched (`--gate "check design --min-reuse 4"`);
+- one page's crashed browser cannot take the run down.
+
+The alternative — importing each gate's `run*Check()` and reading `verdict` —
+would have required per-gate adapters for four different report shapes
+(`verdict: "clean" | "defects"`, `done: boolean`, `verdict: "coherent" |
+"drift"`, plain finding arrays) and would have made every new gate a runner
+change too.
+
+```bash
+vlmkit batch --gate "check integrity" "routes/**/*.html"
+vlmkit batch --gate "check integrity" --gate "check design" "dist/**/*.html" --concurrency 4
+vlmkit batch --gate "check integrity" "routes/**/*.html" --shard 2/3 --output ci-logs/
+```
+
+## Measured: concurrency sweep
+
+9 pages (`fixtures/auto-markup-proof/creative/*.html`), `check integrity`
+(the heaviest gate — 3 viewports per page), 4-core container, one discarded
+warm-up run before the sweep so no row pays the cold Chromium page cache.
+
+| concurrency | wall | job time total | avg in flight | slowest job | speedup vs serial |
+|---|---|---|---|---|---|
+| 1 | 34.9s | 34.9s | 1.00 | 4.3s | 1.00x |
+| 2 | 20.0s | 36.0s | 1.80 | 4.4s | **1.75x** |
+| 4 | 13.1s | 42.4s | 3.23 | 5.7s | **2.66x** |
+| 8 | 11.0s | 64.9s | 5.92 | 8.0s | **3.17x** |
+
+Two things to read off this:
+
+**Per-job time inflates with concurrency, so "jobs in flight" is not speedup.**
+The same nine jobs sum to 34.9s of work at concurrency 1 and 64.9s at
+concurrency 8 — each job gets slower as browsers compete for 4 cores. The
+first draft of the summary line divided job time by wall time and printed
+"5.9x" for the concurrency-8 run, where the honest gain over a serial run was
+3.17x. The output now says `avg 5.9 jobs in flight` instead, which is what
+that ratio actually measures.
+
+**The knee is at cores, and past it you buy wall-clock with CPU.** On 4 cores,
+concurrency 2 is nearly free (+3% total job time for 1.75x). Concurrency 4
+costs +21% job time for 2.66x. Concurrency 8 buys a further 16% of wall for
++53% more CPU — worth it on a dedicated CI runner billed by wall clock,
+wasteful on a shared one. Default is `min(4, cores - 1)`.
+
+## Measured: sharding across runners
+
+Same page set, `--shard i/3`, concurrency 2 per shard — the "three CI machines"
+case:
+
+| shard | jobs | wall |
+|---|---|---|
+| 1/3 | 3 | 7.8s |
+| 2/3 | 3 | 7.8s |
+| 3/3 | 3 | 7.6s |
+
+Balanced to within 0.2s, versus 20.0s for one runner at the same concurrency.
+Sharding is **stride**, not contiguous slices: pages in one directory tend to
+cost the same (a `routes/admin/**` subtree of dense tables is uniformly slow),
+so contiguous slicing hands one shard the whole expensive subtree. Stride
+spreads neighbours across shards.
+
+## The floor
+
+No amount of concurrency beats the slowest single job (4.3s serial, 8.0s at
+concurrency 8). That is why the summary prints the five slowest jobs: when
+wall time is dominated by one page, the fix is that page's gate set or that
+page, not more parallelism. Adding runners past `pages / slowest-job` buys
+nothing.
+
+## Scope
+
+- Verdicts are exit codes, so a *warn*-level finding (`check design` drift,
+  `check copy` advisories) does not fail a batch run — same as running the gate
+  by hand. `--output <dir>` keeps every job's log plus `batch-summary.json`
+  when you want the warnings anyway.
+- One gate set applies to all matched pages. Per-page gate sets remain the
+  separate open backlog item (中央ゲート設定ファイル); this runner is the
+  execution half, not the configuration half.
+- Numbers above are one 4-core container. The point is the shape (knee at
+  cores, per-job inflation, stride balance), not the absolute seconds.

--- a/docs/reports/2026-08-02-differential-audit-three-axes.md
+++ b/docs/reports/2026-08-02-differential-audit-three-axes.md
@@ -1,0 +1,96 @@
+# Differential audit: viewport order, dpr, `--json` vs printed output
+
+2026-08-02. The load-mechanism defect earlier today was found by asking "do two
+paths that should agree actually agree?" This applies the same instrument to the
+three remaining axes. Two produced defects; one turned out not to be an
+equivalence question at all.
+
+## 1. Viewport sweep order — defect
+
+`check integrity` dedupes findings across the sweep, keeping the first
+observation. So the retained finding — and its reported viewport — depended on
+the order the caller listed widths in:
+
+```
+--viewports 1280,768,375 :  low-contrast-text | p.low-contrast | 1280
+--viewports 375,768,1280 :  low-contrast-text | p.low-contrast | 375
+```
+
+Same defect, same page, different attribution. Two consequences:
+
+- **`--allow "…@1280"` was silently order-dependent.** The exemption feature
+  added hours earlier matches on viewport, so a rule scoped to a width worked or
+  didn't depending on how the sweep was ordered.
+- **"@375" reads as "mobile only"** for a defect present at every width, which
+  is a different bug to fix than a genuinely mobile-only one.
+
+**Fix.** The sweep is sorted widest-first internally, whatever order the caller
+gave, and a repeat at a narrower width now records that width instead of being
+dropped without trace:
+
+```
+low-contrast-text | p.low-contrast | 1280,768,375
+near-misalignment | button.btn-b   | 1280,768,375
+near-misalignment | button.btn-c   | 1280,768        <- 375 is fine, and now visible
+```
+
+`btn-c` misaligns at two widths and not the third — information that did not
+exist in the report before. `--allow` matches any observed width.
+
+## 2. dpr — not an equivalence axis
+
+Only `build component` exposes `--dpr`, and there it deliberately changes the
+render to match a retina target image, so there is nothing that "should agree".
+The gates do not take a dpr, and the one measurement already available (the font
+determinism probe, same day) put dpr 2 at ≤1.00px of ink drift with zero verdict
+flips. No work; recorded so the axis is not re-opened as an unknown.
+
+## 3. Printed output vs the data — defect
+
+`check a11y contrast`, `check a11y touch` and `check a11y focus` printed a
+headline count and then **five rows, with no note that the list was cut**:
+
+```
+✗ 12 contrast failure(s)
+  p.low0 — 1.92:1 …
+  p.low1 — 1.92:1 …
+  p.low2 — 1.92:1 …
+  p.low3 — 1.92:1 …
+  p.low4 — 1.92:1 …          <- and that is the whole output
+```
+
+Twelve findings, five shown. `check breakpoints` and `check integrity` already
+disclosed their caps (`… N more (use --json for all)`); these three did not, and
+their markdown reports cut at 20/30 rows silently too.
+
+**Fix, and the mistake inside it.** I added the disclosure lines first —
+"… 7 more (see the report, or --json for all)" — and then checked: **these gates
+had no `--json` flag at all.** The notice pointed at something that did not
+exist, and the markdown version claimed "the JSON report has all of them" when
+there was no JSON report. Rather than soften the wording to match a weaker
+reality, `--json` was added to all four (the three a11y gates plus
+`stress i18n`), so the claim is true and an agent can get every row:
+
+```
+check a11y contrast --json  ->  json rows: 12
+check a11y touch    --json  ->  json rows: 12
+```
+
+That is also a consistency fix in its own right: the docs describe `--json` as
+available on the gates, and these were the exceptions.
+
+## Regression gate
+
+`packages/vlmkit-markup/src/output-consistency.test.ts` — six tests: same
+findings in either sweep order, attribution to the widest observed width, the
+per-width list distinguishing page-wide from mobile-only, `--allow` matching any
+observed width, and the two a11y reports retaining all twelve findings the
+console truncates.
+
+## Method note
+
+Three defects in one day came from the same question, asked of a different pair
+each time: navigate vs `setContent`, four hand-rolled argv parsers vs each other,
+sweep order vs sweep order, printed vs stored. None of them was visible in a
+single run — each needed two runs and a comparison. Axes now measured and clean:
+`file://` vs `http://`, dpr, and these three.

--- a/docs/reports/2026-08-02-external-asset-load-defect.md
+++ b/docs/reports/2026-08-02-external-asset-load-defect.md
@@ -1,0 +1,114 @@
+# Six gates were measuring a different document
+
+2026-08-02. Found while inventorying refactor candidates: the answer to "what
+else should be refactored" turned out to be a correctness bug, so the refactor
+became the fix.
+
+## The defect
+
+A gate that takes an HTML file had two ways to load it, and they do not produce
+the same document:
+
+| Mechanism | Document base URL | `<link rel="stylesheet" href="style.css">` |
+|---|---|---|
+| `page.goto(pathToFileURL(file))` | the file URL | loads |
+| `page.setContent(await readFile(file))` | `about:blank` | **never loads** |
+
+Ten gates used the second form. Since almost every real project keeps its CSS
+in a separate file, those gates were judging unstyled markup.
+
+First measurement, on a page whose only defect is `p { color: #bbbbbb }`
+(1.92:1 on white) in an external stylesheet:
+
+```
+check a11y contrast, external stylesheet : ✓ 0 contrast failure(s)
+check a11y contrast, same CSS inlined    : ✗ 1 contrast failure(s)
+check integrity (navigates to the file)  : low-contrast-text … 1.92:1
+```
+
+## Which gates, measured — not assumed
+
+The file-list said ten. Running each gate against
+`fixtures/external-assets/page.html` and against a twin with the identical CSS
+inlined said **six**, and the other four were already fine:
+
+| Gate | Before | After |
+|---|---|---|
+| `check a11y contrast` | 0 failures vs 1 — missed it entirely | agree |
+| `check a11y touch` | **verdict inverted** (below) | agree |
+| `check tokens` | 12 padding violations vs 9 | agree |
+| `check theme` | differed | agree |
+| `stress i18n` | card `21→86` vs `95→185` | agree |
+| `stress media` | **forced-colors ✗ vs ✓** | agree |
+| `check a11y focus` | already agreed | — |
+| `check breakpoints` | already agreed | — |
+| `check copy` | already agreed | — |
+| `check design` | already agreed | — |
+
+Two are worth spelling out, because "fewer findings" understates them:
+
+**`check a11y touch` was inverted, not just incomplete.** With the stylesheet
+missing it inspected 3 elements instead of 4 — the 20×20 tap target gets its
+size from CSS, so unstyled it is a zero-size inline `<a>` and never becomes a
+candidate at all. Meanwhile it reported three buttons as undersized at their
+unstyled sizes (39×21, 58×21, 52×21) that are 66×42 / 80×39 / … once styled. So
+it missed the one real violation and invented three.
+
+**`stress media` flipped a pass into a fail.** It compares screenshots across
+media emulations; on an unstyled document forced-colors barely changes anything,
+so it reported `Δ 0.36% → fails`. With the CSS applied: `Δ 1.46% → passes`.
+
+## The fix
+
+`packages/vlmkit-core/src/page-open.ts` — one way to open the page under test:
+`openSource` (navigate; relative assets resolve; auth state and redirect
+description folded in) and `openHtml` (for gates that must rewrite the document
+first). All six gates now call it.
+
+`openHtml` needed an empirical detour. The obvious fix for mutated HTML is to
+inject a `<base href="file:///dir/">`; measured on the same fixture, that does
+**not** work:
+
+```
+setContent + injected <base href="file:///dir/">  ->  rgb(0, 0, 0)   (unstyled)
+goto(file) then setContent                        ->  rgb(4, 5, 6)   (styled)
+```
+
+The `setContent` document has an opaque origin and Chromium blocks a `file://`
+subresource from one. So `openHtml` navigates to the source first and *then*
+replaces the markup: the document keeps a real base URL. The `<base>` helper was
+deleted rather than shipped, since keeping it would enshrine a technique
+measured as broken.
+
+## The regression gate
+
+`fixtures/external-assets/` declares **every** defect in `style.css` and none in
+`page.html`: a contrast failure, a CSS-sized tap target, copy hidden by
+`font-size: 0`, a spacing outlier, and three button styles.
+`packages/vlmkit-markup/src/external-assets.test.ts` runs each gate on it and on
+an inlined twin and requires the same verdict. The assertion is differential, so
+a threshold change moves both numbers without breaking the test, while a gate
+that stops resolving assets breaks it immediately.
+
+Two traps hit while writing that test, both worth recording:
+
+- Two assertions were **vacuous** — they compared `${o.selector}` on both sides
+  where the field is `path`, so both sides stringified to `undefined` and
+  `deepEqual` passed. `tsc` caught it; the test run did not.
+- The fixture path was cwd-relative, so under `pnpm --filter` the whole suite
+  errored on ENOENT **while the summary still printed `0 fail`**. A suite that
+  fails to build is not a failing test in that reporter. Fixture paths are now
+  resolved from `import.meta.url`.
+
+## Scope
+
+- Verdicts on pages with external CSS change, by design — that is the fix. A
+  project that tuned thresholds against the old unstyled measurements will see
+  different numbers.
+- Untouched: modules that `setContent` HTML they synthesized in memory
+  (`build component`, the css-challenge harnesses). They have no file whose
+  siblings need resolving.
+- Not yet unified: `chromium.launch` still appears at 44 sites, and
+  `waitUntil` is 72 `networkidle` / 8 `load` / 1 `domcontentloaded`. Routing
+  those through `openSource` is the remaining half of the refactor; this pass
+  covered the gates where the load mechanism changed the verdict.

--- a/docs/reports/2026-08-02-font-determinism-collision-floors.md
+++ b/docs/reports/2026-08-02-font-determinism-collision-floors.md
@@ -1,0 +1,125 @@
+# Cross-OS font determinism of the `text-collision` ink floors
+
+2026-08-02. Backlog item "クロス OS フォント決定論の実測レポート": do the
+collision gate's 2px/6px floors survive a different font rendering, in both the
+bundled-font and unbundled-font conditions?
+
+**No macOS hardware was available, and this report does not pretend otherwise.**
+What it delivers instead is (a) a probe that fingerprints the corpus in one
+command so the macOS half is a single run plus a diff, and (b) Linux
+measurements of the perturbations that *cause* the cross-OS difference, which
+bound the risk without claiming to have run on macOS.
+
+## What is actually font-dependent
+
+```
+inkInset = clamp((lineHeight - (ascent + descent)) / 2, 0, fontSize / 2)
+report iff  ox >= 6  &&  oy >= 6  &&  oy >= max(2, 0.5 * min-ink-height)
+```
+
+`ascent + descent` comes from canvas `measureText`, so `inkInset` — and through
+it both `oy` and the per-pair threshold — is a function of the resolved face's
+metrics. Two independent things vary across OSes:
+
+| Condition | What differs | Modelled here by |
+|---|---|---|
+| **Font bundled** (`@font-face`, same file everywhere) | Same face, different rasterizer/hinting | `--hinting none` (hinting, subpixel positioning, LCD text off) and `--dpr 2` |
+| **Font not bundled** (`system-ui`, `sans-serif`) | The family resolves to a *different face* | Forcing DejaVu Serif / Liberation Sans / WenQuanYi Zen Hei / bundled Noto Sans onto every element |
+
+The unbundled case is the harsher one, and the substitution conditions model it
+directly: replacing the stack outright moves metrics at least as far as
+`sans-serif` resolving to Helvetica instead of DejaVu Sans.
+
+## The instrument
+
+`src/util/font-determinism-probe.ts` (12 unit tests). It does **not**
+re-implement the gate — it drives the production `COLLECT_INTEGRITY_TEXT`
+script and `findTextCollisions`, then records what the gate does not expose:
+every candidate pair's **distance from its own floor**.
+
+```bash
+# same command on each OS
+node --experimental-strip-types src/util/font-determinism-probe.ts measure \
+  "fixtures/collision-fp-corpus/*.html" --label macos-default --out macos.json
+node --experimental-strip-types src/util/font-determinism-probe.ts compare linux.json macos.json
+```
+
+Two design decisions were forced by first results:
+
+**Near-misses are kept.** The first version recorded only pairs whose ink bands
+already overlapped, which found 5 candidates across 20 pages. Pairs that clear
+each other by a few px are exactly what a metric shift can push into range, so
+the probe now keeps anything within 8px of touching: 121 candidates.
+
+**A flip is classified, not just counted.** The first comparison reported three
+"unstable" verdicts under font substitution. Inspecting the numbers showed the
+pair had not crossed its floor — it had *disappeared*. In
+`sliver-true-positive.html` two absolutely-positioned labels graze because a
+`ui-monospace` string is wide enough to reach the second label's `left: 168px`;
+under a proportional face the string is shorter and the labels never touch.
+Both verdicts are correct for their own rendering. So the tool now separates:
+
+- **threshold flip** — pair present in both runs, reported in one. The only
+  outcome that indicts the floor.
+- **geometry flip** — the overlap itself appeared or vanished. The page renders
+  differently; the gate is not judging differently.
+
+Conflating the two would have produced a false alarm about the gate, from data
+that actually says the gate was right twice.
+
+## Measured
+
+Corpus: 6 collision-FP fixtures + 9 agent-built pages + 5 mirrored real pages
+(MDN, web.dev, Wikipedia, Hacker News, W3C APG) = 20 pages, **2154 text
+blocks**, **121 candidate pairs**, 1 reported at baseline. `dInk` is the
+per-block `inkInset` change vs the Linux default; `dMargin` is the change in
+distance-to-floor for pairs present in both runs.
+
+| condition | dInk max | dInk p95 | dMargin max | pairs in both | **threshold flips** | geometry flips |
+|---|---|---|---|---|---|---|
+| DejaVu Serif (substitution) | 3.00px | 1.00px | 2.00px | 80 | **0** | 0 |
+| Liberation Sans (substitution) | 2.00px | 0.50px | 10.50px | 111 | **0** | 1 |
+| WenQuanYi Zen Hei (substitution) | 2.00px | 1.00px | 12.00px | 80 | **0** | 1 |
+| Noto Sans, bundled woff2 | 2.50px | 1.50px | 10.00px | 90 | **0** | 1 |
+| hinting/subpixel/LCD off | 0.51px | 0.00px | 0.50px | 119 | **0** | 0 |
+| deviceScaleFactor 2 | 1.00px | 1.00px | 1.10px | 115 | **0** | 0 |
+
+**Zero threshold flips under every perturbation.** Margins moved by up to 12px
+(`tall-metrics.html`, whose ink band changes a lot with the face) without a
+single pair crossing its floor.
+
+### Reading it per condition
+
+- **Bundled font** (same face, different rasterizer): `inkInset` moved by at
+  most **0.51px**, p95 **0.00px** — the ink measurement is essentially
+  rasterizer-independent, because `measureText` returns font-unit metrics
+  scaled by font size, not rasterized pixels. dpr 2 adds at most 1.00px through
+  layout rounding. Both left every verdict intact. This is the condition that
+  most plausibly transfers to macOS unchanged.
+- **Unbundled font** (family resolves elsewhere): `inkInset` moved by up to
+  **3.00px**, p95 ≤1.5px, and verdicts still held. The three differing reports
+  were all geometry: the overlap stopped existing.
+
+## The honest limit
+
+**One pair out of 121 sits within ±2px of its floor** (an APG table cell and
+its `<kbd>` child, margin −0.8px). So this corpus cannot demonstrate that the
+floor is robust *in general* — it demonstrates that under six perturbations,
+including ones that move ink by 3px, nothing flipped, and that the at-risk
+population is tiny. The same gap the 2026-08-01 FP re-audit hit applies here:
+few pairs live near the floor, so "quiet under perturbation" and "nothing was
+near the floor to begin with" are hard to separate. The p95 drift (≤1.5px)
+versus the at-risk margin distribution is the quantitative answer available.
+
+What would close it properly:
+
+1. **Run `measure` on macOS** and `compare` against the committed Linux
+   fingerprint. One command each; a threshold flip exits non-zero.
+2. **Fixtures deliberately placed at the floor** — pairs engineered to sit at
+   margin ±0.5px, so a perturbation *must* flip them if the floor is fragile.
+   That is a corpus-authoring task, not a measurement one, and it is the real
+   prerequisite for a strong claim.
+
+Until then the claim this report supports is narrow and stated as such: the ink
+measurement is rasterizer-insensitive (≤0.51px), font substitution moves it by
+≤3px, and no verdict in a 2154-block corpus changed as a result.

--- a/docs/reports/2026-08-02-settle-not-waituntil.md
+++ b/docs/reports/2026-08-02-settle-not-waituntil.md
@@ -1,0 +1,165 @@
+# "Cosmetic: `waitUntil` levelling" was the wrong axis — and six gates were reading the wrong document
+
+2026-08-02. The page-open unification left a remainder I labelled cosmetic:
+44 `chromium.launch` sites, a `waitUntil` spread of 71 `networkidle` / 8 `load` /
+2 `domcontentloaded`, and 6 scattered `fonts.ready` calls. Levelling the load
+states looked like tidying.
+
+The label was wrong for the second time today. Measured against a page that
+renders its content 350ms after `load`:
+
+```
+check layout   (networkidle + settle)   count .card = 2            <- correct
+verify flow    (load, no settle)        count .card = 0, FAIL      <- blames the markup
+build page     (load, no settle)        5.3% of the settled ink    <- every component missing
+scan contract  (load, no settle)        0 landmarks                <- and 4 when settled
+```
+
+Three gates, three different wrong answers about the same page at the same
+instant, every one of them phrased as a defect in the markup.
+
+## Why `waitUntil` is not the axis
+
+`goto(load)` followed by a settle waits for network idle anyway. So the 8 `load`
+and 2 `domcontentloaded` sites are equivalent to the 71 `networkidle` ones
+**provided they settle**. Levelling the load states would have changed nothing;
+the distinction that mattered was never in the `waitUntil` argument.
+
+The real split is **actions versus reads**, and it is why this hid so long:
+
+| | auto-waits? |
+|---|---|
+| `page.click` / `fill` / `hover` / `press` | yes — a late-rendered target is safe |
+| `page.evaluate` | **no** — samples the DOM at that instant |
+| `page.screenshot` | **no** |
+| `getBoundingClientRect` inside evaluate | **no** |
+
+Every gate does its measuring through the bottom three rows. A flow whose first
+action clicks a late element looks fine, because Playwright waits for the click.
+A flow that clicks something present at `load` and *asserts* on late content does
+not.
+
+## Fixes
+
+Five call sites gained the settle they never had — `verify flow`,
+`build page`'s `renderHtmlToPng`, `fix markup`'s computed-style read,
+`heal selector`, and `region-selector-match` (which had a bare `fonts.ready`,
+the one third of settling that mattered least here).
+
+`settleAfterLoad` in `interaction-map.ts` was a byte-for-byte duplicate of
+`settlePage`; it is gone, and the React-placeholder history that justified it
+moved into `settlePage`'s doc comment where the other five callers can find it.
+
+### `scan contract`: the one place the trade was real
+
+`introspect-contract` navigated local files with `load` *deliberately*, and
+`docs/landmark-drilldown-design.md` advertised it as a feature — "keeps dogfood
+introspection under roughly a few hundred milliseconds". That claim was true and
+the behaviour was still wrong. On a built SPA opened as a file:
+
+```
+load only  ->  0 landmarks []                                241ms
+settled    ->  4 [banner, navigation, main, contentinfo]      986ms
+```
+
+Zero landmarks is not a fast answer, it is a wrong one, and it is the input every
+downstream contract command reads. Settled, and the design doc now states the
+measured cost instead of the old speed claim.
+
+**A cheaper primitive was tried and rejected.** Playwright's `networkidle` is a
+fixed 500ms of quiet, so settling costs ~500ms even on a static local file. So I
+wrote a DOM-quiescence wait instead — MutationObserver quiet + rAF, which should
+be the right question ("has the DOM stopped changing?"). It fails both ways:
+
+```
+static       settleDom  128ms  landmarks=4     <- fast, and correct
+late-render  settleDom  125ms  landmarks=0     <- declares settled BEFORE the render starts
+chatty-poll  settleDom 3025ms  landmarks=4     <- burns its whole cap on a 50ms interval
+```
+
+A 100ms quiet window elapses before a 350ms deferred render has emitted its first
+mutation, so "nothing has changed yet" is indistinguishable from "nothing will
+change". Network idle is slower and correct. Recorded so the idea is not
+re-invented.
+
+## What in the item *was* cosmetic
+
+Two thirds of the original item, checked rather than assumed:
+
+- **47 `chromium.launch` sites.** Exactly one file launches twice
+  (`src/diff-pr.ts`, once in `pin` and once in the default run — two
+  subcommands, not two launches per run). Every other site is one launch per
+  gate invocation, which is the right structure for a CLI that runs one gate per
+  process; `batch` already spawns subprocesses, so a shared browser singleton
+  would buy nothing. Count, not waste.
+- **The 10 remaining `load` / `domcontentloaded` navigations.** All settle now,
+  which makes them equivalent to the `networkidle` ones. Left as they are.
+
+Two `goto` sites still do not call `settlePage`, both deliberately:
+`font-determinism-probe.ts` injects a style tag *after* navigating and so waits
+for `fonts.ready` at the only point where it means anything, on static local
+fixtures with no network; and the `page.goto` strings in `vlmkit-generate` are
+prompt text telling the generator *not* to call it, not navigation.
+
+## A second defect, found while writing the probe
+
+My first probe used `{"text": {...}}` where the vocabulary is
+`{"assert": "text", ...}`. `verify flow` did not tell me that. It reported:
+
+```
+apply = FAIL  [text: NO(unknown assert)]
+```
+
+A typo in the flow file, reported as an unmet post-condition — which sends the
+reader to debug markup that is fine. Then the other direction turned out worse:
+
+```
+{"action":"clik"}  ->  done: true
+```
+
+`runAction`'s switch had no default, so an unrecognised action fell through
+silently, the step had no post-conditions to fail, and the run came back **green**.
+A flow that performed no action at all passed.
+
+`validateFlow` now rejects both before a browser opens, names the offending step
+(`step 1 ("open menu"), expect[0]`), lists the valid names, and says explicitly
+that this is a flow-file error rather than a page defect — the rule
+`check integrity --allow` already applies to an unknown finding kind. An empty
+`steps` array is rejected too, rather than reporting `done` on zero steps.
+
+Both vocabularies are now documented in `introduce.md` / `introduce.ja.md`; a
+reader previously had to infer the assert names from one example, which is
+exactly how `visble` happens.
+
+## A doc that was ahead of the code
+
+`introduce.md` already claimed gates handle "client-rendered apps that paint on a
+tick after `load`, which every gate now waits out". That was false for six of
+them until this commit. The claim is now true. Worth noting as a verification
+gap: this morning's doc pass checked that every *command and flag* in
+`introduce.md` existed, but not that a *behavioural* claim held — a client-rendered
+page through `verify flow` would have caught it.
+
+## Regression gate
+
+`packages/vlmkit-markup/src/settle-consistency.test.ts` — 11 tests. The settle
+half was ablated to confirm it is not vacuous: removing the `settlePage` call
+from `page-compose` fails exactly the `build page` test, and removing it from
+`flow-verify` fails exactly the two `verify flow` tests, with the others still
+green.
+
+The `scan contract` case is pinned by role list (`banner, navigation, main,
+contentinfo`) rather than by count, because it is the fix most likely to be
+reverted for being slow. One test also parses `flow-verify.ts` and asserts the
+validator's name lists equal the `FlowAction` / `FlowAssert` type unions — drift
+there would start rejecting a *valid* flow, which is loud but still wrong.
+
+## Method note
+
+Fourth defect class today from the same question — "do two paths that should
+agree actually agree?" — asked of: navigate vs `setContent`, four argv parsers,
+sweep order vs sweep order, printed vs stored, and now settled vs not. The
+pattern in the last two is narrower and worth naming on its own: **a gate that
+cannot distinguish "your page is wrong" from "I measured the wrong thing" will
+always phrase the second as the first.** Every one of these shipped as a
+confident, specific, wrong kickback.

--- a/e2e/vlmkit-capture.spec.ts
+++ b/e2e/vlmkit-capture.spec.ts
@@ -2,7 +2,7 @@
  * VRT キャプチャテスト
  *
  * スクリーンショット + A11y スナップショットを収集する。
- * `vrt init` / `vrt capture` コマンドから呼ばれる。
+ * `vlmkit workflow init` / `vlmkit workflow capture` コマンドから呼ばれる。
  */
 import { test, expect } from "@playwright/test";
 import { writeFile, mkdir } from "node:fs/promises";

--- a/examples/markup-vrt-eval/run-offline-fixtures.mjs
+++ b/examples/markup-vrt-eval/run-offline-fixtures.mjs
@@ -19,7 +19,7 @@ export function buildOfflineStructuredPlan() {
         "The Invoice Export row remains visible after the Blocked filter is applied.",
         "The detail panel shows Invoice Export and the compliance approval summary.",
       ],
-      vrt: {
+      vlmkit: {
         startState: "initial Release Queue view",
         goalState: "Blocked filter with Invoice Export detail selected",
       },

--- a/examples/vlmkit.gates.json
+++ b/examples/vlmkit.gates.json
@@ -46,6 +46,14 @@
           "reason": "Payment-method tiles are deliberately styled per provider (brand requirement), so button styles do not consolidate here.",
           "owner": "payments",
           "expires": "2026-11-30"
+        },
+        {
+          "//": "An integrity exemption. The reason inside --allow explains the pattern; the reason here explains the approval. Both are printed.",
+          "gate": "check integrity",
+          "flag": "--allow \"near-misalignment@.provider-badge;provider logos are optically centred, not edge-aligned\"",
+          "reason": "Optical centring signed off with design; the 2px probe cannot express it.",
+          "owner": "payments",
+          "expires": "2026-11-30"
         }
       ]
     }

--- a/examples/vlmkit.gates.json
+++ b/examples/vlmkit.gates.json
@@ -1,0 +1,53 @@
+{
+  "//": "Worked example for `vlmkit gates`. Copy to your repo root as vlmkit.gates.json. Docs: docs/cli-reference.md#gates-config",
+
+  "defaults": {
+    "//": "Gates every page gets unless it overrides `gates`. `extraGates` adds on top.",
+    "gates": [
+      "check integrity",
+      "check breakpoints --sweep",
+      "check design"
+    ],
+    "//suppressions": "Default-scope suppressions apply to every page. Use sparingly — a repo-wide exemption is the hardest kind to revisit.",
+    "suppressions": [
+      {
+        "gate": "check copy",
+        "flag": "--allow-invisible visually-hidden",
+        "reason": "Every page carries the same sr-only skip link; the manifest lists it because legal reviews the wording.",
+        "owner": "web-platform",
+        "expires": "2027-01-31"
+      }
+    ]
+  },
+
+  "pages": [
+    {
+      "id": "home",
+      "source": "routes/index.html",
+      "extraGates": ["check copy --manifest copy/home.txt"]
+    },
+    {
+      "//": "A glob expands to one entry per file; ids become `docs:routes/docs/a.html` so --only docs still selects the group.",
+      "id": "docs",
+      "source": "routes/docs/**/*.html",
+      "gates": ["check integrity", "check copy --manifest copy/docs.txt"]
+    },
+    {
+      "id": "checkout",
+      "source": "https://staging.example.com/checkout",
+      "extraGates": [
+        "check interactions",
+        "verify flow --flow flows/checkout.json"
+      ],
+      "suppressions": [
+        {
+          "gate": "check design",
+          "flag": "--min-reuse 2",
+          "reason": "Payment-method tiles are deliberately styled per provider (brand requirement), so button styles do not consolidate here.",
+          "owner": "payments",
+          "expires": "2026-11-30"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/vrt-snapshot-cloudflare.workflow.yml
+++ b/examples/vrt-snapshot-cloudflare.workflow.yml
@@ -51,7 +51,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx vrt snapshot \
+          npx vlmkit snapshot \
             --backend cloudflare \
             --config vrt.config.json
 

--- a/fixtures/collision-fp-corpus/README.md
+++ b/fixtures/collision-fp-corpus/README.md
@@ -77,7 +77,37 @@ band while dividing by the *box* area silently tightened the gate — a real
 collision fell from 0.32 to 0.19 of the smaller area and disappeared. Both
 sides of the ratio must use the same units.
 
-### Gate for half (b)
+### Half (b) SHIPPED too (2026-08-01, later the same day)
+
+Measuring this corpus showed the blocker was never the 6px floor — it was
+the **overlap-area ratio**. The graze scored 0.172 of the smaller block's
+area against a 0.25 gate, while a legitimate `line-height: 1` stack scored
+0.077 and the pull-up 0.137: overlapping populations, so area cannot
+separate them. By **vertical ink-overlap fraction** the same three are
+**1.000 / 0.077 / 0.137** — a 7x gap. The gate now requires
+`oy >= max(2px, 0.5 x the shorter block's ink height)`; the area ratio is
+retired (`minOverlapRatio` accepted and ignored, `minInkOverlapFraction`
+added).
+
+Gate criterion, met exactly: five legitimate pages **0**,
+`sliver-true-positive.html` **1**.
+
+Real-page A/B (8 mirrored pages x 3 viewports, pre-session revision vs
+current): **0 new collisions, 16 disappeared.** The 16 were all
+pre-existing false positives that the area ratio had been *masking* rather
+than avoiding:
+
+- **MDN 14 -> 0** — items inside a CLOSED `<details>` keep layout boxes
+  (measured 184x56 at y=9137, `checkVisibility() === false`) and stack
+  perfectly, so they scored a 1.0 ink fraction. The text-block collector
+  checked self `visibility`/`display`/`opacity`, none of which express
+  content-visibility skipping. Now filtered with `checkVisibility()`.
+- **APG 2 -> 0** — `li x li > kbd` pairs: an element paired with its own
+  inline descendant, never a collision.
+
+So the loosening added zero false positives on real markup and removed 16.
+
+### Gate for any future change here
 
 The upgrade passes only if:
 

--- a/fixtures/collision-fp-corpus/README.md
+++ b/fixtures/collision-fp-corpus/README.md
@@ -117,3 +117,33 @@ The upgrade passes only if:
 Use `src/util/ab-arm-setup.sh` to run it as a proper A/B against the
 pre-change revision — and heed its warning: prove the arms differ before
 reading any result.
+
+### Font-metric fingerprint (`fingerprints/linux-default.json`)
+
+The floors are functions of the resolved font's metrics, so the same page can
+in principle be judged differently on another OS. `fingerprints/` holds this
+corpus's baseline — every candidate pair's distance from its own floor, as
+measured on Linux with Playwright's bundled Chromium.
+
+To check another platform:
+
+```bash
+node --experimental-strip-types src/util/font-determinism-probe.ts measure \
+  "fixtures/collision-fp-corpus/*.html" "fixtures/auto-markup-proof/creative/*.html" \
+  --label macos-default --out macos.json
+node --experimental-strip-types src/util/font-determinism-probe.ts compare \
+  fixtures/collision-fp-corpus/fingerprints/linux-default.json macos.json
+```
+
+`compare` exits non-zero only on a **threshold flip** — the same overlap judged
+differently. A pair that stops overlapping entirely (font substitution changes
+text width, so absolutely-positioned labels can clear each other) is reported
+separately as a geometry difference, because both verdicts are then correct for
+their own rendering.
+
+Linux perturbation results — 6 font/rasterizer conditions, 0 threshold flips,
+ink drift ≤0.51px for a bundled face and ≤3px under whole-stack substitution:
+`docs/reports/2026-08-02-font-determinism-collision-floors.md`. That report is
+also explicit about what is still missing: only 1 of 121 pairs sits within 2px
+of its floor, so fixtures deliberately placed *at* the floor are the real
+prerequisite for a strong robustness claim.

--- a/fixtures/collision-fp-corpus/README.md
+++ b/fixtures/collision-fp-corpus/README.md
@@ -1,0 +1,89 @@
+# text-collision false-positive corpus
+
+The gate for the **ink-extents collision upgrade** (TODO.md backlog).
+
+## Why this exists
+
+`findTextCollisions` compares text-block *bounding boxes*: a pair is a
+collision when they overlap by ≥ 6px on **both** axes and by ≥ 25% of the
+smaller block's area. The 2026-08-01 round-10 review correctly pointed out
+that boxes are not ink — a 3px×18px sliver that looks broken is below the
+floor, and the fix is to compare glyph ink extents
+(`Range.getClientRects()` / `measureText().actualBoundingBox*`).
+
+That change is deliberately **not** made yet, because loosening this floor
+is the textbook way a gate starts crying wolf. The 2026-08-01 FP re-audit
+(`docs/reports/2026-08-01-fp-reaudit.md`) tried to serve as its gate and
+could not: the 8-page real-site corpus produced exactly **one**
+`text-collision` finding, which cannot distinguish "looser floor, still
+quiet" from "nothing was near the floor."
+
+These fixtures are the missing corpus: layouts where box overlap is large
+and legitimate, so a naive ink-extents switch would light them up.
+
+## The pages
+
+Every page here is **correct markup that must stay CLEAN**. Each isolates
+one construct where line boxes overlap without glyphs touching:
+
+| File | Construct | Why boxes overlap but ink does not |
+|---|---|---|
+| `tight-leading.html` | `line-height: 0.8` display type | line boxes overlap vertically by ~20% of font size |
+| `negative-margin-heading.html` | `h1 { margin-bottom: -0.15em }` | the classic kicker/heading pull-up |
+| `tall-metrics.html` | font stack whose ascent+descent > 1em at `line-height: 1` | line boxes overlap by construction |
+| `vertical-writing.html` | `writing-mode: vertical-rl` columns | axis-aligned boxes of vertical text overlap horizontally |
+| `rotated-labels.html` | `transform: rotate(-45deg)` chart labels | AABBs of rotated text intersect heavily |
+| `sliver-true-positive.html` | a genuine 3px×18px graze | the one page that SHOULD become a finding after the upgrade |
+
+The last file is the counterpart: it is currently a **false negative**
+(below the floor, unreported), and a successful ink-extents upgrade is
+expected to start reporting it *while the other five stay clean*.
+
+## How to use it as a gate
+
+```bash
+# baseline, current floor (expected: 5 clean, 1 missed graze)
+for f in fixtures/collision-fp-corpus/*.html; do
+  echo "== $f"
+  vlmkit check integrity "$f" --viewports 1280 --json \
+    | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+        const r=JSON.parse(s);
+        console.log(r.findings.filter(f=>f.kind==="text-collision").length,"collision finding(s)")})'
+done
+```
+
+## Status (2026-08-01): half the upgrade shipped, half still gated
+
+Building this corpus immediately found a **live false positive**:
+`negative-margin-heading.html` reported a collision with the shipped gate.
+Measured ground truth (each string rendered in isolation, darkest-pixel
+rows compared): kicker ink ends at row 51, `h1` ink starts at row 54 — a
+**2px clear gap**, while the line boxes overlapped 7px. The gate was
+reporting an idiomatic kicker/heading pull-up as a defect.
+
+That split the "ink extents" idea into two independent halves:
+
+- **(a) ink confirmation as a filter — SHIPPED.** Blocks are shrunk to
+  their measured ink band (canvas `actualBoundingBoxAscent/Descent` vs the
+  line box) before the overlap test. This can only *remove* findings, so
+  it carries none of the cry-wolf risk. All six pages here are now clean
+  and a genuine 133×8.8px overlap still fails.
+- **(b) lowering the floor to catch slivers — STILL GATED.** This is the
+  half that adds findings, and it is what `sliver-true-positive.html`
+  measures. That page is a documented false negative today (0 collisions).
+
+Note the ratio bug (a) surfaced on the way: measuring overlap on the ink
+band while dividing by the *box* area silently tightened the gate — a real
+collision fell from 0.32 to 0.19 of the smaller area and disappeared. Both
+sides of the ratio must use the same units.
+
+### Gate for half (b)
+
+The upgrade passes only if:
+
+1. the five legitimate-overlap pages still report **0** collisions, and
+2. `sliver-true-positive.html` reports **1**.
+
+Use `src/util/ab-arm-setup.sh` to run it as a proper A/B against the
+pre-change revision — and heed its warning: prove the arms differ before
+reading any result.

--- a/fixtures/collision-fp-corpus/fingerprints/linux-default.json
+++ b/fixtures/collision-fp-corpus/fingerprints/linux-default.json
@@ -1,0 +1,1556 @@
+{
+  "label": "linux-default",
+  "platform": "linux-x64",
+  "browserVersion": "149.0.7827.55",
+  "dpr": 1,
+  "fontStack": null,
+  "hinting": "default",
+  "fixtures": [
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-fix.html",
+      "blocks": [
+        {
+          "selector": "div.kicker",
+          "height": 15,
+          "inkInset": 1.3
+        },
+        {
+          "selector": "#headline",
+          "height": 40,
+          "inkInset": 3.9
+        },
+        {
+          "selector": "#subline",
+          "height": 21,
+          "inkInset": 1.8
+        },
+        {
+          "selector": "#ship-note",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(1)",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(2)",
+          "height": 19,
+          "inkInset": 3.6
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(3)",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(1) > p:nth-of-type(1)",
+          "height": 38,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(2) > p:nth-of-type(1)",
+          "height": 38,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(3) > p:nth-of-type(1)",
+          "height": 38,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "p.after-cards",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#promo-banner",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > main:nth-of-type(1) > figure:nth-of-type(1) > figcaption:nth-of-type(1)",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > footer:nth-of-type(1)",
+          "height": 19,
+          "inkInset": 2.1
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-haiku.html",
+      "blocks": [
+        {
+          "selector": "div.logo",
+          "height": 27,
+          "inkInset": 10.2
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > header:nth-of-type(1) > nav:nth-of-type(1) > a:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 7.16
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > header:nth-of-type(1) > nav:nth-of-type(1) > a:nth-of-type(2)",
+          "height": 17,
+          "inkInset": 5.16
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > header:nth-of-type(1) > nav:nth-of-type(1) > a:nth-of-type(3)",
+          "height": 17,
+          "inkInset": 5.66
+        },
+        {
+          "selector": "div.hero-content > h1:nth-of-type(1)",
+          "height": 111,
+          "inkInset": 11.3
+        },
+        {
+          "selector": "div.hero-content > p:nth-of-type(1)",
+          "height": 22,
+          "inkInset": 8.5
+        },
+        {
+          "selector": "button.cta-button",
+          "height": 17,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "div.features-grid > div:nth-of-type(1) > h3:nth-of-type(1)",
+          "height": 22,
+          "inkInset": 8.5
+        },
+        {
+          "selector": "div.features-grid > div:nth-of-type(2) > h3:nth-of-type(1)",
+          "height": 22,
+          "inkInset": 8.5
+        },
+        {
+          "selector": "div.features-grid > div:nth-of-type(3) > h3:nth-of-type(1)",
+          "height": 22,
+          "inkInset": 8.5
+        },
+        {
+          "selector": "div.features-grid > div:nth-of-type(1) > p:nth-of-type(1)",
+          "height": 43,
+          "inkInset": 5.92
+        },
+        {
+          "selector": "div.features-grid > div:nth-of-type(2) > p:nth-of-type(1)",
+          "height": 43,
+          "inkInset": 5.92
+        },
+        {
+          "selector": "div.features-grid > div:nth-of-type(3) > p:nth-of-type(1)",
+          "height": 43,
+          "inkInset": 5.92
+        },
+        {
+          "selector": "div.badge",
+          "height": 15,
+          "inkInset": 4.24
+        },
+        {
+          "selector": "div.pricing-grid > div:nth-of-type(1) > h3:nth-of-type(1)",
+          "height": 27,
+          "inkInset": 10.2
+        },
+        {
+          "selector": "div.pricing-grid > div:nth-of-type(2) > h3:nth-of-type(1)",
+          "height": 27,
+          "inkInset": 7.7
+        },
+        {
+          "selector": "div.pricing-grid > div:nth-of-type(1) > div:nth-of-type(1)",
+          "height": 44,
+          "inkInset": 15
+        },
+        {
+          "selector": "div.pricing-grid > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 44,
+          "inkInset": 15
+        },
+        {
+          "selector": "div.pricing-grid > div:nth-of-type(1) > div:nth-of-type(2)",
+          "height": 17,
+          "inkInset": 6.66
+        },
+        {
+          "selector": "div.pricing-grid > div:nth-of-type(2) > div:nth-of-type(3)",
+          "height": 17,
+          "inkInset": 5.16
+        },
+        {
+          "selector": "div.faq-container > details:nth-of-type(1) > summary:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.3
+        },
+        {
+          "selector": "div.faq-container > details:nth-of-type(1) > p:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.92
+        },
+        {
+          "selector": "div.faq-container > details:nth-of-type(2) > summary:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.3
+        },
+        {
+          "selector": "div.faq-container > details:nth-of-type(2) > p:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.92
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > footer:nth-of-type(1) > p:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 4.52
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-s15-haiku.html",
+      "blocks": [
+        {
+          "selector": "nav.breadcrumb",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "h1.product-title",
+          "height": 31,
+          "inkInset": 3.8
+        },
+        {
+          "selector": "span.current-price",
+          "height": 27,
+          "inkInset": 8.7
+        },
+        {
+          "selector": "span.original-price",
+          "height": 20,
+          "inkInset": 6.4
+        },
+        {
+          "selector": "span.stock-badge",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "label.variant-label",
+          "height": 16,
+          "inkInset": 5.7
+        },
+        {
+          "selector": "div.variant-options > label:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5.7
+        },
+        {
+          "selector": "div.variant-options > label:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "div.variant-options > label:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "#decrementBtn",
+          "height": 17,
+          "inkInset": 8
+        },
+        {
+          "selector": "#quantityValue",
+          "height": 17,
+          "inkInset": 6.8
+        },
+        {
+          "selector": "#incrementBtn",
+          "height": 17,
+          "inkInset": 5.1
+        },
+        {
+          "selector": "label.quantity-label",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "#mainVisual",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "button.add-to-cart",
+          "height": 17,
+          "inkInset": 3.6
+        },
+        {
+          "selector": "#tab-description",
+          "height": 16,
+          "inkInset": 1.4
+        },
+        {
+          "selector": "#tab-specs",
+          "height": 16,
+          "inkInset": 1.4
+        },
+        {
+          "selector": "#tab-reviews",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "#panel-description > p:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 4.9
+        },
+        {
+          "selector": "h2.faq-title",
+          "height": 20,
+          "inkInset": 5.9
+        },
+        {
+          "selector": "section.faq-section > details:nth-of-type(1) > summary:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.3
+        },
+        {
+          "selector": "section.faq-section > details:nth-of-type(2) > summary:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 6.8
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > footer:nth-of-type(1) > p:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 4.2
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-s16-haiku.html",
+      "blocks": [
+        {
+          "selector": "div.sidebar-brand",
+          "height": 20,
+          "inkInset": 5
+        },
+        {
+          "selector": "h1.page-title",
+          "height": 31,
+          "inkInset": 11
+        },
+        {
+          "selector": "p.page-subtitle",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "nav.sidebar-nav > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "div.filters > button:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "div.filters > button:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "div.filters > button:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 1.4
+        },
+        {
+          "selector": "div.filters > button:nth-of-type(4)",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "nav.sidebar-nav > a:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "nav.sidebar-nav > a:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(1) > div:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 3
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(2) > div:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 3
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(3) > div:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(4) > div:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 3
+        },
+        {
+          "selector": "nav.sidebar-nav > a:nth-of-type(4)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(1) > div:nth-of-type(2)",
+          "height": 27,
+          "inkInset": 7.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 27,
+          "inkInset": 7.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(3) > div:nth-of-type(2)",
+          "height": 27,
+          "inkInset": 9.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(4) > div:nth-of-type(2)",
+          "height": 27,
+          "inkInset": 9.5
+        },
+        {
+          "selector": "#ordersTable > thead:nth-of-type(1) > tr:nth-of-type(1) > th:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "#ordersTable > thead:nth-of-type(1) > tr:nth-of-type(1) > th:nth-of-type(2)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "#ordersTable > thead:nth-of-type(1) > tr:nth-of-type(1) > th:nth-of-type(3) > button:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#ordersTable > thead:nth-of-type(1) > tr:nth-of-type(1) > th:nth-of-type(4)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "#ordersTable > thead:nth-of-type(1) > tr:nth-of-type(1) > th:nth-of-type(5) > button:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(5)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(4) > span:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(2) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(2) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(2) > td:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(2) > td:nth-of-type(5)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "span.status-badge.status-pending",
+          "height": 14,
+          "inkInset": 3
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(3) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(3) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(3) > td:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(3) > td:nth-of-type(5)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(3) > td:nth-of-type(4) > span:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(4) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(4) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(4) > td:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(4) > td:nth-of-type(5)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "span.status-badge.status-refunded",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(5) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(5) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(5) > td:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(5) > td:nth-of-type(5)",
+          "height": 16,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#ordersTable > tbody:nth-of-type(1) > tr:nth-of-type(5) > td:nth-of-type(4) > span:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.pagination > span:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "#prevBtn",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "#nextBtn",
+          "height": 16,
+          "inkInset": 3.4
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-s17-haiku.html",
+      "blocks": [
+        {
+          "selector": "h1.page-title",
+          "height": 36,
+          "inkInset": 12.5
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(1) > legend:nth-of-type(1)",
+          "height": 20,
+          "inkInset": 7
+        },
+        {
+          "selector": "div.order-summary > h2:nth-of-type(1)",
+          "height": 22,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(1) > div:nth-of-type(1) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.75
+        },
+        {
+          "selector": "div.item-name",
+          "height": 17,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.item-variant",
+          "height": 17,
+          "inkInset": 5.75
+        },
+        {
+          "selector": "div.item-price",
+          "height": 20,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(1) > div:nth-of-type(2) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "div.cost-rows > div:nth-of-type(1) > span:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.75
+        },
+        {
+          "selector": "div.cost-rows > div:nth-of-type(1) > span:nth-of-type(2)",
+          "height": 17,
+          "inkInset": 5.25
+        },
+        {
+          "selector": "div.cost-rows > div:nth-of-type(2) > span:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "div.cost-rows > div:nth-of-type(2) > span:nth-of-type(2)",
+          "height": 17,
+          "inkInset": 6.25
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(2) > legend:nth-of-type(1)",
+          "height": 20,
+          "inkInset": 5
+        },
+        {
+          "selector": "div.cost-rows > div:nth-of-type(3) > span:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "div.cost-rows > div:nth-of-type(3) > span:nth-of-type(2)",
+          "height": 17,
+          "inkInset": 6.25
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(2) > div:nth-of-type(1) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.75
+        },
+        {
+          "selector": "div.cost-row.total > span:nth-of-type(1)",
+          "height": 20,
+          "inkInset": 7
+        },
+        {
+          "selector": "div.cost-row.total > span:nth-of-type(2)",
+          "height": 20,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(2) > div:nth-of-type(2) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.75
+        },
+        {
+          "selector": "div.reassurance",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(2) > div:nth-of-type(3) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.75
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(2) > div:nth-of-type(4) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(2) > div:nth-of-type(5) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.75
+        },
+        {
+          "selector": "#checkout-form > fieldset:nth-of-type(3) > legend:nth-of-type(1)",
+          "height": 20,
+          "inkInset": 5
+        },
+        {
+          "selector": "div.radio-group > div:nth-of-type(1) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 5.75
+        },
+        {
+          "selector": "div.radio-group > div:nth-of-type(2) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "div.radio-group > div:nth-of-type(3) > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "div.details-section > details:nth-of-type(1) > summary:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "div.checkbox-group > label:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.25
+        },
+        {
+          "selector": "#submit-btn",
+          "height": 17,
+          "inkInset": 2.1
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-s18-haiku.html",
+      "blocks": [
+        {
+          "selector": "div.workspace-name",
+          "height": 17,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.channel-title",
+          "height": 22,
+          "inkInset": 5.5
+        },
+        {
+          "selector": "div.team-name",
+          "height": 15,
+          "inkInset": 5.25
+        },
+        {
+          "selector": "div.channel-topic",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.channel-members",
+          "height": 15,
+          "inkInset": 5.25
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(2) > h2:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(2) > ul:nth-of-type(1) > li:nth-of-type(1) > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(2)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(2) > ul:nth-of-type(1) > li:nth-of-type(2) > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "span.unread-badge",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(2) > ul:nth-of-type(1) > li:nth-of-type(3) > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(2)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(2) > ul:nth-of-type(1) > li:nth-of-type(4) > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(2)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(3) > h2:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 3
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(3) > ul:nth-of-type(1) > li:nth-of-type(1) > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(4) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(4) > div:nth-of-type(2) > div:nth-of-type(1) > span:nth-of-type(2)",
+          "height": 14,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(3) > ul:nth-of-type(1) > li:nth-of-type(2) > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "div.message-list-container > div:nth-of-type(4) > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "aside.sidebar > div:nth-of-type(3) > ul:nth-of-type(1) > li:nth-of-type(3) > a:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "button.invite-button",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "button.send-button",
+          "height": 16,
+          "inkInset": 2.9
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-s19-haiku.html",
+      "blocks": [
+        {
+          "selector": "div.hud-left",
+          "height": 20,
+          "inkInset": 4.3
+        },
+        {
+          "selector": "div.hud-stats > div:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "div.hud-stats > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "div.hud-stats > div:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "div.energy-label",
+          "height": 11,
+          "inkInset": 1
+        },
+        {
+          "selector": "div.energy-value",
+          "height": 22,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.battlefield > div:nth-of-type(3) > div:nth-of-type(2) > div:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 3.6
+        },
+        {
+          "selector": "div.enemy-intent",
+          "height": 14,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "div.block-display",
+          "height": 17,
+          "inkInset": 3.6
+        },
+        {
+          "selector": "div.battlefield > div:nth-of-type(1) > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 17,
+          "inkInset": 3.6
+        },
+        {
+          "selector": "button.character-info > div:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#hand > button:nth-of-type(1) > div:nth-of-type(1)",
+          "height": 32,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#hand > button:nth-of-type(5) > div:nth-of-type(1)",
+          "height": 32,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#hand > button:nth-of-type(2) > div:nth-of-type(1)",
+          "height": 29,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#hand > button:nth-of-type(4) > div:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#hand > button:nth-of-type(3) > div:nth-of-type(1)",
+          "height": 14,
+          "inkInset": 2.7
+        },
+        {
+          "selector": "#hand > button:nth-of-type(4) > div:nth-of-type(2)",
+          "height": 12,
+          "inkInset": 2
+        },
+        {
+          "selector": "#hand > button:nth-of-type(1) > div:nth-of-type(2)",
+          "height": 14,
+          "inkInset": 2
+        },
+        {
+          "selector": "#hand > button:nth-of-type(5) > div:nth-of-type(2)",
+          "height": 14,
+          "inkInset": 2
+        },
+        {
+          "selector": "#hand > button:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 12,
+          "inkInset": 2
+        },
+        {
+          "selector": "#hand > button:nth-of-type(3) > div:nth-of-type(2)",
+          "height": 11,
+          "inkInset": 2
+        },
+        {
+          "selector": "#hand > button:nth-of-type(4) > div:nth-of-type(3)",
+          "height": 24,
+          "inkInset": 1
+        },
+        {
+          "selector": "#hand > button:nth-of-type(1) > div:nth-of-type(3)",
+          "height": 18,
+          "inkInset": 1
+        },
+        {
+          "selector": "#hand > button:nth-of-type(5) > div:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 2
+        },
+        {
+          "selector": "#hand > button:nth-of-type(2) > div:nth-of-type(3)",
+          "height": 13,
+          "inkInset": 2
+        },
+        {
+          "selector": "#hand > button:nth-of-type(3) > div:nth-of-type(3)",
+          "height": 11,
+          "inkInset": 2
+        },
+        {
+          "selector": "button.end-turn-btn",
+          "height": 16,
+          "inkInset": 2.9
+        },
+        {
+          "selector": "div.piles > div:nth-of-type(1)",
+          "height": 15,
+          "inkInset": 3.3
+        },
+        {
+          "selector": "div.piles > div:nth-of-type(2)",
+          "height": 15,
+          "inkInset": 3.3
+        }
+      ],
+      "pairs": [
+        {
+          "pair": "#hand > button:nth-of-type(1) > div:nth-of-type(2) x #hand > button:nth-of-type(1) > div:nth-of-type(3)",
+          "ox": 35,
+          "oy": -4,
+          "threshold": 6,
+          "margin": -10,
+          "reported": false
+        },
+        {
+          "pair": "div.energy-label x div.energy-value",
+          "ox": 28,
+          "oy": -5.5,
+          "threshold": 6,
+          "margin": -11.5,
+          "reported": false
+        },
+        {
+          "pair": "#hand > button:nth-of-type(5) > div:nth-of-type(2) x #hand > button:nth-of-type(5) > div:nth-of-type(3)",
+          "ox": 35,
+          "oy": -6,
+          "threshold": 6,
+          "margin": -12,
+          "reported": false
+        },
+        {
+          "pair": "#hand > button:nth-of-type(1) > div:nth-of-type(1) x #hand > button:nth-of-type(1) > div:nth-of-type(2)",
+          "ox": 34,
+          "oy": -6.7,
+          "threshold": 6,
+          "margin": -12.7,
+          "reported": false
+        },
+        {
+          "pair": "#hand > button:nth-of-type(5) > div:nth-of-type(1) x #hand > button:nth-of-type(5) > div:nth-of-type(2)",
+          "ox": 35,
+          "oy": -6.7,
+          "threshold": 6,
+          "margin": -12.7,
+          "reported": false
+        },
+        {
+          "pair": "#hand > button:nth-of-type(4) > div:nth-of-type(2) x #hand > button:nth-of-type(4) > div:nth-of-type(3)",
+          "ox": 34,
+          "oy": -8,
+          "threshold": 6,
+          "margin": -14,
+          "reported": false
+        }
+      ],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/attempt-stress.html",
+      "blocks": [
+        {
+          "selector": "div.sidebar-mark",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.title-block > h1:nth-of-type(1)",
+          "height": 36,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "div.sidebar-version",
+          "height": 31,
+          "inkInset": 3.9
+        },
+        {
+          "selector": "p.lead",
+          "height": 20,
+          "inkInset": 5.9
+        },
+        {
+          "selector": "ul.sidebar-nav > li:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 6
+        },
+        {
+          "selector": "ul.sidebar-nav > li:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(1) > div:nth-of-type(1)",
+          "height": 31,
+          "inkInset": 7.3
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(2) > div:nth-of-type(1)",
+          "height": 31,
+          "inkInset": 7.3
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(3) > div:nth-of-type(1)",
+          "height": 31,
+          "inkInset": 4.8
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(4) > div:nth-of-type(1)",
+          "height": 31,
+          "inkInset": 7.3
+        },
+        {
+          "selector": "ul.sidebar-nav > li:nth-of-type(3)",
+          "height": 16,
+          "inkInset": 6
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(1) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(2) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(3) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "div.stats > div:nth-of-type(4) > div:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "ul.sidebar-nav > li:nth-of-type(4)",
+          "height": 16,
+          "inkInset": 6
+        },
+        {
+          "selector": "ul.sidebar-nav > li:nth-of-type(5)",
+          "height": 16,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.card-title",
+          "height": 17,
+          "inkInset": 4.5
+        },
+        {
+          "selector": "div.endpoint-string",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "div.card-note",
+          "height": 16,
+          "inkInset": 4.2
+        },
+        {
+          "selector": "#conflict",
+          "height": 27,
+          "inkInset": 5.4
+        },
+        {
+          "selector": "div.section-content > p:nth-of-type(1)",
+          "height": 44,
+          "inkInset": 6.1
+        },
+        {
+          "selector": "div.section-content > p:nth-of-type(2)",
+          "height": 44,
+          "inkInset": 6.1
+        },
+        {
+          "selector": "#limits",
+          "height": 27,
+          "inkInset": 5.4
+        },
+        {
+          "selector": "table.limits-table > thead:nth-of-type(1) > tr:nth-of-type(1) > th:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "table.limits-table > thead:nth-of-type(1) > tr:nth-of-type(1) > th:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(1) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(2) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(2) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(3) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(3) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(4) > td:nth-of-type(1)",
+          "height": 16,
+          "inkInset": 3.5
+        },
+        {
+          "selector": "table.limits-table > tbody:nth-of-type(1) > tr:nth-of-type(4) > td:nth-of-type(2)",
+          "height": 16,
+          "inkInset": 5
+        },
+        {
+          "selector": "#changelog",
+          "height": 14,
+          "inkInset": 3
+        },
+        {
+          "selector": "footer.footer",
+          "height": 16,
+          "inkInset": 3.5
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/auto-markup-proof/creative/broken-spec.html",
+      "blocks": [
+        {
+          "selector": "div.kicker",
+          "height": 15,
+          "inkInset": 1.3
+        },
+        {
+          "selector": "#headline",
+          "height": 40,
+          "inkInset": 3.9
+        },
+        {
+          "selector": "#subline",
+          "height": 21,
+          "inkInset": 1.8
+        },
+        {
+          "selector": "#ship-note",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "p.after-cards",
+          "height": 57,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(1)",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(2)",
+          "height": 19,
+          "inkInset": 3.6
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(3)",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(1) > p:nth-of-type(1)",
+          "height": 38,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(2) > p:nth-of-type(1)",
+          "height": 38,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#card-row > div:nth-of-type(3) > p:nth-of-type(1)",
+          "height": 38,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "#promo-banner",
+          "height": 38,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > main:nth-of-type(1) > figure:nth-of-type(1) > figcaption:nth-of-type(1)",
+          "height": 19,
+          "inkInset": 2.1
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > footer:nth-of-type(1)",
+          "height": 19,
+          "inkInset": 2.1
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/collision-fp-corpus/negative-margin-heading.html",
+      "blocks": [
+        {
+          "selector": "p.kicker",
+          "height": 15,
+          "inkInset": 1.3
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > h1:nth-of-type(1)",
+          "height": 46,
+          "inkInset": 4
+        },
+        {
+          "selector": "p.lede",
+          "height": 21,
+          "inkInset": 1.8
+        }
+      ],
+      "pairs": [
+        {
+          "pair": "p.kicker x html > body:nth-of-type(1) > h1:nth-of-type(1)",
+          "ox": 148,
+          "oy": 1.7,
+          "threshold": 6.2,
+          "margin": -4.5,
+          "reported": false
+        }
+      ],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/collision-fp-corpus/rotated-labels.html",
+      "blocks": [
+        {
+          "selector": "div.axis > span:nth-of-type(1)",
+          "height": 114,
+          "inkInset": 2.8
+        },
+        {
+          "selector": "div.axis > span:nth-of-type(2)",
+          "height": 114,
+          "inkInset": 2.8
+        },
+        {
+          "selector": "div.axis > span:nth-of-type(3)",
+          "height": 114,
+          "inkInset": 2.8
+        },
+        {
+          "selector": "div.axis > span:nth-of-type(4)",
+          "height": 114,
+          "inkInset": 2.8
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/collision-fp-corpus/sliver-true-positive.html",
+      "blocks": [
+        {
+          "selector": "#total",
+          "height": 19,
+          "inkInset": 2.6
+        },
+        {
+          "selector": "#refund",
+          "height": 19,
+          "inkInset": 3.6
+        }
+      ],
+      "pairs": [
+        {
+          "pair": "#total x #refund",
+          "ox": 25,
+          "oy": 11.8,
+          "threshold": 6,
+          "margin": 5.8,
+          "reported": true
+        }
+      ],
+      "findings": 1,
+      "reportedPairs": [
+        "#total x #refund"
+      ]
+    },
+    {
+      "fixture": "fixtures/collision-fp-corpus/tall-metrics.html",
+      "blocks": [
+        {
+          "selector": "div.stack > p:nth-of-type(1)",
+          "height": 52,
+          "inkInset": 0
+        },
+        {
+          "selector": "div.stack > p:nth-of-type(2)",
+          "height": 52,
+          "inkInset": 0
+        },
+        {
+          "selector": "div.stack > p:nth-of-type(3)",
+          "height": 52,
+          "inkInset": 0
+        }
+      ],
+      "pairs": [
+        {
+          "pair": "div.stack > p:nth-of-type(1) x div.stack > p:nth-of-type(2)",
+          "ox": 502,
+          "oy": 4,
+          "threshold": 26,
+          "margin": -22,
+          "reported": false
+        },
+        {
+          "pair": "div.stack > p:nth-of-type(2) x div.stack > p:nth-of-type(3)",
+          "ox": 511,
+          "oy": 4,
+          "threshold": 26,
+          "margin": -22,
+          "reported": false
+        }
+      ],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/collision-fp-corpus/tight-leading.html",
+      "blocks": [
+        {
+          "selector": "h1.display",
+          "height": 149,
+          "inkInset": 0
+        },
+        {
+          "selector": "html > body:nth-of-type(1) > p:nth-of-type(1)",
+          "height": 17,
+          "inkInset": 4.8
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    },
+    {
+      "fixture": "fixtures/collision-fp-corpus/vertical-writing.html",
+      "blocks": [
+        {
+          "selector": "div.cols > p:nth-of-type(1)",
+          "height": 183,
+          "inkInset": 0.4
+        },
+        {
+          "selector": "div.cols > p:nth-of-type(2)",
+          "height": 167,
+          "inkInset": 0
+        }
+      ],
+      "pairs": [],
+      "findings": 0,
+      "reportedPairs": []
+    }
+  ]
+}

--- a/fixtures/collision-fp-corpus/negative-margin-heading.html
+++ b/fixtures/collision-fp-corpus/negative-margin-heading.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Negative margin heading</title>
+<style>
+  body { margin: 0; padding: 40px; font-family: system-ui, sans-serif; background: #fff; }
+  /* The kicker/heading pull-up: the heading's box is dragged up into the
+     kicker's box. Extremely common; must stay CLEAN. */
+  .kicker { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: #5b6270; margin: 0; }
+  h1 { font-size: 40px; margin: -0.18em 0 0.4em; }
+  .lede { font-size: 18px; color: #3a4050; max-width: 620px; margin-top: -0.1em; }
+</style></head><body>
+  <p class="kicker">Quarterly report</p>
+  <h1>Settlement volume grew nineteen percent</h1>
+  <p class="lede">A lede paragraph pulled slightly up under the heading.</p>
+</body></html>

--- a/fixtures/collision-fp-corpus/rotated-labels.html
+++ b/fixtures/collision-fp-corpus/rotated-labels.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rotated axis labels</title>
+<style>
+  body { margin: 0; padding: 40px 40px 120px; background: #fff; font-family: system-ui, sans-serif; }
+  /* Rotated chart labels: the AABB of each rotated string intersects its
+     neighbours heavily while the ink is well separated. Must stay CLEAN. */
+  .axis { display: flex; gap: 26px; margin-top: 30px; }
+  .axis span { transform: rotate(-45deg); transform-origin: left top; font-size: 13px; white-space: nowrap; color: #3a4050; }
+  .plot { height: 160px; background: linear-gradient(#eef3fe, #fff); border-bottom: 1px solid #c9d2e3; }
+</style></head><body>
+  <div class="plot"></div>
+  <div class="axis">
+    <span>2026-01 reconciliation</span><span>2026-02 reconciliation</span>
+    <span>2026-03 reconciliation</span><span>2026-04 reconciliation</span>
+  </div>
+</body></html>

--- a/fixtures/collision-fp-corpus/sliver-true-positive.html
+++ b/fixtures/collision-fp-corpus/sliver-true-positive.html
@@ -1,0 +1,16 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Sliver graze</title>
+<style>
+  body { margin: 0; padding: 40px; background: #fff; font-family: ui-monospace, monospace; }
+  /* The counterpart case: two absolutely-positioned labels that GRAZE —
+     a few px horizontally across the full line height. Visually broken,
+     currently BELOW the both-axes floor and therefore unreported.
+     An ink-extents upgrade is expected to start reporting exactly this. */
+  .row { position: relative; height: 40px; font-size: 16px; }
+  #total  { position: absolute; left: 0px;   top: 10px; white-space: nowrap; }
+  #refund { position: absolute; left: 168px; top: 10px; white-space: nowrap; }
+</style></head><body>
+  <div class="row">
+    <span id="total">Total: 1,240,000 EUR</span>
+    <span id="refund">Refunds: 80 EUR</span>
+  </div>
+</body></html>

--- a/fixtures/collision-fp-corpus/tall-metrics.html
+++ b/fixtures/collision-fp-corpus/tall-metrics.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Tall font metrics</title>
+<style>
+  body { margin: 0; padding: 40px; background: #fff; }
+  /* Many webfonts have ascent+descent > 1em; at line-height:1 the line
+     boxes necessarily overlap even though glyphs do not. Must stay CLEAN. */
+  .stack { font-family: "Noto Sans", "DejaVu Sans", Verdana, sans-serif; font-size: 24px; line-height: 1; max-width: 560px; }
+  .stack p { margin: 0; }
+</style></head><body>
+  <div class="stack">
+    <p>Line one of a block set solid at line-height one.</p>
+    <p>Line two sits immediately beneath it with no leading.</p>
+    <p>Line three completes the stack of solid-set lines.</p>
+  </div>
+</body></html>

--- a/fixtures/collision-fp-corpus/tight-leading.html
+++ b/fixtures/collision-fp-corpus/tight-leading.html
@@ -1,0 +1,11 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Tight leading</title>
+<style>
+  body { margin: 0; padding: 40px; font-family: Georgia, serif; background: #fff; color: #16181d; }
+  /* Display type set tighter than 1: adjacent line BOXES overlap
+     vertically, but the glyphs never touch. Must stay CLEAN. */
+  .display { font-size: 56px; line-height: 0.78; max-width: 640px; margin: 0 0 32px; letter-spacing: -0.02em; }
+  p { max-width: 620px; line-height: 1.6; }
+</style></head><body>
+  <h1 class="display">Editorial headlines are set with negative leading on purpose</h1>
+  <p>Body copy below the headline, at normal leading, so the page has both regimes.</p>
+</body></html>

--- a/fixtures/collision-fp-corpus/vertical-writing.html
+++ b/fixtures/collision-fp-corpus/vertical-writing.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Vertical writing mode</title>
+<style>
+  body { margin: 0; padding: 40px; background: #fff; font-family: system-ui, sans-serif; }
+  /* Vertical text: axis-aligned bounding boxes of adjacent columns overlap
+     horizontally under some metrics, though the columns are distinct.
+     Must stay CLEAN. */
+  .cols { writing-mode: vertical-rl; height: 380px; font-size: 18px; line-height: 1.1; display: flex; gap: 4px; }
+  .cols p { margin: 0; }
+</style></head><body>
+  <div class="cols">
+    <p>縦書きの列がならぶ組版で、行ボックスは重なりうる</p>
+    <p>けれども字面そのものは接触していない状態を作る</p>
+  </div>
+</body></html>

--- a/fixtures/design-md-scenario/paws-and-paths/attempts/agent-a/log.md
+++ b/fixtures/design-md-scenario/paws-and-paths/attempts/agent-a/log.md
@@ -2,17 +2,17 @@
 
 ## Setup note (CRITICAL)
 
-`vrt compare <baseline.html> <variant.html>` with bare paths renders BOTH pages with
+`vlmkit diff html <baseline.html> <variant.html>` with bare paths renders BOTH pages with
 stylesheets effectively missing (Chromium loads them with `about:blank` base URL or
 file:// schema oddities). Diff reads **0.0%** on every viewport — a false PASS:
-both renderers are equally broken. Switching to `vrt compare --url file://... --current-url file://...`
+both renderers are equally broken. Switching to `vlmkit diff html --url file://... --current-url file://...`
 gives real signal. I lost ~5 minutes of round 1 to this.
 
 ## Rounds
 
 ### Round 1 — bare paths (false signal)
 - All viewports 0.0%. Heading mismatch warning: golden uses `<h2>` for "Mia Carter".
-- I confirmed via `vrt snapshot file:///...page.html` that my page actually rendered correctly. So the 0% diff was a lie.
+- I confirmed via `vlmkit snapshot file:///...page.html` that my page actually rendered correctly. So the 0% diff was a lie.
 
 ### Round 1b — `--url file://...` (real signal)
 - mobile 17.2%, desktop 3.1%, wide 2.8%
@@ -52,10 +52,10 @@ gives real signal. I lost ~5 minutes of round 1 to this.
 - **DOM equivalence warning** told me `Mia Carter` should be a heading, which I had as a `<p>`.
 
 ## Where vrt was unhelpful / misleading
-- **`vrt compare` silent failure with bare paths.** Returned 0.0% diff with no warning that stylesheet loading was broken. The only hint was a "failed-resource-load" warning about Google Fonts (which is a side issue) — nothing about my local `style.css`. This made me think round 1 was perfect.
+- **`vlmkit diff html` silent failure with bare paths.** Returned 0.0% diff with no warning that stylesheet loading was broken. The only hint was a "failed-resource-load" warning about Google Fonts (which is a side issue) — nothing about my local `style.css`. This made me think round 1 was perfect.
 - **`--output` flag is silently ignored.** I passed `--output /tmp/agent-a-round-1` but report always went to `/home/user/vrt/test-results/migration/`. No error, no log line.
 - **The PNG saved as `page-desktop.png` was NOT the rendered variant** — it appeared to be the heatmap/diff overlay rendered against a blank canvas. The visual was completely unstyled, leading me to think my CSS was broken when really only the comparison apparatus was.
-- **No way to view "variant render alone" from `compare`.** I had to fall back to `vrt snapshot` separately to see what my page actually looked like.
+- **No way to view "variant render alone" from `compare`.** I had to fall back to `vlmkit snapshot` separately to see what my page actually looked like.
 - **"Fix Candidates: no suggestions"** every round. The fix-candidate engine is documented as for DOM-correspondence cases, but the suggested-next-step section explicitly says "wireframe / from-screenshot mode — DOM-position-diff is empty." If that's known, the tool could still propose CSS guesses (e.g. "increase margin-top of nth section by Δy") instead of being silent.
 - **Heading-mismatch warning fires only on h1/h2/h3 etc.** Wasn't aware until output told me. The brief said `title-lg` (which has no semantic implication), so this was a stealth requirement.
 - **Color names not back-resolved.** Palette diff reports raw hex. I knew `#e4ecfc` ≈ `#e2e8f8` = `surface-container-high` only because I have the token table memorized in scratch. Auto-mapping to nearest DESIGN.md token name would be huge.

--- a/fixtures/design-md-scenario/paws-and-paths/attempts/agent-a/log.md
+++ b/fixtures/design-md-scenario/paws-and-paths/attempts/agent-a/log.md
@@ -45,13 +45,13 @@ gives real signal. I lost ~5 minutes of round 1 to this.
 ### Final
 - wide 1.8% / desktop 2.0% / mobile 10.3%
 
-## What vrt helped with
+## What vlmkit helped with
 - **Text-row Δy table** is gold — it gave me literal +/- pixel offsets per row, letting me reason about vertical spacing without guessing.
 - **Component bbox table with IoU** quickly flagged mobile layout as wrong-tree (IoU 0.18) vs desktop being wrong-position (IoU 0.7+, near-uniform Δ).
 - **Palette diff** caught the stat-card color in one shot — `#e4ecfc` missing → `#dce4f4` extra, with the explicit hex. I could pick the correct token directly.
 - **DOM equivalence warning** told me `Mia Carter` should be a heading, which I had as a `<p>`.
 
-## Where vrt was unhelpful / misleading
+## Where vlmkit was unhelpful / misleading
 - **`vlmkit diff html` silent failure with bare paths.** Returned 0.0% diff with no warning that stylesheet loading was broken. The only hint was a "failed-resource-load" warning about Google Fonts (which is a side issue) — nothing about my local `style.css`. This made me think round 1 was perfect.
 - **`--output` flag is silently ignored.** I passed `--output /tmp/agent-a-round-1` but report always went to `/home/user/vrt/test-results/migration/`. No error, no log line.
 - **The PNG saved as `page-desktop.png` was NOT the rendered variant** — it appeared to be the heatmap/diff overlay rendered against a blank canvas. The visual was completely unstyled, leading me to think my CSS was broken when really only the comparison apparatus was.
@@ -61,7 +61,7 @@ gives real signal. I lost ~5 minutes of round 1 to this.
 - **Color names not back-resolved.** Palette diff reports raw hex. I knew `#e4ecfc` ≈ `#e2e8f8` = `surface-container-high` only because I have the token table memorized in scratch. Auto-mapping to nearest DESIGN.md token name would be huge.
 - **No paint-tree backend.** Crater BiDi was unavailable; the entire "Paint Tree" section was dead in every report. So I had no DOM/computed-style data — only image features.
 
-## What I wished vrt had told me
+## What I wished vlmkit had told me
 - "Stylesheet failed to load on variant" (and on baseline). A render-sanity check for `<link rel=stylesheet>` 404s, with side-by-side flagging.
 - "Container top padding differs by ~24px across viewports — try increasing/decreasing one token step on `.container` or its first child."
 - A "spacing-token snap" suggestion: given a baseline Δy of +12px and my margin-top of `space-sm` (12px), it could say "try `space-md` (24px)" — token-aware suggestions.

--- a/fixtures/design-md-scenario/paws-and-paths/attempts/agent-b/log.md
+++ b/fixtures/design-md-scenario/paws-and-paths/attempts/agent-b/log.md
@@ -28,7 +28,7 @@ node --experimental-strip-types src/vrt.ts compare \
 
 Result: **0.0 % on every viewport, "PASS, clean (3/3)"**.
 
-That diff is a lie. Three independent vrt bugs hit at once:
+That diff is a lie. Three independent vlmkit bugs hit at once:
 
 1. `vlmkit diff html` (file-mode) uses `page.setContent()` with no base URL, so
    relative `<link href="style.css">` never resolves in either side.
@@ -49,7 +49,7 @@ What I changed in response: workaround — copied my file to `variant.html`
 to dodge the name collision; switched to `--url file:///...` URL mode so
 playwright's `page.goto()` resolves relative CSS hrefs; inlined a copy of
 my CSS in a `<style>` block inside `page.html` as a belt-and-braces so
-**any** vrt path would see styled content.
+**any** vlmkit path would see styled content.
 
 ## Round 2 — real first diff
 
@@ -146,7 +146,7 @@ Result (after all four fixes applied together):
 ## Round 5 — final pass
 
 Synced `style.css` with the inline `<style>` block in `page.html` so
-the deliverable matches what vrt actually rendered. Deleted the
+the deliverable matches what vlmkit actually rendered. Deleted the
 `variant.html` workaround copy.
 
 Final diff:
@@ -159,6 +159,6 @@ Final diff:
 
 Remaining mobile delta is overwhelmingly text-rendering jitter inside
 the profile / stats cards (`profile-sub`, the `247 / 4.97` numbers).
-Not actionable from vrt's output without character-level shaping
+Not actionable from vlmkit's output without character-level shaping
 controls.
 

--- a/fixtures/design-md-scenario/paws-and-paths/attempts/agent-b/log.md
+++ b/fixtures/design-md-scenario/paws-and-paths/attempts/agent-b/log.md
@@ -30,7 +30,7 @@ Result: **0.0 % on every viewport, "PASS, clean (3/3)"**.
 
 That diff is a lie. Three independent vrt bugs hit at once:
 
-1. `vrt compare` (file-mode) uses `page.setContent()` with no base URL, so
+1. `vlmkit diff html` (file-mode) uses `page.setContent()` with no base URL, so
    relative `<link href="style.css">` never resolves in either side.
 2. Both files happen to be named `page.html`, so `baselineName` and
    `variantName` both serialize to `"page"`. The variant screenshot

--- a/fixtures/external-assets/README.md
+++ b/fixtures/external-assets/README.md
@@ -1,0 +1,30 @@
+# External-asset fixture — the load-mechanism gate
+
+**Every defect on this page is declared in `style.css`, never in `page.html`.**
+
+That is the whole point. A gate that loads the markup with
+`page.setContent(await readFile(file))` gets a document whose base URL is
+`about:blank`, so `<link rel="stylesheet" href="style.css">` never loads and the
+gate measures unstyled markup — reporting a clean page.
+
+Measured before the fix (2026-08-02): `check a11y contrast` reported
+**0 failures** here, and **1 failure** when the identical CSS was inlined in a
+`<style>` block. `check integrity`, which navigates to the file URL, reported the
+same defect correctly at 1.92:1.
+
+## What each defect is for
+
+| Class | Declared in CSS as | Gate that should catch it |
+|---|---|---|
+| Contrast | `.low-contrast { color: #bbbbbb }` — 1.92:1 on white | `check a11y contrast`, `check integrity` |
+| Touch target | `.tiny-tap { width: 20px; height: 20px }` | `check a11y touch` |
+| Invisible copy | `.hidden-copy { font-size: 0 }` (with `copy.txt`) | `check copy --manifest copy.txt` |
+| Spacing outlier | `.off-scale { padding-top: 23px }` against 24px | `check design` |
+| Component drift | `.btn-a/.btn-b/.btn-c` — 4 buttons, 3 styles | `check design` |
+
+## Gate criterion
+
+Any gate that accepts an HTML file must report the same findings here as it does
+on a copy with the CSS inlined. If the two disagree, the gate is not resolving
+relative assets, and its verdict on any real project — where CSS lives in its
+own file — means nothing.

--- a/fixtures/external-assets/copy.txt
+++ b/fixtures/external-assets/copy.txt
@@ -1,0 +1,1 @@
+Refunds processed within 14 days.

--- a/fixtures/external-assets/page.html
+++ b/fixtures/external-assets/page.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>External-asset gate fixture</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <div class="card">
+      <p class="low-contrast">Grey on white, below the WCAG floor.</p>
+      <p class="hidden-copy">Refunds processed within 14 days.</p>
+      <p class="off-scale">Padding one pixel off the page's own scale.</p>
+    </div>
+    <div class="card">
+      <button class="btn-a">Buy</button>
+      <button class="btn-a">Save</button>
+      <button class="btn-b">Cancel</button>
+      <button class="btn-c">Ghost</button>
+      <a class="tiny-tap" href="#x" aria-label="Tiny tap target"></a>
+    </div>
+  </main>
+</body>
+</html>

--- a/fixtures/external-assets/style.css
+++ b/fixtures/external-assets/style.css
@@ -1,0 +1,12 @@
+/* Every defect on this page lives HERE, not in the HTML.
+   A gate that loads the markup without resolving this file measures a
+   different document and passes. */
+body { margin: 0; padding: 32px; background: #ffffff; font: 16px/1.5 system-ui, sans-serif; }
+.low-contrast { color: #bbbbbb; }                      /* 1.92:1 on white — WCAG fail */
+.tiny-tap { display: inline-block; width: 20px; height: 20px; background: #444; }  /* 20x20 — below 24px */
+.hidden-copy { font-size: 0; }                          /* copy present in DOM, invisible */
+.off-scale { padding-top: 23px; }                       /* next to the 24px used elsewhere */
+.card { padding: 24px; border-radius: 8px; border: 1px solid #333; }
+.btn-a { padding: 12px 20px; border-radius: 8px; font-size: 14px; border: 1px solid #333; background: #fff; }
+.btn-b { padding: 10px 18px; border-radius: 6px; font-size: 13px; border: 2px solid #333; background: #eee; }
+.btn-c { padding: 14px 22px; border-radius: 0; font-size: 15px; border: 0; background: #ddd; }

--- a/fixtures/wireframe/pricing-card/README.md
+++ b/fixtures/wireframe/pricing-card/README.md
@@ -15,7 +15,7 @@ CSS from scratch.
 ## Files
 
 - `reference.html` — the answer. **Do not show to the agent during
-  the run.** Used by `vrt compare` as the diff target.
+  the run.** Used by `vlmkit diff html` as the diff target.
 - `target-mobile.png`, `target-desktop.png` — pre-rendered
   screenshots of `reference.html` at 375 / 1280 viewports. These
   are what the agent gets to look at.
@@ -33,7 +33,7 @@ ls fixtures/wireframe/pricing-card/target-*.png
 cp fixtures/wireframe/pricing-card/blank.html \
    fixtures/wireframe/pricing-card/working.html
 
-# 3. Run vrt compare. --no-dom-equivalence because the agent may
+# 3. Run vlmkit diff html. --no-dom-equivalence because the agent may
 #    have invented different tags / class names from the reference.
 PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
   node --experimental-strip-types src/migration-compare.ts \
@@ -59,5 +59,5 @@ position." This scenario tests the tools when:
 - The signal must come from per-band shifts + heatmaps + raw
   per-element bbox / style data without selector hints
 
-Use it to validate that `vrt diff-for-agent` remains useful when
+Use it to validate that `vlmkit diff agent` remains useful when
 the DOM-position alignment is broken.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "VLM-driven frontend toolkit: visual regression (snapshot / diff / regression-watch), markup synthesis from screenshots, design-token / theme / a11y / i18n audits, and a 2-stage VLM+LLM CSS auto-repair loop.",
   "license": "MIT",
   "author": "mizchi",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "motion:kagura-runtime-calibrated:game-assets": "node design-runs/game-assets-20260520/tools/check-kagura-runtime-smokes.mjs --calibration-contract design-runs/game-assets-20260520/models/robot-voxel-motion/kagura-calibration-handoff.json",
     "motion:kagura-runtime-utils:game-assets": "node --test design-runs/game-assets-20260520/tools/game-asset-motion-core.test.mjs design-runs/game-assets-20260520/tools/kagura-runtime-smoke-utils.test.mjs design-runs/game-assets-20260520/tools/kagura-runtime-batch-utils.test.mjs",
     "vrt": "playwright test",
-    "vrt:update": "playwright test --update-snapshots"
+    "vrt:update": "playwright test --update-snapshots",
+    "build:packages:js": "pnpm --filter './packages/**' --filter '!@mizchi/vlmkit-mcp' --filter '!@mizchi/vlmkit-markup' --recursive run build && pnpm --filter @mizchi/vlmkit-markup run build:js"
   },
   "devDependencies": {
     "@mizchi/vlmkit-ai": "workspace:*",

--- a/packages/vlmkit-ai/README.md
+++ b/packages/vlmkit-ai/README.md
@@ -3,7 +3,7 @@
 VLM / LLM clients and reasoning pipeline used by VRT to interpret diff
 images and natural-language intent.
 
-Part of the [`vrt`](https://github.com/mizchi/vrt) monorepo.
+Part of the [`vlmkit`](https://github.com/mizchi/vrt) monorepo.
 
 ## Install
 

--- a/packages/vlmkit-ai/package.json
+++ b/packages/vlmkit-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-ai",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "VLM / LLM clients, reasoning pipeline, and NLP helpers used by VRT to interpret diff images and natural-language intent.",
   "license": "MIT",
   "author": "mizchi",

--- a/packages/vlmkit-ai/src/llm-client.ts
+++ b/packages/vlmkit-ai/src/llm-client.ts
@@ -10,6 +10,7 @@
  */
 import type { LLMProvider } from "./intent.ts";
 import { VrtConfigError } from "./errors.ts";
+import { readEnv } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 // ---- Types ----
 
@@ -314,7 +315,7 @@ function resolveProviderConfig(options?: LLMClientOptions):
   | { ok: false; code: "INVALID_PROVIDER" | "MISSING_KEY"; message: string }
 {
   const rawProvider = options?.provider
-    ?? process.env.VRT_LLM_PROVIDER
+    ?? readEnv("LLM_PROVIDER")
     ?? "gemini";
 
   if (!VALID_PROVIDERS.has(rawProvider as LLMProviderName)) {
@@ -326,7 +327,7 @@ function resolveProviderConfig(options?: LLMClientOptions):
   }
   const provider = rawProvider as LLMProviderName;
 
-  const model = options?.model ?? process.env.VRT_LLM_MODEL ?? undefined;
+  const model = options?.model ?? readEnv("LLM_MODEL") ?? undefined;
 
   const keyMap: Record<LLMProviderName, string | undefined> = {
     gemini: process.env.GEMINI_API_KEY ?? process.env.GOOGLE_AI_API_KEY,

--- a/packages/vlmkit-ai/src/reasoning-pipeline.ts
+++ b/packages/vlmkit-ai/src/reasoning-pipeline.ts
@@ -13,6 +13,7 @@ import { createUnifiedLLMClient } from "./llm-client.ts";
 import { createVlmClient, resolveModel, type VlmClient } from "./vlm-client.ts";
 import { VrtConfigError } from "./errors.ts";
 import { resizeBase64Png, type ResolutionPreset } from "@mizchi/vlmkit-core/image-resize.ts";
+import { readEnv } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 // ---- Types ----
 
@@ -244,7 +245,7 @@ export function createReasoningPipeline(config?: PipelineConfig): ReasoningPipel
   const throwIfMissing = config?.throwIfMissing ?? true;
   // Stage 1: VLM
   let vlmClient: VlmClient | null = null;
-  let vlmModelId = config?.vlmModel ?? process.env.VRT_VLM_MODEL ?? "bytedance/ui-tars-1.5-7b";
+  let vlmModelId = config?.vlmModel ?? readEnv("VLM_MODEL") ?? "bytedance/ui-tars-1.5-7b";
 
   // Stage 2: LLM (try configured, then fallback). Always non-throwing here
   // — we synthesize a single ConfigError below if everything fails.

--- a/packages/vlmkit-capture/README.md
+++ b/packages/vlmkit-capture/README.md
@@ -3,7 +3,7 @@
 Playwright / Crater capture infrastructure for VRT — viewport discovery,
 multi-route capture, prescanner integration.
 
-Part of the [`vrt`](https://github.com/mizchi/vrt) monorepo.
+Part of the [`vlmkit`](https://github.com/mizchi/vrt) monorepo.
 
 ## Install
 

--- a/packages/vlmkit-capture/package.json
+++ b/packages/vlmkit-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-capture",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Playwright + Crater capture infrastructure for VRT — viewport discovery, multi-route capture, prescanner.",
   "license": "MIT",
   "author": "mizchi",

--- a/packages/vlmkit-capture/src/capture-config.ts
+++ b/packages/vlmkit-capture/src/capture-config.ts
@@ -1,5 +1,5 @@
 /**
- * Capture configuration loader for `vrt workflow init|capture`.
+ * Capture configuration loader for `vlmkit workflow init|capture`.
  *
  * Allows external projects to drive `e2e/vrt-capture.spec.ts` without
  * editing the spec by sourcing routes from `vrt.config.json` (or any
@@ -30,7 +30,7 @@ export const DEFAULT_CAPTURE_BASE_URL = "http://127.0.0.1:4174";
 
 /**
  * Built-in fallback used when no config or env override is provided.
- * Kept for vrt's own development workflow; external projects should
+ * Kept for vlmkit's own development workflow; external projects should
  * supply their own routes via `vrt.config.json`.
  */
 export const DEFAULT_CAPTURE_ROUTES: CaptureRoute[] = [

--- a/packages/vlmkit-core/README.md
+++ b/packages/vlmkit-core/README.md
@@ -3,7 +3,7 @@
 VRT diff engine and shared types. Pure-TypeScript image / DOM / a11y / visual
 comparison primitives — no Playwright required for the lightweight surface.
 
-Part of the [`vrt`](https://github.com/mizchi/vrt) monorepo.
+Part of the [`vlmkit`](https://github.com/mizchi/vrt) monorepo.
 
 ## Install
 

--- a/packages/vlmkit-core/package.json
+++ b/packages/vlmkit-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "VRT diff engine + shared types — pure image / DOM / a11y / visual comparison primitives.",
   "license": "MIT",
   "author": "mizchi",

--- a/packages/vlmkit-core/src/arg-reader.test.ts
+++ b/packages/vlmkit-core/src/arg-reader.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  hasFlag,
+  readAll,
+  readFlag,
+  readInt,
+  readNumber,
+  readPositionals,
+  tokenizeCommand,
+} from "./arg-reader.ts";
+
+describe("readFlag", () => {
+  it("reads a value, or nothing when the flag is absent", () => {
+    assert.equal(readFlag(["--out", "dir"], "out"), "dir");
+    assert.equal(readFlag(["--out", "dir"], "--out"), "dir");
+    assert.equal(readFlag(["--json"], "out"), undefined);
+  });
+
+  it("refuses to swallow the next flag as a value", () => {
+    // `--output --json` used to set the output directory to "--json".
+    assert.throws(() => readFlag(["--output", "--json"], "output"), /needs a value, got the next flag --json/);
+    assert.throws(() => readFlag(["--output", "-v"], "output"), /got the next flag -v/);
+    assert.throws(() => readFlag(["--output"], "output"), /--output needs a value/);
+  });
+
+  it("treats a negative number as a value, not a flag", () => {
+    assert.equal(readFlag(["--offset", "-3"], "offset"), "-3");
+  });
+
+  it("lets the last occurrence win", () => {
+    assert.equal(readFlag(["--out", "a", "--out", "b"], "out"), "b");
+  });
+});
+
+describe("readAll", () => {
+  it("collects every occurrence of a repeatable flag", () => {
+    assert.deepEqual(readAll(["--gate", "a", "--json", "--gate", "b"], "gate"), ["a", "b"]);
+    assert.deepEqual(readAll(["--json"], "gate"), []);
+  });
+
+  it("does not read a flag as one of the values", () => {
+    assert.throws(() => readAll(["--gate", "a", "--gate", "--json"], "gate"), /got the next flag/);
+  });
+
+  it("treats a repeated flag with no value between them as the error it is", () => {
+    assert.throws(() => readAll(["--only", "--only"], "only"), /--only needs a value/);
+  });
+});
+
+describe("readNumber / readInt", () => {
+  it("parses and range-checks", () => {
+    assert.equal(readInt(["--concurrency", "4"], "concurrency", { min: 1 }), 4);
+    assert.equal(readNumber(["--min-reuse", "2.5"], "min-reuse", { min: 0 }), 2.5);
+    assert.equal(readInt(["--json"], "concurrency"), undefined);
+  });
+
+  it("rejects a non-number instead of yielding NaN", () => {
+    // NaN does not fail loudly: it made runPool build zero lanes and report
+    // success having run nothing.
+    assert.throws(() => readInt(["--concurrency", "abc"], "concurrency"), /must be a number, got "abc"/);
+    assert.throws(() => readInt(["--concurrency", "4abc"], "concurrency"), /must be a number, got "4abc"/);
+    assert.throws(() => readNumber(["--dpr", ""], "dpr"), /must be a number/);
+  });
+
+  it("rejects a fractional value where a whole number is required", () => {
+    assert.throws(() => readInt(["--concurrency", "2.5"], "concurrency"), /must be a whole number/);
+  });
+
+  it("enforces min and max", () => {
+    assert.throws(() => readInt(["--concurrency", "0"], "concurrency", { min: 1 }), /must be >= 1, got 0/);
+    assert.throws(() => readInt(["--shards", "99"], "shards", { max: 32 }), /must be <= 32, got 99/);
+  });
+});
+
+describe("hasFlag", () => {
+  it("matches with or without the leading dashes", () => {
+    assert.equal(hasFlag(["--json"], "json"), true);
+    assert.equal(hasFlag(["--json"], "--json"), true);
+    assert.equal(hasFlag([], "json"), false);
+  });
+});
+
+describe("readPositionals", () => {
+  const VALUE_FLAGS = ["gate", "concurrency", "output"];
+
+  it("keeps positionals and drops flags with their values", () => {
+    assert.deepEqual(
+      readPositionals(["--gate", "check integrity", "a.html", "--concurrency", "4", "b.html", "--quiet"], VALUE_FLAGS),
+      ["a.html", "b.html"],
+    );
+  });
+
+  it("does not mistake a value-flag's value for a positional", () => {
+    assert.deepEqual(readPositionals(["--concurrency", "4"], VALUE_FLAGS), []);
+  });
+
+  it("treats an unknown flag as valueless, so its argument stays a positional", () => {
+    // Conservative on purpose: a swallowed page is worse than an extra one,
+    // because the run would silently cover less than the user asked for.
+    assert.deepEqual(readPositionals(["--unknown", "a.html"], VALUE_FLAGS), ["a.html"]);
+  });
+
+  it("returns nothing when there are no positionals", () => {
+    assert.deepEqual(readPositionals(["--quiet", "--json"], VALUE_FLAGS), []);
+  });
+});
+
+describe("tokenizeCommand", () => {
+  it("splits on whitespace", () => {
+    assert.deepEqual(tokenizeCommand("check design --min-reuse 4"), ["check", "design", "--min-reuse", "4"]);
+    assert.deepEqual(tokenizeCommand("  check   integrity  "), ["check", "integrity"]);
+    assert.deepEqual(tokenizeCommand(""), []);
+  });
+
+  it("keeps quoted values together", () => {
+    // A path with a space, or a selector list, would otherwise arrive at the
+    // gate as several arguments and fail as if the gate were broken.
+    assert.deepEqual(
+      tokenizeCommand('check copy --manifest "copy/press kit.txt"'),
+      ["check", "copy", "--manifest", "copy/press kit.txt"],
+    );
+    assert.deepEqual(
+      tokenizeCommand(`check breakpoints --mask '.hero, .promo'`),
+      ["check", "breakpoints", "--mask", ".hero, .promo"],
+    );
+  });
+
+  it("keeps an empty quoted argument", () => {
+    assert.deepEqual(tokenizeCommand('check copy --prefix ""'), ["check", "copy", "--prefix", ""]);
+  });
+
+  it("allows quotes inside a word", () => {
+    assert.deepEqual(tokenizeCommand(`--selector a"b"c`), ["--selector", "abc"]);
+    assert.deepEqual(tokenizeCommand(`--sel "[data-id='x']"`), ["--sel", "[data-id='x']"]);
+  });
+
+  it("reports an unterminated quote rather than truncating silently", () => {
+    assert.throws(() => tokenizeCommand('check copy --manifest "unclosed.txt'), /Unterminated " quote/);
+  });
+});

--- a/packages/vlmkit-core/src/arg-reader.ts
+++ b/packages/vlmkit-core/src/arg-reader.ts
@@ -1,0 +1,155 @@
+/**
+ * Argv readers that take the array explicitly, and refuse to guess.
+ *
+ * `cli-args.ts` binds to `process.argv` at import time, which makes it
+ * untestable and unusable from a dispatcher-driven leaf. The hand-rolled
+ * readers that grew in its place all shared two silent failure modes:
+ *
+ *   - `--output --json` consumed `--json` as the output directory;
+ *   - `--concurrency abc` produced `NaN`, and `NaN` does not fail loudly. It
+ *     made `runPool` build zero lanes and "successfully" run nothing.
+ *
+ * So a missing value is an error, a value that looks like another flag is an
+ * error, and a numeric flag is validated where it is read rather than wherever
+ * the NaN eventually lands.
+ */
+
+import { UsageError } from "./cli-error.ts";
+
+const flagName = (name: string) => (name.startsWith("-") ? name : `--${name}`);
+
+/** A value must not itself look like a flag — `-1` is a value, `--json` is not. */
+const looksLikeFlag = (value: string) => /^--/.test(value) || /^-[a-zA-Z]/.test(value);
+
+export function hasFlag(argv: readonly string[], name: string): boolean {
+  return argv.includes(flagName(name));
+}
+
+/**
+ * Last occurrence wins, matching how shells and most CLIs behave when a flag is
+ * repeated. Throws when the value is missing or is another flag.
+ */
+export function readFlag(argv: readonly string[], name: string): string | undefined {
+  const flag = flagName(name);
+  const index = argv.lastIndexOf(flag);
+  if (index < 0) return undefined;
+  const value = argv[index + 1];
+  if (value === undefined) throw new UsageError(`${flag} needs a value`);
+  if (looksLikeFlag(value)) throw new UsageError(`${flag} needs a value, got the next flag ${value}`);
+  return value;
+}
+
+/** Every occurrence, for repeatable flags (`--gate`, `--only`, `--pages`). */
+export function readAll(argv: readonly string[], name: string): string[] {
+  const flag = flagName(name);
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] !== flag) continue;
+    const value = argv[i + 1];
+    if (value === undefined) throw new UsageError(`${flag} needs a value`);
+    if (looksLikeFlag(value)) throw new UsageError(`${flag} needs a value, got the next flag ${value}`);
+    out.push(value);
+    i++;
+  }
+  return out;
+}
+
+export interface NumberFlagOptions {
+  min?: number;
+  max?: number;
+  integer?: boolean;
+}
+
+export function readNumber(
+  argv: readonly string[],
+  name: string,
+  options: NumberFlagOptions = {},
+): number | undefined {
+  const raw = readFlag(argv, name);
+  if (raw === undefined) return undefined;
+  const flag = flagName(name);
+  // Always parse the FULL value, even in integer mode: `parseInt("2.5")` is 2,
+  // so parsing as an integer first would silently accept a fraction by
+  // truncating it out of existence before the integrality check ran.
+  const value = Number.parseFloat(raw);
+  // `parseFloat("4abc")` is 4; a partially-numeric value is a typo, not a number.
+  if (!Number.isFinite(value) || !/^-?\d+(\.\d+)?$/.test(raw.trim())) {
+    throw new UsageError(`${flag} must be a number, got "${raw}"`);
+  }
+  if (options.integer && !Number.isInteger(value)) {
+    throw new UsageError(`${flag} must be a whole number, got "${raw}"`);
+  }
+  if (options.min !== undefined && value < options.min) {
+    throw new UsageError(`${flag} must be >= ${options.min}, got ${value}`);
+  }
+  if (options.max !== undefined && value > options.max) {
+    throw new UsageError(`${flag} must be <= ${options.max}, got ${value}`);
+  }
+  return value;
+}
+
+export function readInt(argv: readonly string[], name: string, options: NumberFlagOptions = {}): number | undefined {
+  return readNumber(argv, name, { ...options, integer: true });
+}
+
+/**
+ * Arguments that are neither a flag nor a flag's value.
+ *
+ * The caller has to name the flags that take values, because argv alone cannot
+ * tell `--concurrency 4` (a value) from `--quiet page.html` (a positional). The
+ * hand-rolled version of this was a for-loop per CLI that advanced its own
+ * index, i.e. the same knowledge encoded three times.
+ */
+export function readPositionals(argv: readonly string[], valueFlags: readonly string[] = []): string[] {
+  const takesValue = new Set(valueFlags.map(flagName));
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (takesValue.has(arg)) {
+      i++;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    out.push(arg);
+  }
+  return out;
+}
+
+/**
+ * Split a command string into argv, honouring quotes.
+ *
+ * Needed because gate commands are authored as single strings — in a config
+ * file (`"check copy --manifest copy/press kit.txt"`) or on the command line
+ * (`--gate 'check breakpoints --mask ".hero, .promo"'`). Splitting on
+ * whitespace would hand the gate `kit.txt` and `.promo"` as separate
+ * arguments, which fails in a way that looks like the gate's fault.
+ */
+export function tokenizeCommand(command: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let started = false;
+  for (const char of command) {
+    if (quote) {
+      if (char === quote) quote = null;
+      else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (started) out.push(current);
+      current = "";
+      started = false;
+      continue;
+    }
+    current += char;
+    started = true;
+  }
+  if (quote) throw new UsageError(`Unterminated ${quote} quote in command: ${command}`);
+  if (started) out.push(current);
+  return out;
+}

--- a/packages/vlmkit-core/src/auth-state.test.ts
+++ b/packages/vlmkit-core/src/auth-state.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { readStorageState, STORAGE_STATE_ENV, storageStatePath, withAuthState } from "./auth-state.ts";
+
+const withEnv = async (value: string | undefined, fn: () => Promise<void> | void) => {
+  const prev = process.env[STORAGE_STATE_ENV];
+  if (value === undefined) delete process.env[STORAGE_STATE_ENV];
+  else process.env[STORAGE_STATE_ENV] = value;
+  try {
+    await fn();
+  } finally {
+    if (prev === undefined) delete process.env[STORAGE_STATE_ENV];
+    else process.env[STORAGE_STATE_ENV] = prev;
+  }
+};
+
+test("explicit path beats env; blank values are ignored", async () => {
+  await withEnv("from-env.json", () => {
+    assert.equal(storageStatePath("explicit.json"), "explicit.json");
+    assert.equal(storageStatePath(), "from-env.json");
+    assert.equal(storageStatePath("  "), "from-env.json");
+  });
+  await withEnv(undefined, () => {
+    assert.equal(storageStatePath(), undefined);
+  });
+});
+
+test("valid storage state is accepted and injected into page options", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auth-state-"));
+  try {
+    const file = join(dir, "auth.json");
+    await writeFile(file, JSON.stringify({ cookies: [{ name: "sid", value: "abc" }], origins: [] }));
+    const state = readStorageState(file);
+    assert.equal(state.cookies.length, 1);
+
+    await withEnv(undefined, () => {
+      const opts = withAuthState({ viewport: { width: 1280, height: 800 } }, file);
+      assert.equal(opts.storageState, resolve(file));
+      assert.deepEqual(opts.viewport, { width: 1280, height: 800 });
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("no auth configured leaves page options untouched", async () => {
+  await withEnv(undefined, () => {
+    const base = { viewport: { width: 375, height: 700 } };
+    const opts = withAuthState(base);
+    assert.deepEqual(opts, base);
+    assert.equal("storageState" in opts, false);
+  });
+});
+
+test("bad storage state throws before navigation, with a usable hint", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auth-state-bad-"));
+  try {
+    assert.throws(() => readStorageState(join(dir, "nope.json")), /not found[\s\S]*codegen --save-storage/);
+
+    const bad = join(dir, "bad.json");
+    await writeFile(bad, "{not json");
+    assert.throws(() => readStorageState(bad), /not valid JSON/);
+
+    const wrong = join(dir, "wrong.json");
+    await writeFile(wrong, JSON.stringify({ token: "abc" }));
+    assert.throws(() => readStorageState(wrong), /no "cookies" or "origins" array/);
+
+    const empty = join(dir, "empty.json");
+    await writeFile(empty, JSON.stringify({ cookies: [], origins: [] }));
+    assert.throws(() => readStorageState(empty), /authenticate nothing/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("env-configured auth applies without an explicit flag", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auth-state-env-"));
+  try {
+    const file = join(dir, "auth.json");
+    await writeFile(file, JSON.stringify({ cookies: [{ name: "sid", value: "z" }] }));
+    await withEnv(file, () => {
+      const opts = withAuthState({ viewport: { width: 800, height: 600 } });
+      assert.equal(opts.storageState, resolve(file));
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/vlmkit-core/src/auth-state.ts
+++ b/packages/vlmkit-core/src/auth-state.ts
@@ -1,0 +1,94 @@
+/**
+ * Authenticated-page support for the gates.
+ *
+ * The 2026-08-01 hard-target audit made the auth gap loud (a redirect to a
+ * login wall is now a reported defect instead of a silent CLEAN), but loud
+ * failure is not access: for most product apps the interesting pages —
+ * dashboard, checkout, settings — are all behind a session. This closes
+ * that by accepting a Playwright storage-state file, which is the format
+ * `playwright codegen --save-storage` and `context.storageState()` already
+ * produce, so teams reuse the artifact their e2e suite has.
+ *
+ * Two ways in, because gate invocations live in CI yaml / npm scripts and
+ * threading a flag through every one of them is the exact config sprawl
+ * this project is trying not to create:
+ *   - `--storage-state <path>` on any URL-capable gate
+ *   - `VLMKIT_STORAGE_STATE=<path>` for all of them at once
+ *
+ * An explicit flag always wins over the environment.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const STORAGE_STATE_ENV = "VLMKIT_STORAGE_STATE";
+
+/**
+ * Explicit flag beats env; returns undefined when neither is set. A blank
+ * explicit value counts as "not passed" and falls through to the
+ * environment, so `--storage-state "$MAYBE_UNSET"` in a script does not
+ * silently disable an env-configured session.
+ */
+export function storageStatePath(explicit?: string): string | undefined {
+  for (const candidate of [explicit, process.env[STORAGE_STATE_ENV]]) {
+    if (candidate && candidate.trim() !== "") return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Validate eagerly and loudly. A silently ignored auth file would send the
+ * caller straight back to the failure this feature exists to fix — an
+ * unauthenticated measurement that looks like a real result.
+ */
+export function readStorageState(path: string): { cookies: unknown[]; origins: unknown[] } {
+  const abs = resolve(path);
+  let raw: string;
+  try {
+    raw = readFileSync(abs, "utf8");
+  } catch {
+    throw new Error(
+      `storage state file not found: ${abs}\n` +
+        `Create one with: npx playwright codegen --save-storage=auth.json <your-login-url>`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`storage state file is not valid JSON: ${abs}`);
+  }
+  const obj = parsed as { cookies?: unknown; origins?: unknown };
+  if (!obj || typeof obj !== "object" || (!Array.isArray(obj.cookies) && !Array.isArray(obj.origins))) {
+    throw new Error(
+      `storage state file has no "cookies" or "origins" array: ${abs}\n` +
+        `Expected a Playwright storage-state file (context.storageState() output).`,
+    );
+  }
+  const cookies = Array.isArray(obj.cookies) ? obj.cookies : [];
+  const origins = Array.isArray(obj.origins) ? obj.origins : [];
+  if (cookies.length === 0 && origins.length === 0) {
+    throw new Error(
+      `storage state file carries no cookies and no origins: ${abs}\n` +
+        `It would authenticate nothing — re-capture it after logging in.`,
+    );
+  }
+  return { cookies, origins };
+}
+
+/**
+ * Merge `storageState` into Playwright page options when configured.
+ * `browser.newPage(options)` forwards context options, so every gate can
+ * adopt this by wrapping its existing options object.
+ */
+export function withAuthState<T extends object>(base: T, explicit?: string): T & { storageState?: string } {
+  const path = storageStatePath(explicit);
+  if (!path) return base;
+  readStorageState(path); // throw before we navigate, not after
+  return { ...base, storageState: resolve(path) };
+}
+
+/** One-line notice so a run that used auth says so in its output. */
+export function authStateNotice(explicit?: string): string | null {
+  const path = storageStatePath(explicit);
+  return path ? `auth: storage state from ${resolve(path)}` : null;
+}

--- a/packages/vlmkit-core/src/cli-args.test.ts
+++ b/packages/vlmkit-core/src/cli-args.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  getArg,
+  getArgValues,
+  getFloatArg,
+  getIntArg,
+  getPositionalArgs,
+  getRawArgs,
+  hasFlag,
+} from "./cli-args.ts";
+
+const REAL_ARGV = process.argv;
+const withArgv = <T>(tail: string[], body: () => T): T => {
+  process.argv = ["node", "cli.ts", ...tail];
+  return body();
+};
+
+afterEach(() => {
+  process.argv = REAL_ARGV;
+});
+
+describe("getArg", () => {
+  it("reads a value and falls back when absent", () => {
+    assert.equal(withArgv(["--fixture", "page"], () => getArg("fixture", "default")), "page");
+    assert.equal(withArgv(["--json"], () => getArg("fixture", "default")), "default");
+    assert.equal(withArgv([], () => getArg("fixture")), undefined);
+  });
+
+  it("treats an empty value as absent, as callers were written against", () => {
+    assert.equal(withArgv(["--image", ""], () => getArg("image", "fallback.png")), "fallback.png");
+  });
+
+  it("refuses to return the next flag as the value", () => {
+    // `fix-loop --seed --mode selector` used to yield "--mode", which the
+    // caller's parseInt turned into a NaN seed with no complaint.
+    assert.throws(
+      () => withArgv(["--seed", "--mode", "selector"], () => getArg("seed", "1")),
+      /--seed needs a value, got the next flag --mode/,
+    );
+  });
+
+  it("reads argv per call, so a dispatcher-loaded leaf sees its own arguments", () => {
+    // The previous module captured process.argv at import time; a leaf loaded
+    // after the dispatcher rewrote argv saw the wrong list.
+    assert.equal(withArgv(["--fixture", "a"], () => getArg("fixture", "?")), "a");
+    assert.equal(withArgv(["--fixture", "b"], () => getArg("fixture", "?")), "b");
+  });
+});
+
+describe("getIntArg / getFloatArg", () => {
+  it("parses, falls back, and range-checks", () => {
+    assert.equal(withArgv(["--max-rounds", "5"], () => getIntArg("max-rounds", 3)), 5);
+    assert.equal(withArgv([], () => getIntArg("max-rounds", 3)), 3);
+    assert.equal(withArgv(["--max-cost", "0.001"], () => getFloatArg("max-cost", 999)), 0.001);
+  });
+
+  it("rejects a non-number where the old code produced NaN", () => {
+    assert.throws(() => withArgv(["--seed", "abc"], () => getIntArg("seed", 1)), /--seed must be a number/);
+    assert.throws(
+      () => withArgv(["--max-rounds", "0"], () => getIntArg("max-rounds", 3, { min: 1 })),
+      /--max-rounds must be >= 1/,
+    );
+  });
+});
+
+describe("getPositionalArgs", () => {
+  it("keeps a positional that follows a boolean flag", () => {
+    // The old implementation assumed EVERY flag takes a value, so `--md model`
+    // silently dropped the model name.
+    assert.deepEqual(
+      withArgv(["--md", "qwen/qwen3-vl", "--limit", "30"], () => getPositionalArgs(["limit"])),
+      ["qwen/qwen3-vl"],
+    );
+  });
+
+  it("still drops a named flag's value", () => {
+    assert.deepEqual(
+      withArgv(["model-a", "--max-cost", "0.001", "model-b"], () => getPositionalArgs(["max-cost"])),
+      ["model-a", "model-b"],
+    );
+  });
+});
+
+describe("hasFlag / getArgValues / getRawArgs", () => {
+  it("still work as before", () => {
+    assert.equal(withArgv(["--no-db"], () => hasFlag("no-db")), true);
+    assert.equal(withArgv([], () => hasFlag("no-db")), false);
+    assert.deepEqual(withArgv(["--gate", "a", "--gate", "b"], () => getArgValues("gate")), ["a", "b"]);
+    assert.deepEqual(withArgv(["--fixture", "page"], () => getRawArgs()), ["--fixture", "page"]);
+  });
+});

--- a/packages/vlmkit-core/src/cli-args.ts
+++ b/packages/vlmkit-core/src/cli-args.ts
@@ -1,29 +1,76 @@
-/** Shared CLI argument parsing helpers */
+/**
+ * Shared CLI argument helpers, kept as the ergonomic `process.argv`-bound
+ * facade over `arg-reader.ts`.
+ *
+ * This used to be a standalone implementation, and it silently produced wrong
+ * values. `getArg("seed", fallback)` returned whatever followed the flag, so
+ * `fix-loop --seed --mode selector` yielded `"--mode"`, and the caller's
+ * `parseInt` turned that into a `NaN` seed with no complaint. Every reader here
+ * now delegates to `arg-reader`, which treats a flag-shaped value and a
+ * non-numeric number as errors.
+ *
+ * `argv()` is read per call rather than captured at import time, so a leaf
+ * reached through the CLI dispatcher — which rewrites `process.argv` before
+ * loading the leaf — sees the arguments it was actually given.
+ */
+import {
+  hasFlag as hasFlagIn,
+  readAll,
+  readFlag,
+  readNumber,
+  readPositionals,
+} from "./arg-reader.ts";
 
-const args = process.argv.slice(2);
+const argv = (): string[] => process.argv.slice(2);
 
 export function getArg(name: string, fallback: string): string;
 export function getArg(name: string): string | undefined;
 export function getArg(name: string, fallback?: string): string | undefined {
-  const idx = args.indexOf(`--${name}`);
-  return idx >= 0 && args[idx + 1] ? args[idx + 1] : fallback;
+  const value = readFlag(argv(), name);
+  // An empty value counts as absent, which is the behaviour callers were
+  // written against (`--image ""` should fall back, not blank the path).
+  return value === undefined || value === "" ? fallback : value;
+}
+
+/**
+ * Numeric flags, validated. Callers used to write `parseInt(getArg(n, d), 10)`,
+ * which is where a bad value became `NaN` — far from the flag that caused it.
+ */
+export function getIntArg(name: string, fallback: number, options: { min?: number; max?: number } = {}): number {
+  return readNumber(argv(), name, { ...options, integer: true }) ?? fallback;
+}
+
+export function getFloatArg(name: string, fallback: number, options: { min?: number; max?: number } = {}): number {
+  return readNumber(argv(), name, options) ?? fallback;
 }
 
 export function hasFlag(name: string): boolean {
-  return args.includes(`--${name}`);
+  return hasFlagIn(argv(), name);
 }
 
 export function getArgValues(name: string): string[] {
-  const values: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === `--${name}` && args[i + 1]) values.push(args[i + 1]);
-  }
-  return values;
+  return readAll(argv(), name);
 }
 
-/** Get positional args (not flags or flag values) */
-export function getPositionalArgs(): string[] {
-  return args.filter((a, i) => !a.startsWith("--") && (i === 0 || !args[i - 1]?.startsWith("--")));
+/**
+ * Positional arguments.
+ *
+ * `valueFlags` names the flags that consume the next argument — required,
+ * because argv alone cannot tell `--limit 30` from `--md model-name`. The old
+ * implementation assumed *every* flag takes a value, which silently dropped a
+ * positional that happened to follow a boolean flag.
+ */
+export function getPositionalArgs(valueFlags: readonly string[] = []): string[] {
+  return readPositionals(argv(), valueFlags);
 }
 
-export { args };
+/** Raw argv tail, for callers doing their own scanning. */
+export function getRawArgs(): string[] {
+  return argv();
+}
+
+/**
+ * @deprecated Captured at import time, so it is empty or stale in a leaf loaded
+ * through the dispatcher. Use `getRawArgs()`.
+ */
+export const args = argv();

--- a/packages/vlmkit-core/src/cli-error.ts
+++ b/packages/vlmkit-core/src/cli-error.ts
@@ -9,12 +9,26 @@
  */
 import { statSync } from "node:fs";
 
+/**
+ * A bad flag or missing argument — the caller's typo, not a defect. Thrown by
+ * `arg-reader` and printed as one line, because a stack trace for
+ * `--concurrency abc` buries the one sentence that fixes it.
+ */
+export class UsageError extends Error {
+  override readonly name = "UsageError";
+}
+
 export function handleCliError(e: unknown): never {
   // Node fs errors carry the offending path on `.path`; that's more
   // reliable than parsing it out of `.message` (which sometimes
   // doesn't include the path at all, e.g. EISDIR from readFile).
   const err = e as { code?: string; message?: string; name?: string; path?: string };
   const msg = String(err?.message ?? e);
+
+  if (err?.name === "UsageError") {
+    process.stderr.write(`error: ${msg}\n`);
+    process.exit(1);
+  }
 
   // ENOENT — missing local file path.
   if (err?.code === "ENOENT") {

--- a/packages/vlmkit-core/src/cli-error.ts
+++ b/packages/vlmkit-core/src/cli-error.ts
@@ -1,6 +1,6 @@
 /**
  * Shared CLI error-prettifier. Recognizes common error shapes that
- * make `vrt` look user-hostile (ENOENT stack traces, Playwright
+ * make `vlmkit` look user-hostile (ENOENT stack traces, Playwright
  * navigation errors with absolute source paths) and rewrites them
  * to a one-line message.
  *
@@ -39,7 +39,7 @@ export function handleCliError(e: unknown): never {
   // EISDIR — caller passed a directory where an HTML file (or other
   // single-file artifact) was expected. Surfaced repeatedly in
   // back-to-back cold-start dogfoods (2026-05-15) as the worst raw-
-  // stack-trace first impression in the toolkit. Almost every vrt
+  // stack-trace first impression in the toolkit. Almost every vlmkit
   // subcommand accepts `<html-or-url>` as its first positional, so
   // catching the directory case here covers all of them at once.
   // Node's fsPromises.readFile drops `err.path`, so we fall back to
@@ -83,7 +83,7 @@ export function handleCliError(e: unknown): never {
  * EISDIR fallback: Node's `fsPromises.readFile` doesn't attach `.path`
  * to the error, and the message string doesn't include the path
  * either. Scan argv for the first positional that exists as a
- * directory — close enough since most vrt subcommands take exactly
+ * directory — close enough since most vlmkit subcommands take exactly
  * one path argument and the failure happens during the initial read.
  */
 function findDirectoryArg(): string | undefined {

--- a/packages/vlmkit-core/src/element-compare.ts
+++ b/packages/vlmkit-core/src/element-compare.ts
@@ -6,9 +6,9 @@
  * compares individual DOM elements independently via locator.screenshot().
  *
  * Usage:
- *   vrt elements --url http://localhost:3000/ --current-url http://localhost:8080/ \
+ *   vlmkit diff elements --url http://localhost:3000/ --current-url http://localhost:8080/ \
  *     --selectors "header,main,footer"
- *   vrt elements before.html after.html --selectors "header,.content,.sidebar"
+ *   vlmkit diff elements before.html after.html --selectors "header,.content,.sidebar"
  */
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -263,12 +263,12 @@ function parseArgs(args: string[]): ElementCompareOptions {
 function formatUsage(): string {
   return [
     "Usage:",
-    "  vrt diff component --url <baseline> --current-url <current> --selectors \"header,main,footer\"",
-    "  vrt diff component before.html after.html --selectors \"header,.content\"",
+    "  vlmkit diff component --url <baseline> --current-url <current> --selectors \"header,main,footer\"",
+    "  vlmkit diff component before.html after.html --selectors \"header,.content\"",
     "",
     "Aliases:",
-    "  vrt diff elements",
-    "  vrt elements",
+    "  vlmkit diff elements",
+    "  vlmkit diff elements",
     "",
     "Options:",
     "  --selectors <sel1,sel2,...>   CSS selectors to compare (required)",

--- a/packages/vlmkit-core/src/gate-config.test.ts
+++ b/packages/vlmkit-core/src/gate-config.test.ts
@@ -73,6 +73,19 @@ describe("parseGateConfig", () => {
     assert.throws(() => parseGateConfig(json({ pages: [] })), /pages: is empty/);
   });
 
+  it("refuses an empty gate list, which would silently gate nothing", () => {
+    // `defaults: {gates: []}` used to validate and then run zero jobs for every
+    // page relying on the defaults — a pass that checked nothing.
+    assert.throws(
+      () => parseGateConfig(json({ defaults: { gates: [] }, pages: [{ id: "a", source: "a.html", gates: ["g"] }] })),
+      /defaults\.gates: is empty/,
+    );
+    assert.throws(
+      () => parseGateConfig(json({ pages: [{ id: "a", source: "a.html", gates: [] }] })),
+      /pages\[0\]\.gates: is empty/,
+    );
+  });
+
   it("names the JSON path in every structural error", () => {
     assert.throws(() => parseGateConfig("{"), /not valid JSON/);
     assert.throws(() => parseGateConfig(json({ pages: "routes" })), /pages: must be an array/);

--- a/packages/vlmkit-core/src/gate-config.test.ts
+++ b/packages/vlmkit-core/src/gate-config.test.ts
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  type GateConfig,
+  gateMatches,
+  parseGateConfig,
+  resolveGatePlan,
+  resolveSuppression,
+  summarizeSuppressions,
+} from "./gate-config.ts";
+
+const NOW = new Date("2026-08-02T12:00:00Z");
+
+const json = (value: unknown) => JSON.stringify(value);
+
+describe("parseGateConfig", () => {
+  it("accepts a minimal config", () => {
+    const config = parseGateConfig(json({
+      defaults: { gates: ["check integrity"] },
+      pages: [{ source: "index.html" }],
+    }));
+    assert.deepEqual(config.pages, [{ id: "index.html", source: "index.html" }]);
+    assert.deepEqual(config.defaults?.gates, ["check integrity"]);
+  });
+
+  it("defaults a page id to its source, and keeps ids unique", () => {
+    const config = parseGateConfig(json({
+      pages: [{ source: "a.html", gates: ["check integrity"] }, { id: "b", source: "b.html", gates: ["check design"] }],
+    }));
+    assert.deepEqual(config.pages.map((p) => p.id), ["a.html", "b"]);
+    assert.throws(
+      () => parseGateConfig(json({ pages: [{ id: "x", source: "a.html", gates: ["g"] }, { id: "x", source: "b.html", gates: ["g"] }] })),
+      /duplicate page id "x"/,
+    );
+  });
+
+  it("rejects a suppression with no reason", () => {
+    // A flag records what was silenced but not why, which is exactly the state
+    // that gets re-approved a year later without anyone knowing what it was for.
+    assert.throws(
+      () => parseGateConfig(json({
+        pages: [{
+          source: "a.html",
+          gates: ["check copy"],
+          suppressions: [{ gate: "check copy", flag: "--allow-invisible hidden" }],
+        }],
+      })),
+      /pages\[0\]\.suppressions\[0\]: reason is required/,
+    );
+  });
+
+  it("rejects a malformed or impossible expiry", () => {
+    const withExpiry = (expires: string) => json({
+      pages: [{
+        source: "a.html",
+        gates: ["check copy"],
+        suppressions: [{ gate: "check copy", flag: "--x", reason: "r", expires }],
+      }],
+    });
+    assert.throws(() => parseGateConfig(withExpiry("soon")), /expires must be YYYY-MM-DD/);
+    assert.throws(() => parseGateConfig(withExpiry("2026-13-45")), /not a real date/);
+    assert.doesNotThrow(() => parseGateConfig(withExpiry("2026-12-01")));
+  });
+
+  it("refuses a page with no gates from any source", () => {
+    assert.throws(
+      () => parseGateConfig(json({ pages: [{ source: "a.html" }] })),
+      /pages\[0\]: no gates/,
+    );
+  });
+
+  it("refuses an empty page list rather than running nothing", () => {
+    assert.throws(() => parseGateConfig(json({ pages: [] })), /pages: is empty/);
+  });
+
+  it("names the JSON path in every structural error", () => {
+    assert.throws(() => parseGateConfig("{"), /not valid JSON/);
+    assert.throws(() => parseGateConfig(json({ pages: "routes" })), /pages: must be an array/);
+    assert.throws(() => parseGateConfig(json({ pages: [{ gates: ["g"] }] })), /pages\[0\]: source is required/);
+    assert.throws(
+      () => parseGateConfig(json({ pages: [{ source: "a.html", gates: ["ok", ""] }] })),
+      /pages\[0\]\.gates\[1\]: must be a non-empty string/,
+    );
+  });
+});
+
+describe("gateMatches", () => {
+  it("matches on whole tokens, not substrings", () => {
+    assert.equal(gateMatches("check copy --manifest x.txt", "check copy"), true);
+    assert.equal(gateMatches("check copy", "check"), true);
+    assert.equal(gateMatches("check copyright", "check copy"), false);
+    assert.equal(gateMatches("check copy", "check copy --manifest x.txt"), false);
+    assert.equal(gateMatches("check design", "check copy"), false);
+  });
+});
+
+describe("resolveSuppression", () => {
+  it("treats the expiry day itself as still valid", () => {
+    assert.equal(resolveSuppression({ gate: "g", flag: "-f", reason: "r", expires: "2026-08-02" }, "p", NOW).status, "active");
+    assert.equal(resolveSuppression({ gate: "g", flag: "-f", reason: "r", expires: "2026-08-01" }, "p", NOW).status, "expired");
+  });
+
+  it("reports days left, negative when overdue", () => {
+    assert.equal(resolveSuppression({ gate: "g", flag: "-f", reason: "r", expires: "2026-08-12" }, "p", NOW).daysLeft, 10);
+    assert.equal(resolveSuppression({ gate: "g", flag: "-f", reason: "r", expires: "2026-07-28" }, "p", NOW).daysLeft, -5);
+  });
+
+  it("calls a missing expiry permanent rather than active", () => {
+    const r = resolveSuppression({ gate: "g", flag: "-f", reason: "r" }, "p", NOW);
+    assert.equal(r.status, "permanent");
+    assert.equal(r.daysLeft, null);
+  });
+});
+
+describe("resolveGatePlan", () => {
+  const config: GateConfig = parseGateConfig(json({
+    defaults: { gates: ["check integrity", "check design"] },
+    pages: [
+      {
+        id: "checkout",
+        source: "checkout.html",
+        extraGates: ["check copy --manifest copy.txt"],
+        suppressions: [{
+          gate: "check copy",
+          flag: "--allow-invisible visually-hidden",
+          reason: "skip link is assistive-tech only",
+          owner: "web-platform",
+          expires: "2026-12-01",
+        }],
+      },
+      { id: "game", source: "game.html", gates: ["check design"], suppressions: [{
+        gate: "check design",
+        flag: "--min-reuse 2",
+        reason: "zones intentionally differ",
+        expires: "2026-07-01",
+      }] },
+    ],
+  }));
+
+  it("expands defaults plus extras, in order", () => {
+    const plan = resolveGatePlan(config, { now: NOW });
+    assert.deepEqual(plan.jobs.filter((j) => j.pageId === "checkout").map((j) => j.baseGate), [
+      "check integrity",
+      "check design",
+      "check copy --manifest copy.txt",
+    ]);
+  });
+
+  it("appends an active suppression's flag to the matching gate only", () => {
+    const plan = resolveGatePlan(config, { now: NOW });
+    const copy = plan.jobs.find((j) => j.baseGate.startsWith("check copy"))!;
+    assert.equal(copy.gate, "check copy --manifest copy.txt --allow-invisible visually-hidden");
+    assert.equal(copy.appliedSuppressions.length, 1);
+    const integrity = plan.jobs.find((j) => j.baseGate === "check integrity")!;
+    assert.equal(integrity.gate, "check integrity");
+    assert.deepEqual(integrity.appliedSuppressions, []);
+  });
+
+  it("does NOT apply an expired suppression — the gate goes back to failing", () => {
+    // An expiry that keeps working after it passes is a comment, not a deadline.
+    const plan = resolveGatePlan(config, { now: NOW });
+    const game = plan.jobs.find((j) => j.pageId === "game")!;
+    assert.equal(game.gate, "check design");
+    assert.deepEqual(game.appliedSuppressions, []);
+    assert.equal(plan.expired.length, 1);
+    assert.equal(plan.expired[0]!.scope, "game");
+  });
+
+  it("applies the same suppression once it is renewed", () => {
+    const plan = resolveGatePlan(config, { now: new Date("2026-06-01T00:00:00Z") });
+    assert.equal(plan.jobs.find((j) => j.pageId === "game")!.gate, "check design --min-reuse 2");
+    assert.deepEqual(plan.expired, []);
+  });
+
+  it("applies default-scope suppressions to every page", () => {
+    const shared = parseGateConfig(json({
+      defaults: {
+        gates: ["check copy --manifest c.txt"],
+        suppressions: [{ gate: "check copy", flag: "--allow-invisible visually-hidden", reason: "sr-only nav" }],
+      },
+      pages: [{ id: "a", source: "a.html" }, { id: "b", source: "b.html" }],
+    }));
+    const plan = resolveGatePlan(shared, { now: NOW });
+    assert.equal(plan.jobs.length, 2);
+    assert.ok(plan.jobs.every((j) => j.gate.endsWith("--allow-invisible visually-hidden")));
+    assert.equal(plan.suppressions.length, 1);
+    assert.equal(plan.suppressions[0]!.scope, "defaults");
+  });
+
+  it("filters pages with --only by id or source substring", () => {
+    assert.deepEqual(
+      [...new Set(resolveGatePlan(config, { now: NOW, only: ["game"] }).jobs.map((j) => j.pageId))],
+      ["game"],
+    );
+    assert.deepEqual(
+      [...new Set(resolveGatePlan(config, { now: NOW, only: ["checkout.html"] }).jobs.map((j) => j.pageId))],
+      ["checkout"],
+    );
+    assert.deepEqual(resolveGatePlan(config, { now: NOW, only: ["nope"] }).jobs, []);
+  });
+
+  it("inventories suppressions from filtered-out pages too", () => {
+    // The inventory is of the config, not of this run: narrowing to one page
+    // must not hide what is silenced elsewhere.
+    const plan = resolveGatePlan(config, { now: NOW, only: ["checkout"] });
+    assert.equal(plan.suppressions.length, 2);
+    assert.equal(plan.expired.length, 1);
+  });
+});
+
+describe("summarizeSuppressions", () => {
+  const rows = [
+    { gate: "a", flag: "-1", reason: "r", expires: "2026-07-01" },
+    { gate: "b", flag: "-2", reason: "r", expires: "2026-08-10", owner: "team" },
+    { gate: "c", flag: "-3", reason: "r", expires: "2027-01-01", owner: "team" },
+    { gate: "d", flag: "-4", reason: "r" },
+  ].map((s) => resolveSuppression(s, "p", NOW));
+
+  it("counts each status, plus unowned and expiring-soon", () => {
+    const summary = summarizeSuppressions(rows, 30);
+    assert.equal(summary.expired, 1);
+    assert.equal(summary.active, 2);
+    assert.equal(summary.permanent, 1);
+    assert.equal(summary.expiringSoon, 1); // 2026-08-10 is 8 days out
+    assert.equal(summary.unowned, 1); // the permanent one; the expired is excluded
+  });
+
+  it("sorts expired first, then soonest expiry", () => {
+    assert.deepEqual(summarizeSuppressions(rows).rows.map((r) => r.gate), ["a", "b", "c", "d"]);
+  });
+});

--- a/packages/vlmkit-core/src/gate-config.ts
+++ b/packages/vlmkit-core/src/gate-config.ts
@@ -120,6 +120,10 @@ function parseSuppression(raw: unknown, path: string): GateSuppression {
 
 function parseGateList(raw: unknown, path: string): string[] {
   if (!Array.isArray(raw)) fail(path, "must be an array of gate command strings");
+  // An empty list is almost certainly a half-finished edit, and it is the worst
+  // possible outcome: `defaults: {gates: []}` used to validate and then run
+  // nothing for every page that relied on the defaults.
+  if (raw.length === 0) fail(path, "is empty — remove the key or list at least one gate");
   return raw.map((g, i) => {
     if (typeof g !== "string" || !g.trim()) fail(`${path}[${i}]`, "must be a non-empty string");
     return (g as string).trim();
@@ -214,6 +218,12 @@ export function resolveGatePlan(config: GateConfig, options: ResolveOptions = {}
     suppressions.push(...pageSuppressions);
     if (only.length > 0 && !only.some((o) => pageId.includes(o) || page.source.includes(o))) continue;
     const gates = [...(page.gates ?? defaultGates), ...(page.extraGates ?? [])];
+    if (gates.length === 0) {
+      throw new Error(
+        `Page "${pageId}" resolved to zero gates — set its \`gates\` or \`defaults.gates\`.`
+        + ` A page that silently runs nothing is worse than a config error.`,
+      );
+    }
     const candidates = [...defaultSuppressions, ...pageSuppressions];
     for (const baseGate of gates) {
       const applied = candidates.filter((s) => s.status !== "expired" && gateMatches(baseGate, s.gate));

--- a/packages/vlmkit-core/src/gate-config.ts
+++ b/packages/vlmkit-core/src/gate-config.ts
@@ -1,0 +1,270 @@
+/**
+ * `vlmkit.gates.json` — one reviewed file that says which gates run on which
+ * pages, and holds every suppression with a reason attached.
+ *
+ * Why this exists: the documented convention was npm scripts, one line per
+ * page. Three separate reviewers landed on the same complaint — the scripts
+ * stop scaling around twenty pages, and once a `--allow-invisible` or an
+ * integrity exemption is inlined in a script, the only way to audit what has
+ * been silenced repo-wide is `grep`. A suppression nobody can enumerate is a
+ * suppression nobody revisits.
+ *
+ * Two decisions make the file worth reviewing rather than just worth having:
+ *
+ *   1. **A suppression must carry a reason.** Parsing fails without one. The
+ *      flag alone records what was silenced but not why, which is exactly the
+ *      state that makes a reviewer approve it again a year later.
+ *   2. **An expired suppression is dropped, not applied.** It is reported
+ *      loudly and the gate goes back to failing. An expiry date that keeps
+ *      working after it passes is a comment, not a deadline.
+ */
+
+export interface GateSuppression {
+  /**
+   * Gate this applies to, as a prefix of the gate command: `check copy`
+   * matches `check copy --manifest x.txt`.
+   */
+  gate: string;
+  /** Flag(s) appended to that gate's invocation, e.g. `--allow-invisible visually-hidden`. */
+  flag: string;
+  /** Why this is acceptable. Required — an unexplained suppression is unauditable. */
+  reason: string;
+  /** Who signed off. Optional but reported, so an unowned entry is visible. */
+  owner?: string;
+  /** `YYYY-MM-DD`. Omitted means permanent, which the inventory counts separately. */
+  expires?: string;
+}
+
+export interface GatePage {
+  /** Short stable name for `--only` and reports. Defaults to the source. */
+  id?: string;
+  /** File path, glob, or URL handed to each gate. */
+  source: string;
+  /** Gate commands for this page. Falls back to `defaults.gates`. */
+  gates?: string[];
+  /** Extra gates for this page on top of the defaults. */
+  extraGates?: string[];
+  suppressions?: GateSuppression[];
+}
+
+export interface GateConfig {
+  defaults?: {
+    gates?: string[];
+    suppressions?: GateSuppression[];
+  };
+  pages: GatePage[];
+}
+
+export interface ResolvedSuppression extends GateSuppression {
+  /** Page id this came from, or `defaults`. */
+  scope: string;
+  status: "active" | "expired" | "permanent";
+  /** Days until expiry; negative when overdue, null when permanent. */
+  daysLeft: number | null;
+}
+
+export interface GateJob {
+  pageId: string;
+  source: string;
+  /** Gate command with any active suppression flags already appended. */
+  gate: string;
+  /** The gate as written in the config, before suppression flags. */
+  baseGate: string;
+  appliedSuppressions: ResolvedSuppression[];
+}
+
+export interface GatePlan {
+  jobs: GateJob[];
+  /** Every suppression the config declares, resolved against `now`. */
+  suppressions: ResolvedSuppression[];
+  /**
+   * Suppressions past their expiry. Their flags are NOT applied — the gate
+   * fails again — and callers are expected to print these before running.
+   */
+  expired: ResolvedSuppression[];
+}
+
+const DAY_MS = 86400000;
+
+export const GATE_CONFIG_FILENAMES = ["vlmkit.gates.json", ".vlmkit/gates.json"];
+
+function fail(path: string, message: string): never {
+  throw new Error(`${path}: ${message}`);
+}
+
+function parseSuppression(raw: unknown, path: string): GateSuppression {
+  if (typeof raw !== "object" || raw === null) fail(path, "must be an object");
+  const s = raw as Record<string, unknown>;
+  for (const key of ["gate", "flag", "reason"] as const) {
+    if (typeof s[key] !== "string" || !(s[key] as string).trim()) {
+      fail(path, `${key} is required and must be a non-empty string`);
+    }
+  }
+  if (s.owner !== undefined && typeof s.owner !== "string") fail(path, "owner must be a string");
+  if (s.expires !== undefined) {
+    if (typeof s.expires !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(s.expires)) {
+      fail(path, `expires must be YYYY-MM-DD, got ${JSON.stringify(s.expires)}`);
+    }
+    if (Number.isNaN(Date.parse(`${s.expires}T00:00:00Z`))) {
+      fail(path, `expires is not a real date: ${s.expires}`);
+    }
+  }
+  return {
+    gate: (s.gate as string).trim(),
+    flag: (s.flag as string).trim(),
+    reason: (s.reason as string).trim(),
+    ...(s.owner ? { owner: s.owner as string } : {}),
+    ...(s.expires ? { expires: s.expires as string } : {}),
+  };
+}
+
+function parseGateList(raw: unknown, path: string): string[] {
+  if (!Array.isArray(raw)) fail(path, "must be an array of gate command strings");
+  return raw.map((g, i) => {
+    if (typeof g !== "string" || !g.trim()) fail(`${path}[${i}]`, "must be a non-empty string");
+    return (g as string).trim();
+  });
+}
+
+/** Parse and validate. Every error names the JSON path so the fix is obvious. */
+export function parseGateConfig(raw: string): GateConfig {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`gate config is not valid JSON: ${e instanceof Error ? e.message : e}`);
+  }
+  if (typeof data !== "object" || data === null) fail("config", "must be a JSON object");
+  const root = data as Record<string, unknown>;
+  const defaults: GateConfig["defaults"] = {};
+  if (root.defaults !== undefined) {
+    if (typeof root.defaults !== "object" || root.defaults === null) fail("defaults", "must be an object");
+    const d = root.defaults as Record<string, unknown>;
+    if (d.gates !== undefined) defaults.gates = parseGateList(d.gates, "defaults.gates");
+    if (d.suppressions !== undefined) {
+      if (!Array.isArray(d.suppressions)) fail("defaults.suppressions", "must be an array");
+      defaults.suppressions = d.suppressions.map((s, i) => parseSuppression(s, `defaults.suppressions[${i}]`));
+    }
+  }
+  if (!Array.isArray(root.pages)) fail("pages", "must be an array");
+  if (root.pages.length === 0) fail("pages", "is empty — nothing would run");
+  const seen = new Set<string>();
+  const pages = root.pages.map((raw, i) => {
+    const at = `pages[${i}]`;
+    if (typeof raw !== "object" || raw === null) fail(at, "must be an object");
+    const p = raw as Record<string, unknown>;
+    if (typeof p.source !== "string" || !p.source.trim()) fail(at, "source is required (path, glob, or URL)");
+    const id = typeof p.id === "string" && p.id.trim() ? p.id.trim() : p.source.trim();
+    if (seen.has(id)) fail(at, `duplicate page id "${id}" — ids must be unique so --only is unambiguous`);
+    seen.add(id);
+    const page: GatePage = { id, source: p.source.trim() };
+    if (p.gates !== undefined) page.gates = parseGateList(p.gates, `${at}.gates`);
+    if (p.extraGates !== undefined) page.extraGates = parseGateList(p.extraGates, `${at}.extraGates`);
+    if (p.suppressions !== undefined) {
+      if (!Array.isArray(p.suppressions)) fail(`${at}.suppressions`, "must be an array");
+      page.suppressions = p.suppressions.map((s, j) => parseSuppression(s, `${at}.suppressions[${j}]`));
+    }
+    if (!page.gates && !page.extraGates && !defaults.gates) {
+      fail(at, `no gates: set ${at}.gates or defaults.gates`);
+    }
+    return page;
+  });
+  return { ...(Object.keys(defaults).length > 0 ? { defaults } : {}), pages };
+}
+
+/** UTC midnight, so "expires today" behaves the same in every timezone. */
+function utcDay(date: Date): number {
+  return Math.floor(date.getTime() / DAY_MS);
+}
+
+export function resolveSuppression(s: GateSuppression, scope: string, now: Date): ResolvedSuppression {
+  if (!s.expires) return { ...s, scope, status: "permanent", daysLeft: null };
+  const daysLeft = utcDay(new Date(`${s.expires}T00:00:00Z`)) - utcDay(now);
+  // Expiry day itself is still valid; the day after is not.
+  return { ...s, scope, status: daysLeft < 0 ? "expired" : "active", daysLeft };
+}
+
+export interface ResolveOptions {
+  now?: Date;
+  /** Page ids or sources to keep. Substring match, so `admin` selects a subtree. */
+  only?: string[];
+}
+
+/**
+ * Turn the config into the exact list of gate invocations to run.
+ *
+ * Suppression flags are appended to matching gates only when active. An
+ * expired one is surfaced in `plan.expired` and deliberately left off the
+ * command line: the gate returns to failing, which is what an expiry date is
+ * supposed to mean.
+ */
+export function resolveGatePlan(config: GateConfig, options: ResolveOptions = {}): GatePlan {
+  const now = options.now ?? new Date();
+  const only = options.only?.filter((s) => s.trim()) ?? [];
+  const defaultGates = config.defaults?.gates ?? [];
+  const defaultSuppressions = (config.defaults?.suppressions ?? [])
+    .map((s) => resolveSuppression(s, "defaults", now));
+
+  const jobs: GateJob[] = [];
+  const suppressions: ResolvedSuppression[] = [...defaultSuppressions];
+
+  for (const page of config.pages) {
+    const pageId = page.id ?? page.source;
+    const pageSuppressions = (page.suppressions ?? []).map((s) => resolveSuppression(s, pageId, now));
+    suppressions.push(...pageSuppressions);
+    if (only.length > 0 && !only.some((o) => pageId.includes(o) || page.source.includes(o))) continue;
+    const gates = [...(page.gates ?? defaultGates), ...(page.extraGates ?? [])];
+    const candidates = [...defaultSuppressions, ...pageSuppressions];
+    for (const baseGate of gates) {
+      const applied = candidates.filter((s) => s.status !== "expired" && gateMatches(baseGate, s.gate));
+      jobs.push({
+        pageId,
+        source: page.source,
+        baseGate,
+        gate: [baseGate, ...applied.map((s) => s.flag)].join(" "),
+        appliedSuppressions: applied,
+      });
+    }
+  }
+  return { jobs, suppressions, expired: suppressions.filter((s) => s.status === "expired") };
+}
+
+/**
+ * Token-wise prefix match: `check copy` matches `check copy --manifest x.txt`
+ * but not `check copyright`, and `check` matches every check gate.
+ */
+export function gateMatches(gate: string, pattern: string): boolean {
+  const g = gate.split(/\s+/).filter(Boolean);
+  const p = pattern.split(/\s+/).filter(Boolean);
+  if (p.length > g.length) return false;
+  return p.every((token, i) => token === g[i]);
+}
+
+export interface SuppressionSummary {
+  rows: ResolvedSuppression[];
+  active: number;
+  expired: number;
+  permanent: number;
+  /** Active entries with no owner — visible rather than tolerated silently. */
+  unowned: number;
+  /** Active entries expiring within `soonDays`. */
+  expiringSoon: number;
+}
+
+export function summarizeSuppressions(
+  suppressions: ResolvedSuppression[],
+  soonDays = 30,
+): SuppressionSummary {
+  const rows = [...suppressions].sort((a, b) => {
+    const rank = (s: ResolvedSuppression) => (s.status === "expired" ? 0 : s.status === "active" ? 1 : 2);
+    return rank(a) - rank(b) || (a.daysLeft ?? Infinity) - (b.daysLeft ?? Infinity);
+  });
+  return {
+    rows,
+    active: rows.filter((s) => s.status === "active").length,
+    expired: rows.filter((s) => s.status === "expired").length,
+    permanent: rows.filter((s) => s.status === "permanent").length,
+    unowned: rows.filter((s) => s.status !== "expired" && !s.owner).length,
+    expiringSoon: rows.filter((s) => s.status === "active" && (s.daysLeft ?? Infinity) <= soonDays).length,
+  };
+}

--- a/packages/vlmkit-core/src/gate-exit.test.ts
+++ b/packages/vlmkit-core/src/gate-exit.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { gateExitCode, parseGateExitFlags } from "./gate-exit.ts";
+
+test("a suspect fails by default — the contract the audit demanded", () => {
+  assert.equal(gateExitCode(true, { advisory: false }), 1);
+  assert.equal(gateExitCode(false, { advisory: false }), 0);
+});
+
+test("--advisory opts back into print-and-succeed for pilots", () => {
+  assert.equal(gateExitCode(true, { advisory: true }), 0);
+  assert.equal(gateExitCode(false, { advisory: true }), 0);
+});
+
+test("--fail-on-suspect stays accepted as a no-op so existing scripts keep working", () => {
+  const flags = parseGateExitFlags(["page.html", "--fail-on-suspect"]);
+  assert.equal(flags.advisory, false);
+  assert.equal(gateExitCode(true, flags), 1); // same as without the flag
+});
+
+test("flag parsing", () => {
+  assert.deepEqual(parseGateExitFlags(["a.html"]), { advisory: false });
+  assert.deepEqual(parseGateExitFlags(["a.html", "--advisory"]), { advisory: true });
+});

--- a/packages/vlmkit-core/src/gate-exit.ts
+++ b/packages/vlmkit-core/src/gate-exit.ts
@@ -1,0 +1,56 @@
+/**
+ * One exit-code contract for every gate.
+ *
+ * Measured during the 2026-08-01 round-10 audit, the behaviour was
+ * incoherent: verdict gates (integrity DEFECTS, layout VIOLATED, flow
+ * FAILED, markup NOT DONE) exited non-zero on their own, `check
+ * interactions` and `scan handlers` also exited non-zero on a suspect, but
+ * `check copy`, `check asset` and `scan scroll` exited ZERO unless you
+ * remembered `--fail-on-suspect`. Two commands in the same `scan` group
+ * disagreed. Worse, the safe-looking default was the dangerous one: a
+ * pre-push or CI command that printed a defect and exited 0.
+ *
+ * The contract is now: **a suspect fails the command.** A verification tool
+ * whose default is "found a defect, exiting 0" is a footgun; the burden
+ * belongs on the person who wants to ignore findings, not on the person who
+ * wants them enforced.
+ *
+ * `--advisory` opts back into print-and-succeed for gates being piloted
+ * before they gate CI — which is the rollout order the docs recommend.
+ * `--fail-on-suspect` is kept as an accepted no-op so existing scripts and
+ * the published documentation keep working.
+ *
+ * Warns never affect the exit code, under any flag.
+ */
+
+export interface GateExitFlags {
+  /** Print findings and exit 0 even when suspects exist. */
+  advisory: boolean;
+}
+
+/** Parse the shared exit-code flags out of an argv array. */
+export function parseGateExitFlags(argv: readonly string[]): GateExitFlags {
+  return { advisory: argv.includes("--advisory") };
+}
+
+/**
+ * Decide the process exit code. `hasSuspect` should count only
+ * defect-severity findings; warn-level findings must not reach it.
+ */
+export function gateExitCode(hasSuspect: boolean, flags: GateExitFlags): 0 | 1 {
+  if (!hasSuspect) return 0;
+  return flags.advisory ? 0 : 1;
+}
+
+/** Shared help text so every gate documents the contract identically. */
+export const GATE_EXIT_HELP =
+  "  --advisory              Print findings but exit 0 (default: a suspect exits 1)";
+
+/**
+ * Apply the contract. Sets `process.exitCode` rather than calling
+ * `process.exit` so buffered stdout is not truncated.
+ */
+export function applyGateExit(hasSuspect: boolean, flags: GateExitFlags): void {
+  const code = gateExitCode(hasSuspect, flags);
+  if (code !== 0) process.exitCode = code;
+}

--- a/packages/vlmkit-core/src/legacy-names.test.ts
+++ b/packages/vlmkit-core/src/legacy-names.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The `vrt` → `vlmkit` rename of state paths, config filenames and env vars is
+ * only safe if the old names keep working. These tests are the proof, because
+ * the failure mode is silent: a project whose baselines live in `.vrt/baselines`
+ * would report every route as a new baseline, which reads as "nothing to
+ * approve" rather than as an error.
+ */
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CONFIG_CANDIDATES,
+  CONFIG_FILE,
+  ENV_SUFFIXES,
+  LEGACY_CONFIG_FILE,
+  LEGACY_STATE_DIR,
+  STATE_DIR,
+  readEnv,
+  resetLegacyNotices,
+  resolveStatePath,
+} from "./legacy-names.ts";
+
+const fresh = (): string => mkdtempSync(join(tmpdir(), "legacy-names-"));
+afterEach(() => resetLegacyNotices());
+
+describe("state paths prefer the new directory but never abandon the old one", () => {
+  it("resolves to .vlmkit/<entry> in a project with neither", () => {
+    const dir = fresh();
+    assert.equal(resolveStatePath(dir, "baselines"), join(dir, STATE_DIR, "baselines"));
+  });
+
+  it("resolves to .vrt/<entry> when that is where the history is", () => {
+    // The case that would have lost every approved baseline.
+    const dir = fresh();
+    mkdirSync(join(dir, LEGACY_STATE_DIR, "baselines"), { recursive: true });
+    assert.equal(resolveStatePath(dir, "baselines"), join(dir, LEGACY_STATE_DIR, "baselines"));
+  });
+
+  it("prefers .vlmkit/<entry> when both exist", () => {
+    const dir = fresh();
+    mkdirSync(join(dir, LEGACY_STATE_DIR, "baselines"), { recursive: true });
+    mkdirSync(join(dir, STATE_DIR, "baselines"), { recursive: true });
+    assert.equal(resolveStatePath(dir, "baselines"), join(dir, STATE_DIR, "baselines"));
+  });
+
+  it("decides per entry, not per directory", () => {
+    // `.vlmkit/` already exists in any project that ran a gate (run ledger,
+    // gates, markup-loop), so a per-directory check would resolve to the new
+    // location immediately and skip the legacy baselines sitting next to it.
+    const dir = fresh();
+    mkdirSync(join(dir, STATE_DIR, "gates"), { recursive: true });
+    mkdirSync(join(dir, LEGACY_STATE_DIR, "baselines"), { recursive: true });
+    assert.equal(resolveStatePath(dir, "baselines"), join(dir, LEGACY_STATE_DIR, "baselines"));
+    assert.equal(resolveStatePath(dir, "gates"), join(dir, STATE_DIR, "gates"));
+  });
+});
+
+describe("config filename search order", () => {
+  it("lists new names before legacy ones, JSON before TOML", () => {
+    assert.deepEqual(CONFIG_CANDIDATES.map((c) => c.name), [
+      CONFIG_FILE, "vlmkit.config.toml", LEGACY_CONFIG_FILE, "vrt.config.toml",
+    ]);
+    assert.deepEqual(CONFIG_CANDIDATES.map((c) => c.legacy), [false, false, true, true]);
+  });
+
+  it("every candidate is a real filename a project could have on disk", () => {
+    const dir = fresh();
+    for (const { name } of CONFIG_CANDIDATES) {
+      writeFileSync(join(dir, name), "{}");
+    }
+    // Nothing to assert beyond "these are writable filenames" — the point is
+    // that the list is filenames, not patterns, so the caller can name them all
+    // in a not-found error.
+    assert.equal(CONFIG_CANDIDATES.length, 4);
+  });
+});
+
+describe("env vars read the new name and fall back to the old", () => {
+  const clear = (suffix: string) => {
+    delete process.env[`VLMKIT_${suffix}`];
+    delete process.env[`VRT_${suffix}`];
+  };
+
+  it("returns undefined when neither is set", () => {
+    clear("LLM_MODEL");
+    assert.equal(readEnv("LLM_MODEL"), undefined);
+  });
+
+  it("reads VLMKIT_* first", () => {
+    clear("LLM_MODEL");
+    process.env.VLMKIT_LLM_MODEL = "new";
+    process.env.VRT_LLM_MODEL = "old";
+    assert.equal(readEnv("LLM_MODEL"), "new");
+    clear("LLM_MODEL");
+  });
+
+  it("falls back to VRT_* so an existing CI keeps working", () => {
+    clear("VLM_MODEL");
+    process.env.VRT_VLM_MODEL = "bytedance/ui-tars-1.5-7b";
+    assert.equal(readEnv("VLM_MODEL"), "bytedance/ui-tars-1.5-7b");
+    clear("VLM_MODEL");
+  });
+
+  it("treats an empty string as unset, matching the previous `||` reads", () => {
+    clear("BASE_URL");
+    process.env.VLMKIT_BASE_URL = "";
+    process.env.VRT_BASE_URL = "http://localhost:3000";
+    assert.equal(readEnv("BASE_URL"), "http://localhost:3000");
+    clear("BASE_URL");
+  });
+
+  it("every suffix in ENV_SUFFIXES resolves through the same path", () => {
+    // Guards against a suffix being listed in docs but never routed.
+    for (const suffix of ENV_SUFFIXES) {
+      clear(suffix);
+      process.env[`VRT_${suffix}`] = `legacy-${suffix}`;
+      assert.equal(readEnv(suffix), `legacy-${suffix}`, suffix);
+      clear(suffix);
+    }
+  });
+});
+
+describe("the legacy notice is printed once, not per call", () => {
+  it("announces a given old name a single time", () => {
+    const dir = fresh();
+    mkdirSync(join(dir, LEGACY_STATE_DIR, "runs"), { recursive: true });
+    const lines: string[] = [];
+    const write = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string) => { lines.push(String(chunk)); return true; }) as typeof process.stderr.write;
+    try {
+      resolveStatePath(dir, "runs");
+      resolveStatePath(dir, "runs");
+      resolveStatePath(dir, "runs");
+    } finally {
+      process.stderr.write = write;
+    }
+    const notices = lines.filter((l) => l.includes("[vlmkit legacy]"));
+    assert.equal(notices.length, 1, notices.join(""));
+    assert.match(notices[0]!, /\.vrt\/runs.*\.vlmkit\/runs.*1\.0\.0/);
+  });
+});

--- a/packages/vlmkit-core/src/legacy-names.ts
+++ b/packages/vlmkit-core/src/legacy-names.ts
@@ -1,0 +1,130 @@
+/**
+ * Backward compatibility for the `vrt` → `vlmkit` rename of things that are not
+ * text: the state directory, the config filename, and the environment
+ * variables.
+ *
+ * The command-name rename was pure text — nothing on disk moved. These three
+ * are different: rename them without a fallback and every existing project
+ * silently loses its approved baselines, stops finding its config, and drops
+ * whatever its CI exports. So each new name is preferred, each old name still
+ * works, and using an old one prints one line saying so.
+ *
+ * ## Why per-subpath and not per-directory
+ *
+ * `.vlmkit/` already exists in any project that has run a gate — the run
+ * ledger, `gates`, `markup-loop` and `copy-review` all live there, while
+ * `baselines`, `runs` and `last-diff-for-agent.json` were still under `.vrt/`.
+ * So "if `.vlmkit/` is missing, use `.vrt/`" would resolve to the new directory
+ * immediately and lose the baselines anyway. The check has to be on the
+ * specific entry: `.vlmkit/baselines` vs `.vrt/baselines`.
+ *
+ * ## What is deliberately NOT here
+ *
+ * Values that leave this process or land in someone else's file — the
+ * `X-Title` header sent to OpenRouter, the Playwright `projectName` that
+ * appears inside snapshot paths, the plan schema's `vrt?:` field, the published
+ * OpenAPI title. Those are wire and data formats, not local state, and moving
+ * them is a separate decision.
+ */
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export const STATE_DIR = ".vlmkit";
+export const LEGACY_STATE_DIR = ".vrt";
+export const CONFIG_FILE = "vlmkit.config.json";
+export const LEGACY_CONFIG_FILE = "vrt.config.json";
+
+/** One notice per distinct old name per process — a loop must not spam. */
+const announced = new Set<string>();
+
+export function noteLegacyName(oldName: string, newName: string, detail = ""): void {
+  if (announced.has(oldName)) return;
+  announced.add(oldName);
+  const color = !process.env.NO_COLOR && process.stderr.isTTY;
+  const tag = color ? "\x1b[33m[vlmkit legacy]\x1b[0m" : "[vlmkit legacy]";
+  process.stderr.write(`${tag} using ${oldName} — rename to ${newName}; support ends in 1.0.0${detail ? `. ${detail}` : ""}\n`);
+}
+
+/** Reset between tests. */
+export function resetLegacyNotices(): void {
+  announced.clear();
+}
+
+/**
+ * Absolute path for a state entry, preferring `.vlmkit/<entry>` and falling back
+ * to an existing `.vrt/<entry>`.
+ *
+ * Writers get the new path unless the old one is already populated, so a
+ * project keeps appending where its history is instead of starting a second,
+ * half-empty baseline set beside it.
+ */
+export function resolveStatePath(cwd: string, entry: string): string {
+  const next = resolve(cwd, join(STATE_DIR, entry));
+  if (existsSync(next)) return next;
+  const legacy = resolve(cwd, join(LEGACY_STATE_DIR, entry));
+  if (existsSync(legacy)) {
+    noteLegacyName(`${LEGACY_STATE_DIR}/${entry}`, `${STATE_DIR}/${entry}`, "move it to keep using one location");
+    return legacy;
+  }
+  return next;
+}
+
+/**
+ * Config filenames in search order: new before old, JSON before TOML (JSON wins
+ * when both exist, which was the pre-rename behaviour). `legacy: true` entries
+ * are what `findConfigPath` reports a notice for.
+ *
+ * Exported as data rather than a resolver because the caller also has to name
+ * every candidate in its "not found" error — listing only the new one would
+ * tell a project with a working `vrt.config.json` that it has no config.
+ */
+export const CONFIG_CANDIDATES: readonly { name: string; legacy: boolean }[] = [
+  { name: CONFIG_FILE, legacy: false },
+  { name: "vlmkit.config.toml", legacy: false },
+  { name: LEGACY_CONFIG_FILE, legacy: true },
+  { name: "vrt.config.toml", legacy: true },
+];
+
+/**
+ * `VLMKIT_FOO`, falling back to `VRT_FOO`.
+ *
+ * Pass the suffix, not the whole name, so a call site cannot mismatch the two
+ * halves — `readEnv("LLM_MODEL")` reads `VLMKIT_LLM_MODEL` then `VRT_LLM_MODEL`.
+ * An empty string counts as unset, matching how the previous `process.env.X ||`
+ * reads behaved.
+ */
+export function readEnv(suffix: string): string | undefined {
+  const next = process.env[`VLMKIT_${suffix}`];
+  if (next) return next;
+  const legacy = process.env[`VRT_${suffix}`];
+  if (legacy) {
+    noteLegacyName(`VRT_${suffix}`, `VLMKIT_${suffix}`);
+    return legacy;
+  }
+  return undefined;
+}
+
+/**
+ * `DEBUG_VLMKIT`, falling back to `DEBUG_VRT`. Separate from `readEnv` because
+ * this one is a prefix, not a suffix — `DEBUG_VRT`, not `VRT_DEBUG`.
+ */
+export function debugEnabled(): boolean {
+  if (process.env.DEBUG_VLMKIT) return true;
+  if (process.env.DEBUG_VRT) {
+    noteLegacyName("DEBUG_VRT", "DEBUG_VLMKIT");
+    return true;
+  }
+  return false;
+}
+
+/** Every env suffix that has both spellings, so the docs and tests can enumerate. */
+export const ENV_SUFFIXES = [
+  "BASE_URL",
+  "CAPTURE_BACKEND",
+  "CONFIG_FILE",
+  "CONFIG_PATH",
+  "LLM_MODEL",
+  "LLM_PROVIDER",
+  "PROJECT_ROOT",
+  "VLM_MODEL",
+] as const;

--- a/packages/vlmkit-core/src/navigation-redirect.test.ts
+++ b/packages/vlmkit-core/src/navigation-redirect.test.ts
@@ -8,7 +8,11 @@ test("auth-wall redirect is called out as a login wall", () => {
   assert.match(msg!, /requested \/dashboard/);
   assert.match(msg!, /measured http:\/\/127\.0\.0\.1:8901\/login/);
   assert.match(msg!, /login wall/i);
-  assert.match(msg!, /cannot inject a session/i);
+  // Points at the fix the tool actually offers. This assertion previously
+  // pinned "cannot inject a session", which stopped being true when
+  // --storage-state landed — the test was holding the stale claim in place.
+  assert.match(msg!, /--storage-state/);
+  assert.doesNotMatch(msg!, /cannot inject a session/i);
 });
 
 test("non-auth cross-path redirect warns without the auth hint", () => {

--- a/packages/vlmkit-core/src/navigation-redirect.test.ts
+++ b/packages/vlmkit-core/src/navigation-redirect.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { describeRedirect } from "./navigation-redirect.ts";
+
+test("auth-wall redirect is called out as a login wall", () => {
+  const msg = describeRedirect("http://127.0.0.1:8901/dashboard", "http://127.0.0.1:8901/login");
+  assert.ok(msg, "expected a warning");
+  assert.match(msg!, /requested \/dashboard/);
+  assert.match(msg!, /measured http:\/\/127\.0\.0\.1:8901\/login/);
+  assert.match(msg!, /login wall/i);
+  assert.match(msg!, /cannot inject a session/i);
+});
+
+test("non-auth cross-path redirect warns without the auth hint", () => {
+  const msg = describeRedirect("https://example.com/old-pricing", "https://example.com/pricing");
+  assert.ok(msg);
+  assert.match(msg!, /measured the destination/);
+  assert.doesNotMatch(msg!, /login wall/i);
+});
+
+test("cosmetic redirects stay quiet", () => {
+  // trailing slash, scheme upgrade, www canonicalization — same page
+  assert.equal(describeRedirect("http://example.com/pricing", "https://example.com/pricing"), null);
+  assert.equal(describeRedirect("https://example.com/pricing", "https://example.com/pricing/"), null);
+  assert.equal(describeRedirect("https://example.com/pricing/", "https://example.com/pricing"), null);
+  assert.equal(describeRedirect("https://www.example.com/a", "https://example.com/a"), null);
+  assert.equal(describeRedirect("https://example.com/a", "https://example.com/a"), null);
+});
+
+test("different host is reported even when the path matches", () => {
+  const msg = describeRedirect("https://staging.example.com/app", "https://example.com/app");
+  assert.ok(msg);
+  assert.match(msg!, /measured https:\/\/example\.com\/app/);
+});
+
+test("file:// and malformed inputs produce no warning", () => {
+  assert.equal(describeRedirect("file:///tmp/a.html", "file:///tmp/a.html"), null);
+  assert.equal(describeRedirect("page.html", "file:///tmp/page.html"), null);
+  assert.equal(describeRedirect("", "https://example.com/"), null);
+});

--- a/packages/vlmkit-core/src/navigation-redirect.ts
+++ b/packages/vlmkit-core/src/navigation-redirect.ts
@@ -46,7 +46,12 @@ export function describeRedirect(requested: string, final: string): string | nul
 
   const looksLikeAuth = /login|signin|sign-in|auth|sso|account\/login/i.test(b.pathname);
   const hint = looksLikeAuth
-    ? " This looks like a login wall: the gate measured the sign-in page, NOT the page you asked about. vlmkit cannot inject a session — point it at a route that does not need auth, or render the page to a local file."
+    // The hint used to end "vlmkit cannot inject a session", which stopped being
+    // true the day `--storage-state` landed. A hint that denies a feature the
+    // tool has sends the reader to the wrong fix.
+    ? " This looks like a login wall: the gate measured the sign-in page, NOT the page you asked about."
+      + " Pass a logged-in Playwright storage state (--storage-state <file>, or VLMKIT_STORAGE_STATE),"
+      + " or point the gate at a route that does not need auth."
     : " The gate measured the destination, not the URL you passed.";
   return `redirected: requested ${a.pathname}${a.search} but measured ${b.href}.${hint}`;
 }

--- a/packages/vlmkit-core/src/navigation-redirect.ts
+++ b/packages/vlmkit-core/src/navigation-redirect.ts
@@ -1,0 +1,52 @@
+/**
+ * Redirect disclosure for gates that navigate.
+ *
+ * Discovered by the 2026-08-01 hard-target audit: pointing a gate at an
+ * auth-walled route (`/dashboard` behind a session cookie) silently
+ * followed the 302 to `/login` and measured THAT page. `check integrity`
+ * reported `verdict: CLEAN` — a green gate on a page that never rendered,
+ * which is worse than an error, and `check copy` reported the dashboard's
+ * copy as "missing" when the real problem was that it was never visited.
+ *
+ * A gate must never report on a URL it did not measure. This helper
+ * compares requested vs. final URL and returns a message when they differ
+ * in a way the caller should hear about.
+ *
+ * Deliberately quiet about cosmetic redirects — scheme upgrade, added or
+ * dropped trailing slash, host canonicalization (www.) — because those
+ * still land on the intended page and crying wolf about them would train
+ * users to ignore the warning.
+ */
+
+function normalizePath(pathname: string): string {
+  const p = pathname.replace(/\/+$/, "");
+  return p === "" ? "/" : p;
+}
+
+/**
+ * Returns a human-readable warning when the final URL is a different page
+ * than the one requested, or `null` when the navigation landed where the
+ * caller intended (or when either URL is unparseable / not http(s)).
+ */
+export function describeRedirect(requested: string, final: string): string | null {
+  if (!requested || !final || requested === final) return null;
+  let a: URL, b: URL;
+  try {
+    a = new URL(requested);
+    b = new URL(final);
+  } catch {
+    return null; // file:// paths and malformed inputs: nothing useful to say
+  }
+  if (a.protocol !== "http:" && a.protocol !== "https:") return null;
+
+  const hostA = a.hostname.replace(/^www\./, "");
+  const hostB = b.hostname.replace(/^www\./, "");
+  const samePath = normalizePath(a.pathname) === normalizePath(b.pathname);
+  if (samePath && hostA === hostB) return null; // scheme/slash/www only
+
+  const looksLikeAuth = /login|signin|sign-in|auth|sso|account\/login/i.test(b.pathname);
+  const hint = looksLikeAuth
+    ? " This looks like a login wall: the gate measured the sign-in page, NOT the page you asked about. vlmkit cannot inject a session — point it at a route that does not need auth, or render the page to a local file."
+    : " The gate measured the destination, not the URL you passed.";
+  return `redirected: requested ${a.pathname}${a.search} but measured ${b.href}.${hint}`;
+}

--- a/packages/vlmkit-core/src/page-open.test.ts
+++ b/packages/vlmkit-core/src/page-open.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { after, describe, it } from "node:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { Browser } from "playwright";
+import { isUrlSource, openHtml, openSource, sourceToUrl } from "./page-open.ts";
+
+describe("isUrlSource / sourceToUrl", () => {
+  it("distinguishes URLs from paths", () => {
+    assert.equal(isUrlSource("https://example.com/"), true);
+    assert.equal(isUrlSource("http://localhost:3000"), true);
+    assert.equal(isUrlSource("routes/index.html"), false);
+    assert.equal(isUrlSource("/abs/index.html"), false);
+  });
+
+  it("turns a path into a file URL and leaves a URL alone", () => {
+    assert.equal(sourceToUrl("https://example.com/a"), "https://example.com/a");
+    assert.equal(sourceToUrl("page.html"), pathToFileURL(resolve("page.html")).href);
+  });
+});
+
+describe("openSource / openHtml (real browser)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "page-open-"));
+  writeFileSync(join(dir, "style.css"), "body { background: rgb(1, 2, 3); } p { color: rgb(4, 5, 6); }");
+  writeFileSync(
+    join(dir, "page.html"),
+    '<!doctype html><meta charset="utf-8"><link rel="stylesheet" href="style.css"><body><p>hello</p></body>',
+  );
+  const page = join(dir, "page.html");
+  let browser: Browser | undefined;
+  const getBrowser = async (): Promise<Browser> => {
+    if (!browser) {
+      const { chromium } = await import("playwright");
+      browser = await chromium.launch();
+    }
+    return browser;
+  };
+  after(async () => {
+    await browser?.close();
+  });
+
+  const colorOf = async (p: import("playwright").Page) =>
+    p.evaluate(() => getComputedStyle(document.querySelector("p")!).color);
+
+  it("resolves a relative stylesheet when navigating to the file", async () => {
+    const { page: opened, redirect } = await openSource(await getBrowser(), page, { viewport: { width: 800, height: 600 } });
+    assert.equal(await colorOf(opened), "rgb(4, 5, 6)");
+    assert.equal(redirect, null);
+    await opened.close();
+  });
+
+  it("resolves it for mutated HTML too, given the source it came from", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const html = (await readFile(page, "utf-8")).replace("hello", "HELLO WORLD");
+    const opened = await openHtml(await getBrowser(), html, { baseSource: page });
+    assert.equal(await colorOf(opened), "rgb(4, 5, 6)");
+    assert.match(await opened.textContent("p") ?? "", /HELLO WORLD/);
+    await opened.close();
+  });
+
+  it("demonstrates the defect this exists to fix: no base, no stylesheet", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const html = await readFile(page, "utf-8");
+    const opened = await openHtml(await getBrowser(), html); // baseSource omitted
+    assert.equal(await colorOf(opened), "rgb(0, 0, 0)", "unstyled — this is what the gates were measuring");
+    await opened.close();
+  });
+});

--- a/packages/vlmkit-core/src/page-open.ts
+++ b/packages/vlmkit-core/src/page-open.ts
@@ -30,6 +30,18 @@ import { describeRedirect } from "./navigation-redirect.ts";
 
 export const isUrlSource = (source: string): boolean => /^https?:\/\//.test(source);
 
+/**
+ * Normalize a source for storage and display: an absolute path for a file, the
+ * URL untouched for a URL.
+ *
+ * `resolve()` alone mangles a URL into a path — `resolve("http://x/p.html")`
+ * yields `<cwd>/http:/x/p.html`, which then fails as "file not found" and tells
+ * the caller nothing about what actually went wrong.
+ */
+export function resolveSource(source: string): string {
+  return isUrlSource(source) ? source : resolve(source);
+}
+
 /** File path or URL → a URL Playwright can navigate to. */
 export function sourceToUrl(source: string): string {
   return isUrlSource(source) ? source : pathToFileURL(resolve(source)).href;

--- a/packages/vlmkit-core/src/page-open.ts
+++ b/packages/vlmkit-core/src/page-open.ts
@@ -1,0 +1,151 @@
+/**
+ * One way to open the page under test.
+ *
+ * Two mechanisms had grown up side by side, and they do not measure the same
+ * document:
+ *
+ *   - `page.goto(pathToFileURL(file))` — the document has an origin, so
+ *     `<link rel="stylesheet" href="style.css">`, `<img src="hero.png">` and
+ *     relative scripts all resolve.
+ *   - `page.setContent(await readFile(file))` — the document's base URL is
+ *     `about:blank`, so every relative reference silently fails to load.
+ *
+ * Measured consequence (2026-08-02): a page with `p { color: #bbbbbb }` in an
+ * external stylesheet — 1.92:1 on white, a clear WCAG failure — was reported by
+ * `check a11y contrast` as **0 failures**, because the gate measured unstyled
+ * markup. Inlining the same CSS in a `<style>` block made the same gate report
+ * the failure correctly. Ten gates read a user's file and pushed it through
+ * `setContent` with no base URL.
+ *
+ * So: load by navigation whenever the bytes on disk are what we want, and when
+ * a gate must mutate the HTML first (inflate text for i18n, force a theme,
+ * delete a CSS rule), navigate to the source and *then* replace the markup, so
+ * the document keeps a base URL its siblings resolve against.
+ */
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { Browser, Page, ViewportSize } from "playwright";
+import { withAuthState } from "./auth-state.ts";
+import { describeRedirect } from "./navigation-redirect.ts";
+
+export const isUrlSource = (source: string): boolean => /^https?:\/\//.test(source);
+
+/** File path or URL → a URL Playwright can navigate to. */
+export function sourceToUrl(source: string): string {
+  return isUrlSource(source) ? source : pathToFileURL(resolve(source)).href;
+}
+
+/**
+ * Wait for the page to stop moving: bounded network idle, then webfonts, then
+ * one frame. Every part is best-effort — a page with a long-poll connection
+ * never reaches network idle, and refusing to measure it would be worse than
+ * measuring it slightly early.
+ */
+export async function settlePage(page: Page, settleMs = 250): Promise<void> {
+  await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+  await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => undefined) : undefined))
+    .catch(() => {});
+  if (settleMs > 0) await page.waitForTimeout(settleMs);
+}
+
+export interface OpenPageOptions {
+  viewport?: ViewportSize;
+  deviceScaleFactor?: number;
+  /** `prefers-color-scheme` for the page's context (theme-parity opens both). */
+  colorScheme?: "light" | "dark" | "no-preference";
+  /** Playwright storage state for pages behind a login. */
+  storageState?: string;
+  waitUntil?: "load" | "domcontentloaded" | "networkidle" | "commit";
+  timeout?: number;
+  /** Extra quiet time after load. 0 skips it. */
+  settleMs?: number;
+  /** Skip settling entirely (a gate that measures load timing does its own). */
+  skipSettle?: boolean;
+}
+
+export interface OpenedPage {
+  page: Page;
+  /**
+   * Human-readable note when a URL redirected somewhere meaningful (a login
+   * wall), else null. Gates surface this so an auth-walled route cannot come
+   * back CLEAN by measuring the login page.
+   */
+  redirect: string | null;
+}
+
+function pageOptions(options: OpenPageOptions) {
+  return withAuthState({
+    ...(options.viewport ? { viewport: options.viewport } : {}),
+    ...(options.deviceScaleFactor !== undefined ? { deviceScaleFactor: options.deviceScaleFactor } : {}),
+    ...(options.colorScheme ? { colorScheme: options.colorScheme } : {}),
+  }, options.storageState);
+}
+
+/**
+ * Open a file or URL by navigation, so relative assets resolve.
+ */
+export async function openSource(
+  browser: Browser,
+  source: string,
+  options: OpenPageOptions = {},
+): Promise<OpenedPage> {
+  const page = await browser.newPage(pageOptions(options));
+  await page.goto(sourceToUrl(source), {
+    waitUntil: options.waitUntil ?? "networkidle",
+    timeout: options.timeout ?? 30000,
+  });
+  if (!options.skipSettle) await settlePage(page, options.settleMs ?? 250);
+  return {
+    page,
+    redirect: isUrlSource(source) ? describeRedirect(source, page.url()) : null,
+  };
+}
+
+export interface OpenHtmlOptions extends OpenPageOptions {
+  /**
+   * The file or URL this HTML came from. The page navigates there first, so the
+   * document keeps that base URL and the mutated copy still resolves the
+   * stylesheets and images sitting next to the original.
+   *
+   * Omit only for HTML synthesized from nothing.
+   */
+  baseSource?: string;
+}
+
+/**
+ * Open HTML a gate has rewritten in memory (inflated text, forced theme,
+ * deleted rule).
+ *
+ * Prefer `openSource` when the bytes on disk are what should be measured.
+ *
+ * Navigate-then-replace, because the obvious alternative does not work.
+ * Measured on the same one-line fixture (external `style.css` setting
+ * `p { color: rgb(4,5,6) }`):
+ *
+ *   setContent + injected `<base href="file:///dir/">`  ->  rgb(0, 0, 0)
+ *   goto(file) then setContent                          ->  rgb(4, 5, 6)
+ *
+ * A `<base>` cannot rescue it: the `setContent` document has an opaque origin,
+ * and Chromium blocks a `file://` subresource from one. Navigating first gives
+ * the document a real base URL, and `setContent` replaces the markup without
+ * discarding it.
+ */
+export async function openHtml(
+  browser: Browser,
+  html: string,
+  options: OpenHtmlOptions = {},
+): Promise<Page> {
+  const page = await browser.newPage(pageOptions(options));
+  if (options.baseSource) {
+    await page.goto(sourceToUrl(options.baseSource), {
+      waitUntil: "domcontentloaded",
+      timeout: options.timeout ?? 30000,
+    });
+  }
+  await page.setContent(html, {
+    waitUntil: options.waitUntil ?? "networkidle",
+    timeout: options.timeout ?? 30000,
+  });
+  if (!options.skipSettle) await settlePage(page, options.settleMs ?? 250);
+  return page;
+}

--- a/packages/vlmkit-core/src/page-open.ts
+++ b/packages/vlmkit-core/src/page-open.ts
@@ -52,6 +52,28 @@ export function sourceToUrl(source: string): string {
  * one frame. Every part is best-effort — a page with a long-poll connection
  * never reaches network idle, and refusing to measure it would be worse than
  * measuring it slightly early.
+ *
+ * **A gate that navigates and does not call this measures the wrong document.**
+ * `load` fires before a client-rendered view paints, and the failure is never
+ * reported as "I looked too early" — it is reported as a defect in the page:
+ *
+ *   - 2026-08-01: `check interactions` said "interactive elements: 0" on a React
+ *     page with a button, two links and a scroller. It measured the "Loading…"
+ *     placeholder.
+ *   - 2026-08-02: `verify flow` failed `count .card expected 2, measured 0` on a
+ *     page where `check layout` measured 2 at the same instant, and
+ *     `build page` screenshotted a candidate at 5.3% of its settled ink — so
+ *     every component came back missing. Both blamed the markup.
+ *
+ * Playwright *actions* auto-wait, which is why this stayed hidden: a click on a
+ * late-rendered element is safe. Reads are not — `page.evaluate`,
+ * `page.screenshot` and `getBoundingClientRect` all sample the DOM at that
+ * instant.
+ *
+ * `waitUntil` is not the axis. `goto(load)` followed by this settle waits for
+ * network idle anyway, so the 8 `load` and 2 `domcontentloaded` call sites are
+ * equivalent to the 71 `networkidle` ones **provided they settle**. The
+ * difference that mattered was always the settle, never the load state.
  */
 export async function settlePage(page: Page, settleMs = 250): Promise<void> {
   await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});

--- a/packages/vlmkit-generate/package.json
+++ b/packages/vlmkit-generate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-generate",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Generator contract for Playwright tests: turns a Markdown plan and generation rules into a Playwright spec source file.",
   "license": "MIT",
   "author": "mizchi",

--- a/packages/vlmkit-heal/fixtures/vrt.spec.ts
+++ b/packages/vlmkit-heal/fixtures/vrt.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 // VRT test. The committed baseline matches vrt-page.html as checked in. The
-// vrt smoke mutates the page (an intentional UI change) so this fails, then the
+// vlmkit inspect smoke mutates the page (an intentional UI change) so this fails, then the
 // heal loop asks the vision tier (ui-tars) whether to update the baseline.
 test("dashboard visual", async ({ page }) => {
   await page.setViewportSize({ width: 480, height: 240 });

--- a/packages/vlmkit-heal/package.json
+++ b/packages/vlmkit-heal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-heal",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Cost-optimized self-healing loop for Playwright tests — escalates from cheap to strong models, edits tests/baselines, re-verifies.",
   "license": "MIT",
   "author": "mizchi",

--- a/packages/vlmkit-heal/smoke/dogfood-safety.ts
+++ b/packages/vlmkit-heal/smoke/dogfood-safety.ts
@@ -95,11 +95,11 @@ async function probeVrtRegression() {
     );
     const baselineAfter = readFileSync(baseline);
     const baselineUntouched = Buffer.compare(baselineBefore, baselineAfter) === 0;
-    console.log("\n[B] vrt regression baseline protection");
+    console.log("\n[B] vlmkit regression baseline protection");
     console.log("    verdict           :", result.verdict);
     console.log("    baseline untouched:", baselineUntouched ? "yes" : "NO (unsafe)");
     const safe = result.verdict === "regression" && baselineUntouched;
-    return { name: "vrt regression protection", safe, detail: `${result.verdict}, baseline ${baselineUntouched ? "kept" : "OVERWRITTEN"}` };
+    return { name: "vlmkit regression protection", safe, detail: `${result.verdict}, baseline ${baselineUntouched ? "kept" : "OVERWRITTEN"}` };
   } finally {
     writeFileSync(pageFile, pageOriginal);
     writeFileSync(baseline, baselineBefore); // ensure baseline restored even if overwritten

--- a/packages/vlmkit-heal/src/runner.test.ts
+++ b/packages/vlmkit-heal/src/runner.test.ts
@@ -10,7 +10,7 @@ describe("classify", () => {
   it("detects timeouts", () => {
     assert.equal(classify("Timeout 5000ms exceeded"), "timeout");
   });
-  it("detects vrt diff failures", () => {
+  it("detects vlmkit diff failures", () => {
     assert.equal(classify("Error: Screenshot comparison failed"), "vrt-diff");
     assert.equal(classify("toHaveScreenshot() ... 1234 pixels differ"), "vrt-diff");
   });

--- a/packages/vlmkit-markup/README.md
+++ b/packages/vlmkit-markup/README.md
@@ -4,8 +4,8 @@ VLM-driven markup-assistance tooling — component extraction, design-token
 conformance, theme parity, i18n stress, palette diff, dep-graph, selector heal.
 
 Part of the [`vrt`](https://github.com/mizchi/vrt) monorepo. Most modules
-double as CLI commands routed by the `vrt` CLI (`vrt scan component`,
-`vrt check theme`, `vrt check tokens`, `vrt stress i18n|media`, …).
+double as CLI commands routed by the `vrt` CLI (`vlmkit scan component`,
+`vlmkit check theme`, `vlmkit check tokens`, `vlmkit stress i18n|media`, …).
 
 ## Install
 
@@ -45,7 +45,7 @@ home.contrast.json
 home.responsive.json
 ```
 
-`home.contrast.json` may be the `vrt a11y-contrast` report shape:
+`home.contrast.json` may be the `vlmkit check a11y contrast` report shape:
 
 ```json
 { "totalText": 2, "failures": [] }

--- a/packages/vlmkit-markup/README.md
+++ b/packages/vlmkit-markup/README.md
@@ -3,8 +3,8 @@
 VLM-driven markup-assistance tooling — component extraction, design-token
 conformance, theme parity, i18n stress, palette diff, dep-graph, selector heal.
 
-Part of the [`vrt`](https://github.com/mizchi/vrt) monorepo. Most modules
-double as CLI commands routed by the `vrt` CLI (`vlmkit scan component`,
+Part of the [`vlmkit`](https://github.com/mizchi/vrt) monorepo. Most modules
+double as CLI commands routed by the `vlmkit` CLI (`vlmkit scan component`,
 `vlmkit check theme`, `vlmkit check tokens`, `vlmkit stress i18n|media`, …).
 
 ## Install

--- a/packages/vlmkit-markup/package.json
+++ b/packages/vlmkit-markup/package.json
@@ -38,7 +38,8 @@
     "prepack": "pnpm build",
     "test": "node --test 'src/**/*.test.ts'",
     "moon:test": "moon test markup-core && moon check markup-core-api markup-core-cli",
-    "moon:build": "moon build markup-core markup-core-api markup-core-cli --target js"
+    "moon:build": "moon build markup-core markup-core-api markup-core-cli --target js",
+    "build:js": "pnpm --dir ../.. exec tsdown --config tsdown.packages.config.ts --filter @mizchi/vlmkit-markup"
   },
   "exports": {
     ".": {

--- a/packages/vlmkit-markup/package.json
+++ b/packages/vlmkit-markup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-markup",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "VLM-driven markup tooling for VRT: component extract, design-token / theme-parity / i18n-stress / palette checks, dep-graph, selector heal, smoke runner.",
   "license": "MIT",
   "author": "mizchi",

--- a/packages/vlmkit-markup/src/a11y-contrast.ts
+++ b/packages/vlmkit-markup/src/a11y-contrast.ts
@@ -27,7 +27,7 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
-import { openSource } from "@mizchi/vlmkit-core/page-open.ts";
+import { openSource, resolveSource } from "@mizchi/vlmkit-core/page-open.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { evaluateA11yContrast } from "./markup-core-a11y-contrast.ts";
@@ -210,7 +210,9 @@ export async function runA11yContrast(
 ): Promise<A11yContrastReport> {
   const outputDir = resolve(options.outputDir);
   await mkdir(outputDir, { recursive: true });
-  const htmlPath = resolve(options.htmlPath);
+  // A URL is a valid source now that loading goes through `openSource`;
+  // `resolve()` would have turned it into `<cwd>/http:/host/page.html`.
+  const htmlPath = resolveSource(options.htmlPath);
   const viewport = options.viewport ?? { width: 1280, height: 900 };
   const minLen = options.minTextLength ?? 1;
 

--- a/packages/vlmkit-markup/src/a11y-contrast.ts
+++ b/packages/vlmkit-markup/src/a11y-contrast.ts
@@ -167,7 +167,7 @@ function toHex(c: { r: number; g: number; b: number }): string {
  * Build the list of contrast failures from raw samples (post-process
  * step extracted from `runA11yContrast`). Pure — no I/O — so it can
  * be invoked over Playwright pages owned by other modules (e.g. the
- * `vrt diff-pr` CI gate calls this without spinning up a second
+ * `vlmkit diff-pr` CI gate calls this without spinning up a second
  * browser instance per route).
  */
 export function analyzeA11yContrastSamples(samples: A11yContrastRawSample[]): ContrastFinding[] {

--- a/packages/vlmkit-markup/src/a11y-contrast.ts
+++ b/packages/vlmkit-markup/src/a11y-contrast.ts
@@ -21,7 +21,7 @@
  * this is purely visual — works on any page that renders text.
  *
  * Usage:
- *   vrt a11y-contrast <html>
+ *   vlmkit check a11y contrast <html>
  */
 import { writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -33,6 +33,14 @@ import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { evaluateA11yContrast } from "./markup-core-a11y-contrast.ts";
 
 export interface A11yContrastOptions {
+  /**
+   * Suppress the human-readable console block. Set by `--json`: the console
+   * output caps its list at five rows, so mixing it into stdout ahead of the
+   * JSON left `--json` unparseable — while the truncation notice pointed the
+   * reader at exactly that stream. Shipped broken in 0.9.0-dev; caught by
+   * running the built CLI rather than the run function.
+   */
+  quiet?: boolean;
   htmlPath: string;
   outputDir: string;
   reportPath?: string;
@@ -279,22 +287,24 @@ export async function runA11yContrast(
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt a11y-contrast${RESET}`);
-  console.log(`  ${DIM}html: ${htmlPath}${RESET}`);
-  console.log(`  ${DIM}inspected ${byPath.size} text-bearing element(s)${RESET}`);
-  const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
-  console.log(`  ${icon} ${findings.length} contrast failure(s)`);
-  const CONSOLE_ROWS = 5;
-  for (const f of findings.slice(0, CONSOLE_ROWS)) {
-    console.log(`    ${DIM}${f.path} — ${f.ratio.toFixed(2)}:1 (need ${f.requiredAA}) — \`${f.foreground.hex}\` on \`${f.background.hex}\` — "${f.text}"${RESET}`);
+  if (!options.quiet) {
+    console.log(`  ${BOLD}${CYAN}vlmkit check a11y contrast${RESET}`);
+    console.log(`  ${DIM}html: ${htmlPath}${RESET}`);
+    console.log(`  ${DIM}inspected ${byPath.size} text-bearing element(s)${RESET}`);
+    const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+    console.log(`  ${icon} ${findings.length} contrast failure(s)`);
+    const CONSOLE_ROWS = 5;
+    for (const f of findings.slice(0, CONSOLE_ROWS)) {
+      console.log(`    ${DIM}${f.path} — ${f.ratio.toFixed(2)}:1 (need ${f.requiredAA}) — \`${f.foreground.hex}\` on \`${f.background.hex}\` — "${f.text}"${RESET}`);
+    }
+    // Disclose the cut: a headline count above a five-row list reads as "here they
+    // are", and a reader has no way to know seven more exist. Same wording as
+    // `check breakpoints` and `check integrity`.
+    if (findings.length > CONSOLE_ROWS) {
+      console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
+    }
+    console.log(`  ${DIM}report: ${reportPath}${RESET}`);
   }
-  // Disclose the cut: a headline count above a five-row list reads as "here they
-  // are", and a reader has no way to know seven more exist. Same wording as
-  // `check breakpoints` and `check integrity`.
-  if (findings.length > CONSOLE_ROWS) {
-    console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
-  }
-  console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
   return {
     html: htmlPath,
@@ -353,7 +363,7 @@ function renderReport(r: Omit<A11yContrastReport, "reportPath">): string {
       "toward black/white on a light/dark bg adds ratio.");
     lines.push("3. Common fix: muted-gray-on-white text (e.g. `#9ca3af` on `#ffffff` = 2.85:1) " +
       "→ try `#6b7280` (4.69:1) or darker.");
-    lines.push("4. Re-run `vrt a11y-contrast`. Failures should clear.");
+    lines.push("4. Re-run `vlmkit check a11y contrast`. Failures should clear.");
   }
   lines.push("");
   return lines.join("\n");
@@ -363,7 +373,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt a11y-contrast <html> [--output-dir dir]");
+    console.log("Usage: vlmkit check a11y contrast <html> [--output-dir dir]");
     console.log("Options:");
     console.log("  --output-dir <dir>   Default: ./test-results/a11y-contrast");
     console.log("  --report <path>      Markdown report path");
@@ -374,12 +384,14 @@ async function main(argv = process.argv.slice(2)) {
 
   // the only view of the data — the truncation notices point here.
 
+  const json = argv.includes("--json");
   const result = await runA11yContrast({
     htmlPath: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "a11y-contrast"),
     reportPath: report || undefined,
+    quiet: json,
   });
-  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
+  if (json) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-contrast" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/a11y-contrast.ts
+++ b/packages/vlmkit-markup/src/a11y-contrast.ts
@@ -284,8 +284,15 @@ export async function runA11yContrast(
   console.log(`  ${DIM}inspected ${byPath.size} text-bearing element(s)${RESET}`);
   const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
   console.log(`  ${icon} ${findings.length} contrast failure(s)`);
-  for (const f of findings.slice(0, 5)) {
+  const CONSOLE_ROWS = 5;
+  for (const f of findings.slice(0, CONSOLE_ROWS)) {
     console.log(`    ${DIM}${f.path} — ${f.ratio.toFixed(2)}:1 (need ${f.requiredAA}) — \`${f.foreground.hex}\` on \`${f.background.hex}\` — "${f.text}"${RESET}`);
+  }
+  // Disclose the cut: a headline count above a five-row list reads as "here they
+  // are", and a reader has no way to know seven more exist. Same wording as
+  // `check breakpoints` and `check integrity`.
+  if (findings.length > CONSOLE_ROWS) {
+    console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
   }
   console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
@@ -327,6 +334,7 @@ function renderReport(r: Omit<A11yContrastReport, "reportPath">): string {
       const bgSwatch = `\`${f.background.hex}\``;
       lines.push(`| \`${f.path}\` (${f.fontSize.toFixed(0)}px${f.fontWeight >= 600 ? " b" : ""}) | \`${f.text}\` | ${fgSwatch} | ${bgSwatch} | **${f.ratio}:1** | ${f.requiredAA}:1 |`);
     }
+    if (r.failures.length > 20) lines.push(`\n_… ${r.failures.length - 20} more row(s) omitted; the JSON report has all of them._`);
     if (r.failures.length > 20) {
       lines.push(`| _…${r.failures.length - 20} more_ | | | | | |`);
     }
@@ -359,13 +367,19 @@ async function main(argv = process.argv.slice(2)) {
     console.log("Options:");
     console.log("  --output-dir <dir>   Default: ./test-results/a11y-contrast");
     console.log("  --report <path>      Markdown report path");
+    console.log("  --json               Print the full report as JSON (every row, no cut)");
     process.exit(1);
   }
-  await runA11yContrast({
+  // `--json` so the console/markdown row caps stay a display choice rather than
+
+  // the only view of the data — the truncation notices point here.
+
+  const result = await runA11yContrast({
     htmlPath: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "a11y-contrast"),
     reportPath: report || undefined,
   });
+  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-contrast" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/a11y-contrast.ts
+++ b/packages/vlmkit-markup/src/a11y-contrast.ts
@@ -23,10 +23,11 @@
  * Usage:
  *   vrt a11y-contrast <html>
  */
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
+import { openSource } from "@mizchi/vlmkit-core/page-open.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { evaluateA11yContrast } from "./markup-core-a11y-contrast.ts";
@@ -210,7 +211,6 @@ export async function runA11yContrast(
   const outputDir = resolve(options.outputDir);
   await mkdir(outputDir, { recursive: true });
   const htmlPath = resolve(options.htmlPath);
-  const html = await readFile(htmlPath, "utf-8");
   const viewport = options.viewport ?? { width: 1280, height: 900 };
   const minLen = options.minTextLength ?? 1;
 
@@ -218,8 +218,12 @@ export async function runA11yContrast(
   let samples: A11yContrastRawSample[];
   let screenshotPath: string;
   try {
-    const page = await browser.newPage({ viewport });
-    await page.setContent(html, { waitUntil: "networkidle" });
+    // Navigate rather than `setContent(readFile(...))`: the latter leaves the
+    // document on `about:blank`, so a relative `<link rel="stylesheet">` never
+    // loads and the gate measures unstyled markup. Measured on
+    // fixtures/external-assets: it reported 0 contrast failures where the same
+    // CSS inlined reported 1.
+    const { page } = await openSource(browser, htmlPath, { viewport, settleMs: 0 });
     await page.addStyleTag({
       content: `*, *::before, *::after { transition: none !important; animation: none !important; }`,
     });

--- a/packages/vlmkit-markup/src/a11y-focus-order.ts
+++ b/packages/vlmkit-markup/src/a11y-focus-order.ts
@@ -16,12 +16,12 @@
  *      that should be reachable (e.g., custom button without
  *      `role="button"` + `tabindex="0"`).
  *
- * Pairs well with `vrt a11y-touch` (size) and `vrt a11y-contrast`
+ * Pairs well with `vlmkit check a11y touch` (size) and `vlmkit check a11y contrast`
  * (contrast) — those check static rendering, this checks the
  * keyboard journey.
  *
  * Usage:
- *   vrt a11y-focus-order <html-or-url>
+ *   vlmkit check a11y focus <html-or-url>
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -32,6 +32,14 @@ import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/
 import { classifyFocusOrderStep } from "./markup-core-a11y-focus-order.ts";
 
 export interface FocusOrderOptions {
+  /**
+   * Suppress the human-readable console block. Set by `--json`: the console
+   * output caps its list at five rows, so mixing it into stdout ahead of the
+   * JSON left `--json` unparseable — while the truncation notice pointed the
+   * reader at exactly that stream. Shipped broken in 0.9.0-dev; caught by
+   * running the built CLI rather than the run function.
+   */
+  quiet?: boolean;
   source: string;
   outputDir: string;
   reportPath?: string;
@@ -246,20 +254,22 @@ export async function runFocusOrder(
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt a11y-focus-order${RESET}`);
-  console.log(`  ${DIM}source: ${options.source}${RESET}`);
-  console.log(`  ${DIM}captured ${steps.length} focus step(s)${RESET}`);
-  const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
-  console.log(`  ${icon} ${findings.length} finding(s)`);
-  const CONSOLE_ROWS = 5;
-  for (const f of findings.slice(0, CONSOLE_ROWS)) {
-    console.log(`    ${DIM}[${f.kind}] ${f.message}${RESET}`);
+  if (!options.quiet) {
+    console.log(`  ${BOLD}${CYAN}vlmkit check a11y focus${RESET}`);
+    console.log(`  ${DIM}source: ${options.source}${RESET}`);
+    console.log(`  ${DIM}captured ${steps.length} focus step(s)${RESET}`);
+    const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+    console.log(`  ${icon} ${findings.length} finding(s)`);
+    const CONSOLE_ROWS = 5;
+    for (const f of findings.slice(0, CONSOLE_ROWS)) {
+      console.log(`    ${DIM}[${f.kind}] ${f.message}${RESET}`);
+    }
+    // See a11y-contrast: an undisclosed cut makes a partial list look complete.
+    if (findings.length > CONSOLE_ROWS) {
+      console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
+    }
+    console.log(`  ${DIM}report: ${reportPath}${RESET}`);
   }
-  // See a11y-contrast: an undisclosed cut makes a partial list look complete.
-  if (findings.length > CONSOLE_ROWS) {
-    console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
-  }
-  console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
   return {
     source: options.source, viewport, screenshot: screenshotPath,
@@ -323,7 +333,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, maxSteps } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt a11y-focus-order <html-or-url> [options]");
+    console.log("Usage: vlmkit check a11y focus <html-or-url> [options]");
     console.log("Options:");
     console.log("  --max-steps N        Maximum Tab presses (default: 64)");
     console.log("  --output-dir <dir>   Default: ./test-results/a11y-focus-order");
@@ -335,13 +345,15 @@ async function main(argv = process.argv.slice(2)) {
 
   // the only view of the data — the truncation notices point here.
 
+  const json = argv.includes("--json");
   const result = await runFocusOrder({
     source: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "a11y-focus-order"),
     reportPath: report || undefined,
     maxSteps,
+    quiet: json,
   });
-  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
+  if (json) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-focus-order" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/a11y-focus-order.ts
+++ b/packages/vlmkit-markup/src/a11y-focus-order.ts
@@ -127,7 +127,7 @@ export const A11Y_FOCUS_ORDER_SAMPLE_SCRIPT = `
 
 /**
  * Walk Tab focus on an already-navigated Playwright Page and return
- * the focus sequence. Pulled out of `runFocusOrder` so `vrt diff-pr`
+ * the focus sequence. Pulled out of `runFocusOrder` so `vlmkit diff-pr`
  * can reuse it without launching a second browser. The page is left
  * in whatever focus state Tab ended in — callers that need the
  * pristine page should clone it first.

--- a/packages/vlmkit-markup/src/a11y-focus-order.ts
+++ b/packages/vlmkit-markup/src/a11y-focus-order.ts
@@ -251,8 +251,13 @@ export async function runFocusOrder(
   console.log(`  ${DIM}captured ${steps.length} focus step(s)${RESET}`);
   const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
   console.log(`  ${icon} ${findings.length} finding(s)`);
-  for (const f of findings.slice(0, 5)) {
+  const CONSOLE_ROWS = 5;
+  for (const f of findings.slice(0, CONSOLE_ROWS)) {
     console.log(`    ${DIM}[${f.kind}] ${f.message}${RESET}`);
+  }
+  // See a11y-contrast: an undisclosed cut makes a partial list look complete.
+  if (findings.length > CONSOLE_ROWS) {
+    console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
   }
   console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
@@ -323,14 +328,20 @@ async function main(argv = process.argv.slice(2)) {
     console.log("  --max-steps N        Maximum Tab presses (default: 64)");
     console.log("  --output-dir <dir>   Default: ./test-results/a11y-focus-order");
     console.log("  --report <path>      Markdown report path");
+    console.log("  --json               Print the full report as JSON (every row, no cut)");
     process.exit(1);
   }
-  await runFocusOrder({
+  // `--json` so the console/markdown row caps stay a display choice rather than
+
+  // the only view of the data — the truncation notices point here.
+
+  const result = await runFocusOrder({
     source: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "a11y-focus-order"),
     reportPath: report || undefined,
     maxSteps,
   });
+  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-focus-order" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/a11y-touch.ts
+++ b/packages/vlmkit-markup/src/a11y-touch.ts
@@ -267,9 +267,14 @@ export async function runA11yTouch(options: TouchCheckOptions): Promise<TouchRep
   console.log(`  ${DIM}inspected ${byPath.size} interactive element(s)${RESET}`);
   const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
   console.log(`  ${icon} ${findings.length} undersized target(s)`);
-  for (const f of findings.slice(0, 5)) {
+  const CONSOLE_ROWS = 5;
+  for (const f of findings.slice(0, CONSOLE_ROWS)) {
     const cl = f.cluster ? " (clustered)" : "";
     console.log(`    ${DIM}${f.path} — ${Math.round(f.bbox.width)}×${Math.round(f.bbox.height)}${cl} — "${f.text}"${RESET}`);
+  }
+  // See a11y-contrast: an undisclosed cut makes a partial list look complete.
+  if (findings.length > CONSOLE_ROWS) {
+    console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
   }
   console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
@@ -306,6 +311,7 @@ function renderReport(r: Omit<TouchReport, "reportPath">): string {
     const sz = `${Math.round(f.bbox.width)}×${Math.round(f.bbox.height)}`;
     lines.push(`| \`${f.path}\` | \`${f.text}\` | ${sz} | **${f.minSide}** | ${f.required} | ${f.cluster ? "yes" : "no"} |`);
   }
+  if (r.failures.length > 30) lines.push(`\n_… ${r.failures.length - 30} more row(s) omitted; the JSON report has all of them._`);
   if (r.failures.length > 30) lines.push(`| _…${r.failures.length - 30} more_ | | | | | |`);
   lines.push("");
   lines.push("## Suggested next step");
@@ -332,14 +338,20 @@ async function main(argv = process.argv.slice(2)) {
     console.log("  --level AAA|AA    WCAG threshold — AAA=44px (default), AA=24px-with-spacing.");
     console.log("  --output-dir <dir> Default: ./test-results/a11y-touch");
     console.log("  --report <path>    Markdown report path");
+    console.log("  --json               Print the full report as JSON (every row, no cut)");
     process.exit(1);
   }
-  await runA11yTouch({
+  // `--json` so the console/markdown row caps stay a display choice rather than
+
+  // the only view of the data — the truncation notices point here.
+
+  const result = await runA11yTouch({
     source: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "a11y-touch"),
     reportPath: report || undefined,
     level,
   });
+  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-touch" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/a11y-touch.ts
+++ b/packages/vlmkit-markup/src/a11y-touch.ts
@@ -14,9 +14,9 @@
  * threshold.
  *
  * Usage:
- *   vrt a11y-touch <html-or-url>
- *   vrt a11y-touch <url> --level AAA   # 44x44 (default)
- *   vrt a11y-touch <url> --level AA    # 24x24
+ *   vlmkit check a11y touch <html-or-url>
+ *   vlmkit check a11y touch <url> --level AAA   # 44x44 (default)
+ *   vlmkit check a11y touch <url> --level AA    # 24x24
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
@@ -34,6 +34,14 @@ import {
 export type WcagTouchLevel = "AAA" | "AA";
 
 export interface TouchCheckOptions {
+  /**
+   * Suppress the human-readable console block. Set by `--json`: the console
+   * output caps its list at five rows, so mixing it into stdout ahead of the
+   * JSON left `--json` unparseable — while the truncation notice pointed the
+   * reader at exactly that stream. Shipped broken in 0.9.0-dev; caught by
+   * running the built CLI rather than the run function.
+   */
+  quiet?: boolean;
   /** HTML file path or http(s) URL. */
   source: string;
   outputDir: string;
@@ -262,21 +270,23 @@ export async function runA11yTouch(options: TouchCheckOptions): Promise<TouchRep
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt a11y-touch${RESET}`);
-  console.log(`  ${DIM}source: ${options.source}  level: WCAG ${level} (${required}×${required} min)${RESET}`);
-  console.log(`  ${DIM}inspected ${byPath.size} interactive element(s)${RESET}`);
-  const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
-  console.log(`  ${icon} ${findings.length} undersized target(s)`);
-  const CONSOLE_ROWS = 5;
-  for (const f of findings.slice(0, CONSOLE_ROWS)) {
-    const cl = f.cluster ? " (clustered)" : "";
-    console.log(`    ${DIM}${f.path} — ${Math.round(f.bbox.width)}×${Math.round(f.bbox.height)}${cl} — "${f.text}"${RESET}`);
+  if (!options.quiet) {
+    console.log(`  ${BOLD}${CYAN}vlmkit check a11y touch${RESET}`);
+    console.log(`  ${DIM}source: ${options.source}  level: WCAG ${level} (${required}×${required} min)${RESET}`);
+    console.log(`  ${DIM}inspected ${byPath.size} interactive element(s)${RESET}`);
+    const icon = findings.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+    console.log(`  ${icon} ${findings.length} undersized target(s)`);
+    const CONSOLE_ROWS = 5;
+    for (const f of findings.slice(0, CONSOLE_ROWS)) {
+      const cl = f.cluster ? " (clustered)" : "";
+      console.log(`    ${DIM}${f.path} — ${Math.round(f.bbox.width)}×${Math.round(f.bbox.height)}${cl} — "${f.text}"${RESET}`);
+    }
+    // See a11y-contrast: an undisclosed cut makes a partial list look complete.
+    if (findings.length > CONSOLE_ROWS) {
+      console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
+    }
+    console.log(`  ${DIM}report: ${reportPath}${RESET}`);
   }
-  // See a11y-contrast: an undisclosed cut makes a partial list look complete.
-  if (findings.length > CONSOLE_ROWS) {
-    console.log(`    ${DIM}… ${findings.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
-  }
-  console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
   return {
     source: options.source, level, viewport, screenshot: screenshotPath,
@@ -324,7 +334,7 @@ function renderReport(r: Omit<TouchReport, "reportPath">): string {
     `\`min-width: ${r.failures[0]!.required}px; min-height: ${r.failures[0]!.required}px;\`.`);
   lines.push("   - For inline links, wrap them in a block with hit padding " +
     "and use `display: inline-block`.");
-  lines.push("2. Re-run `vrt a11y-touch`. The failure list should empty out.");
+  lines.push("2. Re-run `vlmkit check a11y touch`. The failure list should empty out.");
   lines.push("");
   return lines.join("\n");
 }
@@ -333,7 +343,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, level } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt a11y-touch <html-or-url> [--level AAA|AA] [--output-dir dir]");
+    console.log("Usage: vlmkit check a11y touch <html-or-url> [--level AAA|AA] [--output-dir dir]");
     console.log("Options:");
     console.log("  --level AAA|AA    WCAG threshold — AAA=44px (default), AA=24px-with-spacing.");
     console.log("  --output-dir <dir> Default: ./test-results/a11y-touch");
@@ -345,13 +355,15 @@ async function main(argv = process.argv.slice(2)) {
 
   // the only view of the data — the truncation notices point here.
 
+  const json = argv.includes("--json");
   const result = await runA11yTouch({
     source: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "a11y-touch"),
     reportPath: report || undefined,
     level,
+    quiet: json,
   });
-  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
+  if (json) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "a11y-touch" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/a11y-touch.ts
+++ b/packages/vlmkit-markup/src/a11y-touch.ts
@@ -133,7 +133,7 @@ export interface A11yTouchRawSample {
 
 /**
  * Build the list of touch-target failures from raw samples. Pure
- * post-process so the `vrt diff-pr` CI gate can reuse it on its
+ * post-process so the `vlmkit diff-pr` CI gate can reuse it on its
  * own Playwright page without spinning up a new browser.
  */
 export function analyzeA11yTouchSamples(

--- a/packages/vlmkit-markup/src/a11y-touch.ts
+++ b/packages/vlmkit-markup/src/a11y-touch.ts
@@ -24,6 +24,7 @@ import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { DIM, RESET, GREEN, RED, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
+import { openSource } from "@mizchi/vlmkit-core/page-open.ts";
 import {
   requiredTouchSide,
   touchTargetBelowRequired,
@@ -198,13 +199,12 @@ export async function runA11yTouch(options: TouchCheckOptions): Promise<TouchRep
   let samples: A11yTouchRawSample[];
   let screenshotPath: string;
   try {
-    const page = await browser.newPage({ viewport });
-    if (isUrl(options.source)) {
-      await page.goto(options.source, { waitUntil: "networkidle", timeout: 30000 });
-    } else {
-      const html = await readFile(resolve(options.source), "utf-8");
-      await page.setContent(html, { waitUntil: "networkidle" });
-    }
+    // One load path for files and URLs. The file branch used to
+    // `setContent(readFile(...))`, which drops the document's base URL: on
+    // fixtures/external-assets that hid the 20x20 tap target entirely (the
+    // element gets its size from CSS) while reporting three styled-and-compliant
+    // buttons as failures at their unstyled sizes.
+    const { page } = await openSource(browser, options.source, { viewport, settleMs: 0 });
     await page.addStyleTag({
       content: `*, *::before, *::after { transition: none !important; animation: none !important; }`,
     });

--- a/packages/vlmkit-markup/src/asset/asset-check.ts
+++ b/packages/vlmkit-markup/src/asset/asset-check.ts
@@ -39,6 +39,7 @@ import { fileURLToPath } from "node:url";
 import { PNG } from "pngjs";
 import { extractPaletteFromFile, extractPaletteFromRgba, type PaletteColor } from "../style/palette-extract.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { applyGateExit } from "@mizchi/vlmkit-core/gate-exit.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -350,7 +351,7 @@ Options:
   --against-bg <#rrggbb>  Backdrop the asset will sit on (silhouette contrast check)
   --page-palette <png>    Page screenshot to check palette harmony against
   --json                  Print JSON report
-  --fail-on-suspect       Exit non-zero when suspect issues are found`);
+  --advisory              Print findings but exit 0 (default: a suspect exits 1)`);
   process.exit(exitCode);
 }
 
@@ -361,7 +362,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   let againstBg: string | undefined;
   let pagePalettePath: string | undefined;
   let json = false;
-  let failOnSuspect = false;
+  let advisory = false;
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
@@ -373,7 +374,8 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     else if (arg === "--against-bg") againstBg = argv[++i]!;
     else if (arg === "--page-palette") pagePalettePath = argv[++i]!;
     else if (arg === "--json") json = true;
-    else if (arg === "--fail-on-suspect") failOnSuspect = true;
+    else if (arg === "--fail-on-suspect") { /* accepted no-op: suspects already fail */ }
+    else if (arg === "--advisory") advisory = true;
     else if (!arg.startsWith("-")) positional.push(arg);
   }
   if (positional.length === 0) printUsage(1);
@@ -387,7 +389,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   });
   if (json) console.log(JSON.stringify(report, null, 2));
   else console.log(formatAssetCheckReport(report));
-  if (failOnSuspect && report.issues.some((i) => i.severity === "suspect")) process.exit(1);
+  applyGateExit(report.issues.some((i) => i.severity === "suspect"), { advisory });
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "asset-check" ||

--- a/packages/vlmkit-markup/src/auth-wall.test.ts
+++ b/packages/vlmkit-markup/src/auth-wall.test.ts
@@ -1,0 +1,128 @@
+/**
+ * A gate pointed at an auth-walled route must never report success for the
+ * login page it actually measured.
+ *
+ * Three gates learned this earlier (integrity / copy / design, via
+ * `describeRedirect`). The rest were left, and the remaining work was labelled
+ * cosmetic. It was not: measured 2026-08-02 against a route that 302s to
+ * `/login` without a session,
+ *
+ *   check breakpoints : status: ok
+ *   check scroll      : status: ok
+ *   scan scroll       : status: ok
+ *   check layout      : VIOLATED "count: expected 2, measured 0"   <- blames the markup
+ *   verify flow       : every step fails on "element not found"    <- blames the flow
+ *
+ * The first three are silent false passes; the last two send the reader to
+ * debug markup that is fine. Every one of them named the requested URL as its
+ * source while measuring a different page.
+ */
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runBreakpointCheck } from "./stress/breakpoint-check.ts";
+import { runFlowVerify } from "./inspect/flow-verify.ts";
+import { runIntegrityCheck } from "./inspect/integrity-check.ts";
+import { runLayoutVerify } from "./inspect/layout-contract.ts";
+import { runScrollBehavior } from "./inspect/scroll-behavior.ts";
+import { runScrollScan } from "./inspect/scroll-scan.ts";
+
+/** `/app` redirects to `/login` unless a session cookie is present. */
+function startWall(): Promise<{ server: Server; base: string }> {
+  const server = createServer((req, res) => {
+    if ((req.url ?? "").startsWith("/app") && !(req.headers.cookie ?? "").includes("session=")) {
+      res.writeHead(302, { location: "/login" });
+      res.end();
+      return;
+    }
+    const login = (req.url ?? "").startsWith("/login");
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end(login
+      ? `<!doctype html><meta charset="utf-8"><title>Sign in</title><body style="font:16px sans-serif;padding:40px"><h1>Sign in</h1><form><input type="password"><button>Sign in</button></form></body>`
+      : `<!doctype html><meta charset="utf-8"><title>Dashboard</title><body style="margin:0"><main><div class="card" style="width:1000px">Revenue</div><div class="card" style="width:1000px">Costs</div></main></body>`);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({ server, base: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+describe("gates refuse to pass on a login wall", () => {
+  let server: Server;
+  let walled = "";
+
+  before(async () => {
+    const started = await startWall();
+    server = started.server;
+    walled = `${started.base}/app`;
+  });
+  after(() => server.close());
+
+  const REDIRECT = /redirected: requested \/app but measured .*\/login/;
+
+  it("check integrity reports it as a fail", async () => {
+    const report = await runIntegrityCheck({ source: walled, viewports: [{ width: 1280, height: 800 }] });
+    const finding = report.findings.find((f) => f.kind === "redirected");
+    assert.ok(finding, JSON.stringify(report.findings.map((f) => f.kind)));
+    assert.match(finding.message, REDIRECT);
+    assert.equal(report.verdict, "defects");
+  });
+
+  it("check breakpoints reports a suspect issue rather than status: ok", async () => {
+    const report = await runBreakpointCheck({ source: walled });
+    const issue = report.issues.find((i) => i.kind === "redirected");
+    assert.ok(issue, "expected a redirected issue");
+    assert.equal(issue.severity, "suspect");
+    assert.match(issue.message, REDIRECT);
+  });
+
+  it("check scroll reports a suspect issue", async () => {
+    const report = await runScrollBehavior({ source: walled });
+    const issue = report.issues.find((i) => i.kind === "redirected");
+    assert.ok(issue, "expected a redirected issue");
+    assert.equal(issue.severity, "suspect");
+  });
+
+  it("scan scroll reports a suspect issue", async () => {
+    const report = await runScrollScan({ source: walled });
+    const issue = report.issues.find((i) => i.kind === "redirected");
+    assert.ok(issue, "expected a redirected issue");
+    assert.equal(issue.severity, "suspect");
+  });
+
+  it("check layout cannot be done, and says why the rules failed", async () => {
+    const report = await runLayoutVerify({
+      source: walled,
+      contract: { rules: [{ selector: ".card", at: 1280, count: 2 }] },
+    });
+    assert.equal(report.done, false);
+    assert.match(report.redirected ?? "", REDIRECT);
+  });
+
+  it("verify flow cannot be done, and says why the steps failed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "auth-wall-flow-"));
+    writeFileSync(join(dir, "flow.json"), "{}");
+    const report = await runFlowVerify({
+      source: walled,
+      flow: { steps: [{ label: "open", do: { action: "click", selector: ".card" } }] },
+    });
+    assert.equal(report.done, false);
+    assert.match(report.redirected ?? "", REDIRECT);
+  });
+
+  it("the hint points at --storage-state, which the tool actually has", async () => {
+    // It used to end "vlmkit cannot inject a session", which stopped being true
+    // the day --storage-state landed. A hint that denies a shipped feature sends
+    // the reader to the wrong fix.
+    const report = await runScrollScan({ source: walled });
+    const issue = report.issues.find((i) => i.kind === "redirected")!;
+    assert.match(issue.message, /--storage-state/);
+    assert.doesNotMatch(issue.message, /cannot inject a session/);
+  });
+});

--- a/packages/vlmkit-markup/src/component/component-bbox.test.ts
+++ b/packages/vlmkit-markup/src/component/component-bbox.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  adaptiveBgTolerance,
   extractComponentsFromRgba,
   matchComponents,
   type ComponentBbox,
@@ -129,5 +130,51 @@ describe("matchComponents", () => {
 
   it("returns empty on empty input", () => {
     assert.deepEqual(matchComponents([], []), []);
+  });
+});
+
+// 2026-08-01 hard-target audit: a fixed tolerance of 12 classified
+// #f4f4f4-on-white cards (per-channel distance 11) as BACKGROUND, so they
+// were never extracted and `verify markup` scored their removal as a 0.01%
+// diff. Most light-surface tokens sit under 12 (#fafafa 5, #f5f5f5 10).
+describe("adaptive background tolerance", () => {
+  const fill = (w: number, h: number, rgb: [number, number, number]) => {
+    const data = new Uint8Array(w * h * 4);
+    for (let i = 0; i < w * h; i++) {
+      data[i * 4] = rgb[0]; data[i * 4 + 1] = rgb[1]; data[i * 4 + 2] = rgb[2]; data[i * 4 + 3] = 255;
+    }
+    return data;
+  };
+
+  it("a clean render gets a tight tolerance; a noisy one keeps the permissive default", () => {
+    const clean = fill(80, 80, [255, 255, 255]);
+    assert.equal(adaptiveBgTolerance(clean, 80, 80, [255, 255, 255]), 4);
+
+    // Noise of +-4/channel around white: the estimate climbs back toward 12.
+    const noisy = fill(80, 80, [255, 255, 255]);
+    for (let i = 0; i < 80 * 80; i++) {
+      const d = (i % 5) - 2 + ((i % 3) - 1); // small, varied deviations
+      const v = 255 - Math.abs(d) * 2;
+      noisy[i * 4] = v; noisy[i * 4 + 1] = v; noisy[i * 4 + 2] = v;
+    }
+    assert.ok(adaptiveBgTolerance(noisy, 80, 80, [255, 255, 255]) > 4);
+  });
+
+  it("extracts a pale #f4f4f4 card on white that the fixed tolerance of 12 missed", () => {
+    const w = 120, h = 120;
+    const data = fill(w, h, [255, 255, 255]);
+    for (let y = 10; y < 60; y++) {
+      for (let x = 10; x < 90; x++) {
+        const i = (y * w + x) * 4;
+        data[i] = 244; data[i + 1] = 244; data[i + 2] = 244;
+      }
+    }
+    const found = extractComponentsFromRgba(data, w, h);
+    assert.equal(found.length, 1, JSON.stringify(found));
+    assert.equal(found[0]!.width, 80);
+    assert.equal(found[0]!.height, 50);
+
+    // Pinning the old tolerance reproduces the miss, documenting the cause.
+    assert.equal(extractComponentsFromRgba(data, w, h, { bgTolerance: 12 }).length, 0);
   });
 });

--- a/packages/vlmkit-markup/src/component/component-bbox.ts
+++ b/packages/vlmkit-markup/src/component/component-bbox.ts
@@ -53,7 +53,12 @@ export interface ExtractComponentsOptions {
   minArea?: number;
   /** How many components to return after sorting by area. Default 8. */
   topN?: number;
-  /** Per-channel difference threshold for "foreground." Default 12. */
+  /**
+   * Per-channel difference threshold for "foreground." Defaults to a value
+   * derived from the image's own noise floor (4 on a clean render, up to 12
+   * on a noisy export) — see `adaptiveBgTolerance`. Pin it only when you
+   * need two extractions to use provably identical settings.
+   */
   bgTolerance?: number;
   /**
    * Explicit background color. When set, edge-based detection is skipped.
@@ -69,8 +74,11 @@ export interface ExtractComponentsOptions {
 const DEFAULT_MIN_AREA = 200;
 const DEFAULT_TOP_N = 8;
 const DEFAULT_BG_TOLERANCE = 12;
+/** Floor for the adaptive tolerance — below this, antialiasing halos start
+ * forming their own components on clean renders. */
+const MIN_BG_TOLERANCE = 4;
 
-function detectBackground(data: Uint8Array, width: number, height: number): [number, number, number] {
+export function detectBackground(data: Uint8Array, width: number, height: number): [number, number, number] {
   // Sample the corners + the middle of each edge. Most-frequent triple wins.
   const samples: Array<[number, number, number]> = [];
   const points = [
@@ -117,6 +125,54 @@ function inBackground(
   tol: number,
 ): boolean {
   return Math.abs(r - bgR) <= tol && Math.abs(g - bgG) <= tol && Math.abs(b - bgB) <= tol;
+}
+
+/**
+ * Pick the foreground tolerance from the image's own noise floor.
+ *
+ * A fixed tolerance of 12 was hiding a very ordinary UI surface: the
+ * 2026-08-01 hard-target audit removed two `#f4f4f4` cards from a
+ * `#ffffff` page — 2.12% of pixels genuinely different — and `verify
+ * markup` reported `pixel diff 0.01%` / DONE, because 255-244 = 11 falls
+ * *inside* 12, so the cards were never foreground to begin with. Most
+ * light-surface tokens land there (#fafafa 5, #f5f5f5 10, #f4f4f4 11).
+ *
+ * The tolerance exists for real reasons — JPEG ringing and antialiasing
+ * around a flat fill — so rather than lowering it blindly, measure how
+ * noisy this image actually is. Deviations are sampled only from pixels
+ * within a narrow band of the background: sensor/codec noise lives there,
+ * while a flat pale fill (deviation ~11) sits outside the band and so
+ * cannot inflate the estimate of itself.
+ *
+ * Clean PNG render -> median deviation 0 -> tolerance 4 (pale cards are
+ * found). Noisy JPEG export -> higher median -> tolerance climbs back
+ * toward the historical 12, which is also the cap: this can only make
+ * extraction more sensitive than before, never less.
+ */
+export function adaptiveBgTolerance(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  bg: [number, number, number],
+): number {
+  const [bgR, bgG, bgB] = bg;
+  const BAND = 6; // above the noise we expect, below any real pale fill
+  const devs: number[] = [];
+  const step = Math.max(1, Math.floor(Math.sqrt((width * height) / 4000)));
+  for (let y = 0; y < height; y += step) {
+    for (let x = 0; x < width; x += step) {
+      const i = (y * width + x) * 4;
+      const dr = Math.abs(data[i]! - bgR);
+      const dg = Math.abs(data[i + 1]! - bgG);
+      const db = Math.abs(data[i + 2]! - bgB);
+      const dev = Math.max(dr, dg, db);
+      if (dev <= BAND) devs.push(dev);
+    }
+  }
+  if (devs.length === 0) return DEFAULT_BG_TOLERANCE;
+  devs.sort((a, b) => a - b);
+  const median = devs[Math.floor(devs.length / 2)]!;
+  return Math.min(DEFAULT_BG_TOLERANCE, Math.max(MIN_BG_TOLERANCE, MIN_BG_TOLERANCE + 3 * median));
 }
 
 /**
@@ -217,11 +273,13 @@ export function extractComponentsFromRgba(
 ): ComponentBbox[] {
   const minArea = options.minArea ?? DEFAULT_MIN_AREA;
   const topN = options.topN ?? DEFAULT_TOP_N;
-  const tol = options.bgTolerance ?? DEFAULT_BG_TOLERANCE;
 
   if (width <= 0 || height <= 0) return [];
 
   const [bgR, bgG, bgB] = options.background ?? detectBackground(data, width, height);
+  // Derived from this image's noise unless the caller pins it (see
+  // adaptiveBgTolerance: pale flat surfaces used to read as background).
+  const tol = options.bgTolerance ?? adaptiveBgTolerance(data, width, height, [bgR, bgG, bgB]);
 
   const mask = new Uint8Array(width * height);
   for (let y = 0; y < height; y++) {

--- a/packages/vlmkit-markup/src/component/component-consistency.ts
+++ b/packages/vlmkit-markup/src/component/component-consistency.ts
@@ -19,7 +19,7 @@
  * multiple pages).
  *
  * Usage:
- *   vrt component-consistency <html> --selector .card
+ *   vlmkit check drift component <html> --selector .card
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
@@ -166,7 +166,7 @@ export async function runComponentConsistency(
   const md = renderReport(htmlPath, options.selector, instances, reference.index, deltas);
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt component-consistency${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit check drift component${RESET}`);
   console.log(`  ${DIM}html: ${htmlPath}  selector: ${options.selector}${RESET}`);
   console.log(`  ${DIM}${instances.length} instance(s), reference = #${reference.index}${RESET}`);
   for (const d of deltas) {
@@ -245,7 +245,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, selector, outputDir, report, threshold, referenceIndex } = parseArgs(argv);
   if (positional.length === 0 || !selector) {
-    console.log("Usage: vrt component-consistency <html> --selector <sel>");
+    console.log("Usage: vlmkit check drift component <html> --selector <sel>");
     console.log("Options:");
     console.log("  --selector <sel>           CSS selector matching ≥ 2 instances of the component.");
     console.log("  --reference-index <N>      Which match to use as the reference. Default 0.");

--- a/packages/vlmkit-markup/src/component/component-extract.ts
+++ b/packages/vlmkit-markup/src/component/component-extract.ts
@@ -8,22 +8,22 @@
  * dominant color + content-kind classification, and optionally
  * crops a selected one to a standalone PNG.
  *
- * Pairs with `vrt component-from-image`: given a full-page
+ * Pairs with `vlmkit build component`: given a full-page
  * screenshot (e.g. a Figma export, competitor mockup, or user-
  * reported bug screenshot), extract the component you want, then
  * feed the cropped PNG to `component-from-image` as the target.
  *
  * Usage:
- *   vrt component-extract <screenshot.png>
+ *   vlmkit scan component <screenshot.png>
  *     # list components ranked by area
  *
- *   vrt component-extract <screenshot.png> --crop 0
+ *   vlmkit scan component <screenshot.png> --crop 0
  *     # crop the largest (rank 0) component to <output-dir>/component-0.png
  *
- *   vrt component-extract <screenshot.png> --crop-all
+ *   vlmkit scan component <screenshot.png> --crop-all
  *     # crop every component into separate PNGs
  *
- *   vrt component-extract <screenshot.png> --at 640,320
+ *   vlmkit scan component <screenshot.png> --at 640,320
  *     # crop the component containing the given (x, y) point
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
@@ -194,7 +194,7 @@ export async function runComponentExtract(
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt component-extract${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit scan component${RESET}`);
   console.log(`  ${DIM}source: ${sourcePath} (${sourcePng.width}×${sourcePng.height})${RESET}`);
   console.log(`  ${DIM}found ${components.length} component(s)${RESET}`);
   for (const c of components.slice(0, 8)) {
@@ -244,9 +244,9 @@ function renderReport(r: Omit<ComponentExtractReport, "reportPath">): string {
   lines.push("");
   lines.push("1. Visually verify the rank → component mapping (open the source PNG, " +
     "compare against the bbox column).");
-  lines.push("2. Crop the component you want as a target: `vrt component-extract " +
+  lines.push("2. Crop the component you want as a target: `vlmkit scan component " +
     "<src> --crop <rank>` (or `--at x,y` to crop by point).");
-  lines.push("3. Feed the cropped PNG to `vrt component-from-image <cropped> <your.html>` " +
+  lines.push("3. Feed the cropped PNG to `vlmkit build component <cropped> <your.html>` " +
     "to iterate against just that component.");
   lines.push("");
   return lines.join("\n");
@@ -256,7 +256,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, cropRank, cropAll, pointXY, cropPadding, minArea } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt component-extract <screenshot.png> [options]");
+    console.log("Usage: vlmkit scan component <screenshot.png> [options]");
     console.log("Options:");
     console.log("  --crop <rank>           Crop the rank-N component (e.g. --crop 0)");
     console.log("  --crop-all              Crop every detected component");

--- a/packages/vlmkit-markup/src/component/component-from-image.ts
+++ b/packages/vlmkit-markup/src/component/component-from-image.ts
@@ -11,7 +11,7 @@
  *      text-row) plus an optional multi-state pass.
  *   4. Agent iterates the HTML until the diff converges.
  *
- * Unlike `vrt compare` (migration mode), this scenario:
+ * Unlike `vlmkit diff html` (migration mode), this scenario:
  *   - has no DOM correspondence — the target is a static PNG.
  *   - runs at a single viewport sized to the target image.
  *   - skips paint-tree, DOM-equivalence, breakpoint-discovery, etc.

--- a/packages/vlmkit-markup/src/component/page-compose.ts
+++ b/packages/vlmkit-markup/src/component/page-compose.ts
@@ -33,6 +33,7 @@ import {
 import { classifyRegion, kindsCanPair, type ComponentKindInfo } from "./component-classify.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 
 export interface PageComponent extends ComponentBbox {
   /** Index in the extraction order (area-desc) of its own side. */
@@ -526,6 +527,11 @@ export async function renderHtmlToPng(
   try {
     const page = await browser.newPage({ viewport: { width, height } });
     await page.goto(pathToFileURL(resolve(htmlPath)).href, { waitUntil: "load" });
+    // A screenshot samples the DOM at that instant. Measured 2026-08-02 on a
+    // candidate that renders its cards 350ms after `load`: this capture held
+    // 5.3% of the settled ink — the "Loading…" placeholder — so every component
+    // came back missing and the kickback blamed the markup.
+    await settlePage(page);
     // Viewport-only, like `build component`: the target screenshot is bounded
     // by the requested viewport, so a full-page capture of a taller candidate
     // would report below-the-fold content as extra components.

--- a/packages/vlmkit-markup/src/contract/introspect-contract.ts
+++ b/packages/vlmkit-markup/src/contract/introspect-contract.ts
@@ -34,6 +34,7 @@ import {
   type UiWidthPolicy,
 } from "./ui-contract.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 
 export interface LandmarkCapture {
   viewport: string;
@@ -362,6 +363,22 @@ export async function introspectUiContractFromHtml(
       const target = introspectionTarget(input);
       const navigateStart = performance.now();
       await page.goto(target, { waitUntil: waitUntilForIntrospectionInput(input) });
+      // The `load`-only fast path for local files was a deliberate speed
+      // choice (docs/landmark-drilldown-design.md), and it was measurably
+      // wrong. `scan contract` on a built SPA opened as a file, 2026-08-02:
+      //
+      //   load only  ->  0 landmarks []                                   241ms
+      //   settled    ->  4 [banner, navigation, main, contentinfo]         986ms
+      //
+      // Zero landmarks is not a slow answer, it is a wrong one — and it is the
+      // input every downstream contract command reads.
+      //
+      // A cheaper primitive was tried and rejected: waiting for the DOM to stop
+      // mutating (MutationObserver quiet + rAF) is 128ms instead of 775ms, but
+      // it declares a page settled *before* a deferred render starts (still 0
+      // landmarks at a 350ms render delay) and burns its whole cap on a page
+      // that polls. Network idle is slower and correct; that is the trade.
+      await settlePage(page);
       const navigateMs = performance.now() - navigateStart;
       const landmarkStart = performance.now();
       const landmarks = await captureLandmarkRegions(page, {

--- a/packages/vlmkit-markup/src/external-assets.test.ts
+++ b/packages/vlmkit-markup/src/external-assets.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The load-mechanism gate: a gate that takes an HTML file must resolve that
+ * file's relative assets.
+ *
+ * `fixtures/external-assets/` declares every one of its defects in `style.css`,
+ * never in `page.html`. A gate that loads the markup with
+ * `page.setContent(await readFile(file))` gets a document whose base URL is
+ * `about:blank`, so the stylesheet never loads and the gate measures unstyled
+ * markup.
+ *
+ * Measured before the fix (2026-08-02):
+ *
+ *   check a11y contrast : 0 failures external / 1 inlined
+ *   check a11y touch    : missed the 20x20 target entirely (it gets its size
+ *                         from CSS) AND reported three compliant buttons as
+ *                         failures at their unstyled sizes — inverted, not just
+ *                         incomplete
+ *   check tokens        : 12 padding violations external / 9 inlined
+ *   stress i18n         : card height 21->86 external / 95->185 inlined
+ *
+ * The assertion here is differential, not absolute: run each gate on the
+ * fixture and on a twin whose CSS is inlined, and require the same verdict. A
+ * threshold change can move both numbers without breaking the test, but a gate
+ * that stops resolving assets breaks it immediately.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runA11yContrast } from "./a11y-contrast.ts";
+import { runA11yTouch } from "./a11y-touch.ts";
+import { runDesignTokens } from "./style/design-tokens.ts";
+import { runI18nStress } from "./stress/i18n-stress.ts";
+
+// Resolved from this file, not the cwd: `pnpm --filter` runs the suite with the
+// package as cwd, and a cwd-relative path made the whole suite error out while
+// the summary still printed "0 fail".
+const FIXTURE_DIR = fileURLToPath(new URL("../../../fixtures/external-assets", import.meta.url));
+const EXTERNAL = join(FIXTURE_DIR, "page.html");
+
+/** Same document, CSS moved from the external file into a `<style>` block. */
+const inlinedTwin = (): string => {
+  const css = readFileSync(join(FIXTURE_DIR, "style.css"), "utf-8");
+  const html = readFileSync(EXTERNAL, "utf-8")
+    .replace('<link rel="stylesheet" href="style.css">', `<style>\n${css}\n</style>`);
+  const dir = mkdtempSync(join(tmpdir(), "inlined-twin-"));
+  const file = join(dir, "page.html");
+  writeFileSync(file, html);
+  return file;
+};
+
+const outDir = () => mkdtempSync(join(tmpdir(), "ext-assets-out-"));
+
+describe("gates resolve a file's relative assets", () => {
+  const INLINED = inlinedTwin();
+
+  it("check a11y contrast sees CSS-declared contrast failures", async () => {
+    const external = await runA11yContrast({ htmlPath: EXTERNAL, outputDir: outDir() });
+    const inlined = await runA11yContrast({ htmlPath: INLINED, outputDir: outDir() });
+    assert.equal(external.failures.length, inlined.failures.length);
+    assert.ok(external.failures.length >= 1, "the fixture declares a 1.92:1 pair in style.css");
+    assert.deepEqual(
+      external.failures.map((f) => `${f.path}:${f.ratio}`).sort(),
+      inlined.failures.map((f) => `${f.path}:${f.ratio}`).sort(),
+    );
+  });
+
+  it("check a11y touch sees an element whose size comes from CSS", async () => {
+    const external = await runA11yTouch({ source: EXTERNAL, outputDir: outDir() });
+    const inlined = await runA11yTouch({ source: INLINED, outputDir: outDir() });
+    assert.equal(external.inspectedCount, inlined.inspectedCount);
+    // The 20x20 anchor is inline with no intrinsic size until CSS applies, so
+    // an unstyled load does not even see it as a target.
+    assert.ok(
+      external.failures.some((f) => f.path.includes("tiny-tap")),
+      `expected the CSS-sized tap target, got ${JSON.stringify(external.failures.map((f) => f.path))}`,
+    );
+    assert.deepEqual(
+      external.failures.map((f) => `${f.path}:${f.minSide}`).sort(),
+      inlined.failures.map((f) => `${f.path}:${f.minSide}`).sort(),
+    );
+  });
+
+  it("check tokens audits the values the page actually renders", async () => {
+    const external = await runDesignTokens({ source: EXTERNAL, outputDir: outDir() });
+    const inlined = await runDesignTokens({ source: INLINED, outputDir: outDir() });
+    assert.equal(external.inspectedCount, inlined.inspectedCount);
+    assert.equal(external.violations.length, inlined.violations.length);
+  });
+
+  it("stress i18n inflates the styled layout, not an unstyled one", async () => {
+    const external = await runI18nStress({ htmlPath: EXTERNAL, outputDir: outDir() });
+    const inlined = await runI18nStress({ htmlPath: INLINED, outputDir: outDir() });
+    assert.equal(external.totalInspected, inlined.totalInspected);
+    assert.equal(external.overflowing.length, inlined.overflowing.length);
+    // Same element, same measured heights — the geometry the gate judged used to
+    // be a different document's (card 21->86 unstyled vs 95->185 styled).
+    assert.deepEqual(
+      external.overflowing.map((o) => `${o.path}:${o.kind}:${o.before.height}->${o.after.height}`),
+      inlined.overflowing.map((o) => `${o.path}:${o.kind}:${o.before.height}->${o.after.height}`),
+    );
+  });
+});

--- a/packages/vlmkit-markup/src/heal/fix-prompt.ts
+++ b/packages/vlmkit-markup/src/heal/fix-prompt.ts
@@ -2,7 +2,7 @@
  * Convert a `snapshot-report.json` into structured fix tasks + a markdown
  * prompt that a coding subagent can act on.
  *
- * Bridges `vrt snapshot` detection output and "fix the diff" agent runs.
+ * Bridges `vlmkit snapshot` detection output and "fix the diff" agent runs.
  */
 import { existsSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -190,8 +190,8 @@ export function formatSnapshotFixPromptMarkdown(
   lines.push("1. Open each pair of baseline/current images to confirm the visual regression.");
   lines.push("2. If a heatmap is present, use it to localize the diff region.");
   lines.push("3. Map the affected DOM (from the captured HTML) back to source files.");
-  lines.push("4. Propose a minimal CSS or markup change and re-run `vrt snapshot` to verify.");
-  lines.push("5. Once green, run `vrt snapshot approve --label <label>` to promote the new baseline if the visual change is intentional.");
+  lines.push("4. Propose a minimal CSS or markup change and re-run `vlmkit snapshot` to verify.");
+  lines.push("5. Once green, run `vlmkit snapshot approve --label <label>` to promote the new baseline if the visual change is intentional.");
   lines.push("");
 
   return lines.join("\n");

--- a/packages/vlmkit-markup/src/heal/selector-heal-cli.ts
+++ b/packages/vlmkit-markup/src/heal/selector-heal-cli.ts
@@ -15,6 +15,7 @@ import { existsSync } from "node:fs";
 import { chromium } from "playwright";
 import { healSelector } from "./selector-heal.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 
 function toUrl(input: string): string {
   if (/^https?:\/\//.test(input)) return input;
@@ -55,6 +56,10 @@ async function main(argv = process.argv.slice(2)) {
   try {
     const page = await browser.newPage({ viewport: { width, height } });
     await page.goto(toUrl(input), { waitUntil: "load" });
+    // Candidate selectors are harvested from the DOM as it stands. Without
+    // settling, a client-rendered page offers candidates from its placeholder,
+    // which is the opposite of useful when healing a selector that broke.
+    await settlePage(page);
 
     const alreadyMatches = await page.locator(brokenSelector).count().catch(() => 0);
     const candidates = await healSelector(page, brokenSelector, { maxCandidates });

--- a/packages/vlmkit-markup/src/inspect/copy-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-check.test.ts
@@ -243,6 +243,47 @@ test("silencing battery: geometric hiding vectors are caught, reachable text sta
   }
 });
 
+// 2026-08-01 hard-target audit: a custom element's visible badge text was
+// reported copy-missing because innerText and a document-scoped TreeWalker
+// both stop at the shadow boundary. Design systems built on web components
+// keep ALL their copy there, so this was a first-day false positive.
+test("open shadow-root copy counts as visible; hidden shadow copy still caught (E2E)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "copy-shadow-"));
+  try {
+    const html = `<!doctype html><body>
+      <h1>Ledger</h1>
+      <ledger-badge></ledger-badge>
+      <sneaky-badge></sneaky-badge>
+      <script>
+        customElements.define("ledger-badge", class extends HTMLElement {
+          connectedCallback() {
+            this.attachShadow({ mode: "open" }).innerHTML =
+              '<style>.b{font:600 13px system-ui;color:#1a7f42}</style><span class="b">Reconciled nightly</span>';
+          }
+        });
+        customElements.define("sneaky-badge", class extends HTMLElement {
+          connectedCallback() {
+            this.attachShadow({ mode: "open" }).innerHTML =
+              '<span style="font-size:0">Fees may apply</span>';
+          }
+        });
+      </script></body>`;
+    const page = join(dir, "page.html");
+    const manifest = join(dir, "copy.txt");
+    await writeFile(page, html);
+    await writeFile(manifest, ["Ledger", "Reconciled nightly", "Fees may apply"].join("\n"));
+
+    const report = await runCopyCheck({ source: page, manifestPath: manifest });
+    // Visible shadow text satisfies the gate...
+    assert.deepEqual(report.missingLines, [], JSON.stringify(report.issues));
+    // ...but hiding copy inside a shadow root is still not a way to pass.
+    assert.deepEqual(report.invisibleLines.map((l) => l.line), ["Fees may apply"]);
+    assert.equal(report.invisibleLines[0]!.reason, "zero-size");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("disclosure-state sweep reveals details / tab / aria-expanded copy (E2E)", async () => {
   const dir = await mkdtemp(join(tmpdir(), "copy-states-"));
   try {

--- a/packages/vlmkit-markup/src/inspect/copy-check.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-check.ts
@@ -59,9 +59,10 @@ import {
 } from "./copy-target.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
-export type CopyIssueKind = "placeholder-text" | "copy-missing" | "copy-invisible" | "copy-image-mismatch";
+export type CopyIssueKind = "placeholder-text" | "copy-missing" | "copy-invisible" | "copy-image-mismatch" | "redirected";
 
 export interface CopyIssue {
   kind: CopyIssueKind;
@@ -353,7 +354,21 @@ export const COLLECT_TEXT_VISIBILITY = `(() => {
   if (!root) return { visible: "", invisible: [] };
   const parts = [];
   const invisible = [];
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  // Open shadow roots hold real, on-screen text that innerText and a
+  // document-scoped TreeWalker both miss (2026-08-01 hard-target audit: a
+  // custom element's visible badge copy was reported copy-missing). Every
+  // component-library design system puts its text here, so walk into each
+  // open root. Closed roots stay unreachable by construction.
+  const roots = [root];
+  for (let ri = 0; ri < roots.length; ri++) {
+    const scope = roots[ri];
+    if (!scope.querySelectorAll) continue;
+    for (const host of scope.querySelectorAll("*")) {
+      if (host.shadowRoot) roots.push(host.shadowRoot);
+    }
+  }
+  for (const scope of roots) {
+  const walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT);
   let node;
   while ((node = walker.nextNode())) {
     if (!node.data || !node.data.trim()) continue;
@@ -403,7 +418,38 @@ export const COLLECT_TEXT_VISIBILITY = `(() => {
     if (camouflaged(el, cs)) { drop("camouflage"); continue; }
     parts.push(text);
   }
+  }
   return { visible: parts.join("\\n"), invisible };
+})()`;
+
+/**
+ * Raw rendered text, shadow roots included.
+ *
+ * The reason-class boundary rule is "copy-invisible only for text that is
+ * present in raw innerText" — that is what keeps `display: none` content
+ * classified as missing rather than as deliberately hidden. innerText also
+ * stops at shadow boundaries, so hidden copy inside a web component used to
+ * land in the vaguer `copy-missing` bucket. Appending each open shadow
+ * root's children's innerText preserves the rule's semantics exactly:
+ * innerText still omits `display: none` subtrees but still includes
+ * `font-size: 0` text, which is what makes the zero-size class detectable.
+ */
+export const COLLECT_RAW_TEXT = `(() => {
+  const extra = [];
+  const walk = (root) => {
+    if (!root || !root.querySelectorAll) return;
+    for (const el of root.querySelectorAll("*")) {
+      if (!el.shadowRoot) continue;
+      for (const child of el.shadowRoot.children) {
+        if (child.tagName === "STYLE" || child.tagName === "SCRIPT") continue;
+        if (typeof child.innerText === "string") extra.push(child.innerText);
+      }
+      walk(el.shadowRoot);
+    }
+  };
+  const body = document.body;
+  walk(body || document);
+  return [body ? body.innerText : ""].concat(extra).join("\\n");
 })()`;
 
 /** The visible half of COLLECT_TEXT_VISIBILITY (the disclosure sweep only needs this). */
@@ -591,6 +637,7 @@ export async function runCopyCheck(options: CopyCheckOptions): Promise<CopyCheck
   let invisibleChunks: { reason: string; text: string }[];
   let blocks: TextBlock[] = [];
   let stateSweep: StateSweep | undefined;
+  let redirectNote: string | null = null;
   try {
     const page = await browser.newPage({ viewport });
     if (options.html !== undefined) {
@@ -600,7 +647,7 @@ export async function runCopyCheck(options: CopyCheckOptions): Promise<CopyCheck
     } else {
       await page.goto(pathToFileURL(resolve(options.source)).href, { waitUntil: "networkidle", timeout: 30000 });
     }
-    pageText = await page.evaluate("document.body ? document.body.innerText : \"\"") as string;
+    pageText = await page.evaluate(COLLECT_RAW_TEXT) as string;
     ({ visible: visibleText, invisible: invisibleChunks } =
       await page.evaluate(COLLECT_TEXT_VISIBILITY) as { visible: string; invisible: { reason: string; text: string }[] });
     if (target) {
@@ -610,6 +657,10 @@ export async function runCopyCheck(options: CopyCheckOptions): Promise<CopyCheck
     if (options.exploreStates !== false) {
       stateSweep = await sweepDisclosureStates(page);
     }
+    // "Copy missing" on a page you never reached is a misleading verdict:
+    // an auth-walled route 302s to /login and every manifest line reads as
+    // absent. Surface the redirect so the real cause is legible.
+    if (isUrl(options.source)) redirectNote = describeRedirect(options.source, page.url());
     await page.close();
   } finally {
     await browser.close();
@@ -627,6 +678,9 @@ export async function runCopyCheck(options: CopyCheckOptions): Promise<CopyCheck
     ...(manifestLines ? { manifestLines } : {}),
     ...(stateSweep ? { stateSweep } : {}),
   });
+  if (redirectNote) {
+    report.issues.unshift({ kind: "redirected", severity: "suspect", message: redirectNote });
+  }
 
   if (target && options.targetPath) {
     const droppedBlocks = Math.max(0, blocks.length - MAX_REVIEW_ROWS);

--- a/packages/vlmkit-markup/src/inspect/copy-check.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-check.ts
@@ -63,6 +63,7 @@ import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
+import { readEnv } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 export type CopyIssueKind = "placeholder-text" | "copy-missing" | "copy-invisible" | "copy-image-mismatch" | "redirected";
 
@@ -919,7 +920,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     }
     const { createVlmClient, resolveModel } = await import("@mizchi/vlmkit-ai/vlm-client.ts");
     const modelId = vlm === true
-      ? (process.env.VRT_VLM_MODEL ?? "bytedance/ui-tars-1.5-7b")
+      ? (readEnv("VLM_MODEL") ?? "bytedance/ui-tars-1.5-7b")
       : vlm;
     const model = await resolveModel(modelId);
     const client = await createVlmClient(model);

--- a/packages/vlmkit-markup/src/inspect/copy-check.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-check.ts
@@ -58,6 +58,7 @@ import {
   type TextBlock,
 } from "./copy-target.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { applyGateExit } from "@mizchi/vlmkit-core/gate-exit.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
@@ -869,7 +870,7 @@ Options:
   --vlm [model]       Transcribe crops with a VLM (default model: VRT_VLM_MODEL); requires API key
   --no-states         Skip the disclosure-state sweep (default-state text only)
   --json              Print JSON report
-  --fail-on-suspect   Exit non-zero when suspect issues are found`);
+  --advisory          Print findings but exit 0 (default: a suspect exits 1)`);
   process.exit(exitCode);
 }
 
@@ -880,7 +881,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   let outDir: string | undefined;
   let vlm: string | true | undefined;
   let json = false;
-  let failOnSuspect = false;
+  let advisory = false;
   let storageState: string | undefined;
   let exploreStates = true;
   let allowInvisible: InvisibleReason[] | undefined;
@@ -903,7 +904,8 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       }
       allowInvisible = classes as InvisibleReason[];
     } else if (arg === "--json") json = true;
-    else if (arg === "--fail-on-suspect") failOnSuspect = true;
+    else if (arg === "--fail-on-suspect") { /* accepted no-op: suspects already fail */ }
+    else if (arg === "--advisory") advisory = true;
     else if (arg === "--storage-state") storageState = argv[++i];
     else if (!arg.startsWith("-")) positional.push(arg);
   }
@@ -939,7 +941,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   });
   if (json) console.log(JSON.stringify(report, null, 2));
   else console.log(formatCopyCheckReport(report));
-  if (failOnSuspect && report.issues.some((i) => i.severity === "suspect")) process.exit(1);
+  applyGateExit(report.issues.some((i) => i.severity === "suspect"), { advisory });
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "copy-check" ||

--- a/packages/vlmkit-markup/src/inspect/copy-check.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-check.ts
@@ -58,6 +58,7 @@ import {
   type TextBlock,
 } from "./copy-target.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
@@ -591,6 +592,11 @@ export function analyzeCopy(input: {
 }
 
 export interface CopyCheckOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   html?: string;
   manifestPath?: string;
@@ -639,7 +645,7 @@ export async function runCopyCheck(options: CopyCheckOptions): Promise<CopyCheck
   let stateSweep: StateSweep | undefined;
   let redirectNote: string | null = null;
   try {
-    const page = await browser.newPage({ viewport });
+    const page = await browser.newPage(withAuthState({ viewport }, options.storageState));
     if (options.html !== undefined) {
       await page.setContent(options.html, { waitUntil: "networkidle" });
     } else if (isUrl(options.source)) {
@@ -845,6 +851,9 @@ is the user-visible copy spec — keep assistive-tech-only strings out
 of it. Markdown headings in the manifest ("# Section") are organizing
 comments, not required lines.
 
+  --storage-state <file>  Playwright storage state for pages behind a login
+                          (or set VLMKIT_STORAGE_STATE)
+
 Reason classes: zero-size, hidden, transparent, visually-hidden
 (sr-only-style clip/1px box), unreachable (off-screen/clipped),
 camouflage, unknown. When an invisibility is deliberate, accept that
@@ -872,6 +881,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   let vlm: string | true | undefined;
   let json = false;
   let failOnSuspect = false;
+  let storageState: string | undefined;
   let exploreStates = true;
   let allowInvisible: InvisibleReason[] | undefined;
   const positional: string[] = [];
@@ -894,6 +904,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       allowInvisible = classes as InvisibleReason[];
     } else if (arg === "--json") json = true;
     else if (arg === "--fail-on-suspect") failOnSuspect = true;
+    else if (arg === "--storage-state") storageState = argv[++i];
     else if (!arg.startsWith("-")) positional.push(arg);
   }
   if (positional.length === 0) printUsage(1);
@@ -918,6 +929,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 
   const report = await runCopyCheck({
     source: positional[0]!,
+    ...(storageState ? { storageState } : {}),
     ...(manifestPath ? { manifestPath } : {}),
     ...(targetPath ? { targetPath } : {}),
     ...(outDir ? { outDir } : {}),

--- a/packages/vlmkit-markup/src/inspect/explore.ts
+++ b/packages/vlmkit-markup/src/inspect/explore.ts
@@ -2,8 +2,8 @@
 /**
  * Auto-discovered interaction exploration.
  *
- * Where `vrt interact` requires the test author to hand-write a
- * `sequence.json`, `vrt explore` reads the *page's* declaration of
+ * Where `vlmkit inspect interact` requires the test author to hand-write a
+ * `sequence.json`, `vlmkit inspect explore` reads the *page's* declaration of
  * what's interactive. Shaped like Chrome's proposed WebMCP without
  * depending on the spec — opt-in via two complementary mechanisms:
  *
@@ -21,14 +21,14 @@
  *      <details><summary data-vrt-action="disclose-faq">FAQ</summary>…</details>
  *
  * For each discovered action: snapshot baseline, invoke the action,
- * snapshot after, diff. Same downstream signal as `vrt interact` —
+ * snapshot after, diff. Same downstream signal as `vlmkit inspect interact` —
  * pixel diff + heatmap regions + dead-action flag — but the
  * sequence is auto-derived. When WebMCP ships, swap the discovery
  * layer to read its tool registry instead.
  *
  * Usage:
- *   vrt explore <html|url>
- *   vrt explore <html|url> --wait 500    # delay after action before snapshot
+ *   vlmkit inspect explore <html|url>
+ *   vlmkit inspect explore <html|url> --wait 500    # delay after action before snapshot
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -346,7 +346,7 @@ export async function runExplore(options: ExploreOptions): Promise<ExploreReport
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt explore${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit inspect explore${RESET}`);
   console.log(`  ${DIM}source: ${options.source}${RESET}`);
   console.log(`  ${DIM}discovered ${actions.length} action(s)${RESET}`);
   let deadCount = 0;
@@ -489,7 +489,7 @@ function renderReport(r: Omit<ExploreReport, "reportPath">): string {
 }
 
 function printUsage(): void {
-  console.log("Usage: vrt explore <html-or-url> [options]");
+  console.log("Usage: vlmkit inspect explore <html-or-url> [options]");
   console.log("Options:");
   console.log("  --wait <ms>          Delay after each action before snapshot (default: 200)");
   console.log("  --threshold <0..1>   Pixel diff threshold (default: 0.03)");

--- a/packages/vlmkit-markup/src/inspect/flow-verify.ts
+++ b/packages/vlmkit-markup/src/inspect/flow-verify.ts
@@ -26,9 +26,10 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Page } from "playwright";
-import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { handleCliError, UsageError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -92,6 +93,53 @@ export interface FlowVerifyReport {
    * reads as a broken flow rather than a missing session.
    */
   redirected?: string;
+}
+
+export const FLOW_ACTIONS = ["click", "press", "fill", "type", "focus", "hover", "wait"] as const;
+export const FLOW_ASSERTS = ["attr", "visible", "hidden", "focused", "text", "count"] as const;
+
+/**
+ * Reject a malformed flow before opening a browser.
+ *
+ * Measured 2026-08-02, both directions were wrong:
+ *
+ *   {"assert":"visble"}  ->  FAIL (unknown assert)   — a flow-file typo read as
+ *                                                      a page defect
+ *   {"action":"clik"}    ->  done: true              — a flow that performed no
+ *                                                      action at all passed
+ *
+ * The second is the worse one: `runAction`'s switch had no default, so an
+ * unrecognised action fell through silently and the step's post-conditions (none
+ * given) all held. A green verdict from a flow that did nothing.
+ *
+ * `--allow` already refuses an unknown finding kind for exactly this reason. A
+ * gate that cannot tell "your page is wrong" from "your flow file is wrong" is
+ * worse than no gate.
+ */
+export function validateFlow(flow: Flow): void {
+  if (!Array.isArray(flow.steps) || flow.steps.length === 0) {
+    throw new UsageError(`flow has no steps. Expected { "steps": [ { "do": <action>, "expect": [<assert>...] } ] }.`);
+  }
+  flow.steps.forEach((step, i) => {
+    const where = `step ${i}${step.label ? ` ("${step.label}")` : ""}`;
+    const action = (step.do as { action?: string } | undefined)?.action;
+    if (!action) throw new UsageError(`${where} has no "do.action". Valid actions: ${FLOW_ACTIONS.join(", ")}.`);
+    if (!FLOW_ACTIONS.includes(action as (typeof FLOW_ACTIONS)[number])) {
+      throw new UsageError(`${where}: unknown action "${action}". Valid actions: ${FLOW_ACTIONS.join(", ")}.`);
+    }
+    (step.expect ?? []).forEach((spec, j) => {
+      const name = (spec as { assert?: string } | undefined)?.assert;
+      if (!name) {
+        throw new UsageError(`${where}, expect[${j}] has no "assert". Valid asserts: ${FLOW_ASSERTS.join(", ")}.`);
+      }
+      if (!FLOW_ASSERTS.includes(name as (typeof FLOW_ASSERTS)[number])) {
+        throw new UsageError(
+          `${where}, expect[${j}]: unknown assert "${name}". Valid asserts: ${FLOW_ASSERTS.join(", ")}.`
+          + ` This is a flow-file error, not a page defect — it used to be reported as a failing post-condition.`,
+        );
+      }
+    });
+  });
 }
 
 function describeAction(a: FlowAction): string {
@@ -172,6 +220,7 @@ export interface FlowVerifyOptions {
 }
 
 export async function runFlowVerify(options: FlowVerifyOptions): Promise<FlowVerifyReport> {
+  validateFlow(options.flow);
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   const steps: StepResult[] = [];
@@ -180,6 +229,14 @@ export async function runFlowVerify(options: FlowVerifyOptions): Promise<FlowVer
     const page = await browser.newPage(withAuthState({ viewport: options.flow.viewport ?? { width: 1280, height: 800 } }, options.storageState));
     const url = /^(https?|file):\/\//.test(options.source) ? options.source : pathToFileURL(resolve(options.source)).href;
     await page.goto(url, { waitUntil: "load", timeout: 30000 });
+    // Assertions read the DOM through `page.evaluate`, which — unlike a
+    // Playwright action — does not auto-wait. Without this settle a flow
+    // pointed at a client-rendered view asserts against the placeholder:
+    // measured 2026-08-02, `count .card expected 2, measured 0` on a page where
+    // `check layout` measured 2 at the same instant. The failure read as a
+    // markup defect, and the only workaround was for the flow author to guess
+    // at an explicit `{"action":"wait"}` first step.
+    await settlePage(page);
     redirected = /^https?:\/\//.test(options.source)
       ? describeRedirect(options.source, page.url()) ?? undefined
       : undefined;

--- a/packages/vlmkit-markup/src/inspect/flow-verify.ts
+++ b/packages/vlmkit-markup/src/inspect/flow-verify.ts
@@ -27,6 +27,7 @@ import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Page } from "playwright";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -154,6 +155,11 @@ function evalAssertion(spec: FlowAssert): (s: FlowAssert) => [boolean, string] {
 }
 
 export interface FlowVerifyOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   flow: Flow;
 }
@@ -163,7 +169,7 @@ export async function runFlowVerify(options: FlowVerifyOptions): Promise<FlowVer
   const browser = await chromium.launch();
   const steps: StepResult[] = [];
   try {
-    const page = await browser.newPage({ viewport: options.flow.viewport ?? { width: 1280, height: 800 } });
+    const page = await browser.newPage(withAuthState({ viewport: options.flow.viewport ?? { width: 1280, height: 800 } }, options.storageState));
     const url = /^(https?|file):\/\//.test(options.source) ? options.source : pathToFileURL(resolve(options.source)).href;
     await page.goto(url, { waitUntil: "load", timeout: 30000 });
 

--- a/packages/vlmkit-markup/src/inspect/flow-verify.ts
+++ b/packages/vlmkit-markup/src/inspect/flow-verify.ts
@@ -28,6 +28,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import type { Page } from "playwright";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -85,6 +86,12 @@ export interface FlowVerifyReport {
   passed: number;
   total: number;
   done: boolean;
+  /**
+   * Set when the URL redirected — almost always a login wall. A flow driven
+   * against a sign-in page fails on "element not found" for every step, which
+   * reads as a broken flow rather than a missing session.
+   */
+  redirected?: string;
 }
 
 function describeAction(a: FlowAction): string {
@@ -168,10 +175,14 @@ export async function runFlowVerify(options: FlowVerifyOptions): Promise<FlowVer
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   const steps: StepResult[] = [];
+  let redirected: string | undefined;
   try {
     const page = await browser.newPage(withAuthState({ viewport: options.flow.viewport ?? { width: 1280, height: 800 } }, options.storageState));
     const url = /^(https?|file):\/\//.test(options.source) ? options.source : pathToFileURL(resolve(options.source)).href;
     await page.goto(url, { waitUntil: "load", timeout: 30000 });
+    redirected = /^https?:\/\//.test(options.source)
+      ? describeRedirect(options.source, page.url()) ?? undefined
+      : undefined;
 
     for (let i = 0; i < options.flow.steps.length; i++) {
       const step = options.flow.steps[i]!;
@@ -202,19 +213,32 @@ export async function runFlowVerify(options: FlowVerifyOptions): Promise<FlowVer
     await browser.close();
   }
   const passed = steps.filter((s) => s.passed).length;
-  const done = steps.length === options.flow.steps.length && steps.every((s) => s.passed);
+  // Not `done` on a redirect: the flow ran against a page the caller did not
+  // ask for, so passing steps would be a claim about the sign-in screen.
+  const done = steps.length === options.flow.steps.length && steps.every((s) => s.passed) && !redirected;
   appendRunLedger({
     tool: "verify-flow",
     source: options.source,
-    headline: { done, passed, total: options.flow.steps.length },
+    headline: { done, passed, total: options.flow.steps.length, ...(redirected ? { redirected: true } : {}) },
   });
-  return { source: options.source, steps, passed, total: options.flow.steps.length, done };
+  return {
+    source: options.source,
+    steps,
+    passed,
+    total: options.flow.steps.length,
+    done,
+    ...(redirected ? { redirected } : {}),
+  };
 }
 
 export function formatFlowReport(report: FlowVerifyReport): string {
   const lines: string[] = [];
   lines.push(`${BOLD}${CYAN}vlmkit verify flow${RESET}`);
   lines.push(`${DIM}source: ${report.source}${RESET}`);
+  if (report.redirected) {
+    lines.push(`${RED}x ${report.redirected}${RESET}`);
+    lines.push(`${DIM}  Every step below ran against that page.${RESET}`);
+  }
   lines.push("");
   lines.push(`verdict: ${report.done ? `${GREEN}DONE${RESET}` : `${RED}FAILED${RESET}`} (${report.passed}/${report.total} steps)`);
   lines.push("");

--- a/packages/vlmkit-markup/src/inspect/handler-map.ts
+++ b/packages/vlmkit-markup/src/inspect/handler-map.ts
@@ -33,6 +33,7 @@
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { DISCOVER_SCRIPT, settleAfterLoad } from "./interaction-map.ts";
@@ -161,11 +162,11 @@ const COLLECT_SURFACE_SCRIPT = `
 })()
 `;
 
-export async function buildHandlerSurface(options: { source: string }): Promise<HandlerSurface> {
+export async function buildHandlerSurface(options: { source: string; storageState?: string }): Promise<HandlerSurface> {
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   try {
-    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+    const page = await browser.newPage(withAuthState({ viewport: { width: 1280, height: 800 } }, options.storageState));
     await page.addInitScript(HANDLER_PATCH_SCRIPT);
     const url = /^(https?|file):\/\//.test(options.source)
       ? options.source

--- a/packages/vlmkit-markup/src/inspect/handler-map.ts
+++ b/packages/vlmkit-markup/src/inspect/handler-map.ts
@@ -35,7 +35,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
-import { DISCOVER_SCRIPT } from "./interaction-map.ts";
+import { DISCOVER_SCRIPT, settleAfterLoad } from "./interaction-map.ts";
 
 export interface HandlerSurfaceEntry {
   /** Handler types on ancestors that also carry handlers (delegation). */
@@ -171,6 +171,9 @@ export async function buildHandlerSurface(options: { source: string }): Promise<
       ? options.source
       : pathToFileURL(resolve(options.source)).href;
     await page.goto(url, { waitUntil: "load", timeout: 30000 });
+    // Client-rendered pages register their handlers after `load` — without
+    // this the scan inventories the pre-render DOM (see settleAfterLoad).
+    await settleAfterLoad(page);
     await page.evaluate(DISCOVER_SCRIPT); // stamp interactive elements for cross-referencing
     const raw = await page.evaluate(COLLECT_SURFACE_SCRIPT) as {
       elements: HandlerSurfaceEntry[];
@@ -198,7 +201,7 @@ const KEYBOARD_TYPES = new Set(["keydown", "keyup", "keypress"]);
 export const PROBED_TYPES = new Set(["click", "keydown", "keyup", "keypress", "focus", "blur"]);
 
 export interface HandlerIssue {
-  kind: "pointer-only-control" | "unprobed-handler-types";
+  kind: "pointer-only-control" | "unprobed-handler-types" | "delegated-handlers-opaque";
   severity: "warn" | "suspect";
   element: string;
   message: string;
@@ -218,8 +221,15 @@ export function deriveHandlerIssues(surface: HandlerSurface): HandlerIssue[] {
   for (const e of surface.elements) {
     const hasPointer = Object.keys(e.types).some((t) => POINTER_TYPES.has(t));
     const hasKeyboard = Object.keys(e.types).some((t) => KEYBOARD_TYPES.has(t));
-    for (const t of Object.keys(e.types)) {
-      if (!PROBED_TYPES.has(t)) unprobedTypes.add(t);
+    // A framework delegation root registers the ENTIRE event vocabulary
+    // (~80 types) up front, whether the app uses them or not. Listing those
+    // as "unprobed" buries the handful of authored types that a reader
+    // should actually check under a wall of noise, so only count types the
+    // page wired to a specific element.
+    if (Object.keys(e.types).length < 10 || !e.containsInteractive) {
+      for (const t of Object.keys(e.types)) {
+        if (!PROBED_TYPES.has(t)) unprobedTypes.add(t);
+      }
     }
     if (
       hasPointer && !hasKeyboard
@@ -235,6 +245,35 @@ export function deriveHandlerIssues(surface: HandlerSurface): HandlerIssue[] {
         message: `${e.path} "${e.text}" has a ${Object.keys(e.types).filter((t) => POINTER_TYPES.has(t)).join("/")} handler but no role, no keyboard handler, and no interactive descendant — mouse users can operate it, keyboard and assistive-tech users cannot. Give it a role + tabindex + key handling, or move the handler onto a real control.`,
       });
     }
+  }
+  // Disclose the blind spot instead of printing a clean bill of health.
+  // React-style root delegation registers pointer handlers on the
+  // container, not on the elements, so per-element attribution — the whole
+  // basis of pointer-only-control detection — is unavailable. The
+  // 2026-08-01 hard-target audit hit exactly this: a React page with a
+  // `<div onClick>` and no keyboard path reported `status: ok`. A gate that
+  // cannot see a defect class on this page must say so.
+  // React 18/19 attach to the ROOT CONTAINER element, not to document, so
+  // the signature is one element carrying a large, generic slab of event
+  // types while containing the real controls — not a `globals` entry.
+  const isDelegationRoot = (e: HandlerSurfaceEntry) =>
+    Object.keys(e.types).length >= 10 && e.containsInteractive;
+  const roots = surface.elements.filter(isDelegationRoot);
+  const ownPointerHandlers = surface.elements
+    .filter((e) => !isDelegationRoot(e) && Object.keys(e.types).some((t) => POINTER_TYPES.has(t))).length;
+  const delegatedPointerTypes = [
+    ...new Set([
+      ...Object.keys(surface.globals).filter((t) => POINTER_TYPES.has(t)),
+      ...roots.flatMap((r) => Object.keys(r.types).filter((t) => POINTER_TYPES.has(t))),
+    ]),
+  ];
+  if (ownPointerHandlers === 0 && delegatedPointerTypes.length > 0) {
+    issues.push({
+      kind: "delegated-handlers-opaque",
+      severity: "warn",
+      element: "(page)",
+      message: `Pointer handlers are registered only at the delegation root (${delegatedPointerTypes.sort().join(", ")}), with none on individual elements — the signature of framework root delegation (React and similar). Per-element attribution is unavailable, so pointer-only-control detection is BLIND on this page: a clean result here is not evidence that every control is keyboard-operable. Verify the interactive elements with 'check interactions' plus a 'verify flow' script that tabs to and activates them.`,
+    });
   }
   if (unprobedTypes.size > 0) {
     issues.push({

--- a/packages/vlmkit-markup/src/inspect/handler-map.ts
+++ b/packages/vlmkit-markup/src/inspect/handler-map.ts
@@ -35,8 +35,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
-import { DISCOVER_SCRIPT, settleAfterLoad } from "./interaction-map.ts";
+import { DISCOVER_SCRIPT } from "./interaction-map.ts";
 
 export interface HandlerSurfaceEntry {
   /** Handler types on ancestors that also carry handlers (delegation). */
@@ -173,8 +174,8 @@ export async function buildHandlerSurface(options: { source: string; storageStat
       : pathToFileURL(resolve(options.source)).href;
     await page.goto(url, { waitUntil: "load", timeout: 30000 });
     // Client-rendered pages register their handlers after `load` — without
-    // this the scan inventories the pre-render DOM (see settleAfterLoad).
-    await settleAfterLoad(page);
+    // this the scan inventories the pre-render DOM (see settlePage).
+    await settlePage(page);
     await page.evaluate(DISCOVER_SCRIPT); // stamp interactive elements for cross-referencing
     const raw = await page.evaluate(COLLECT_SURFACE_SCRIPT) as {
       elements: HandlerSurfaceEntry[];

--- a/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
@@ -523,6 +523,39 @@ describe("S14c false-positive audit", () => {
     );
   });
 
+  // The second half of the ink-extents work (fixtures/collision-fp-corpus):
+  // a graze — a few characters overlapping across the FULL ink height — was
+  // below the old overlap-area ratio (0.172 vs a 0.25 floor) and went
+  // unreported, while a legitimate line-height:1 stack scored 0.077 and a
+  // designed pull-up 0.137. By ink-overlap FRACTION the same three are
+  // 1.000 / 0.077 / 0.137, so the gate now measures that instead.
+  test("a character-level graze is reported; legitimate stacks stay clean", { timeout: 120_000 }, async () => {
+    const graze = page("ink-graze.html", `
+      <div style="position:relative;height:40px;font:16px ui-monospace,monospace">
+        <span style="position:absolute;left:0px;top:10px;white-space:nowrap">Total: 1,240,000 EUR</span>
+        <span style="position:absolute;left:168px;top:10px;white-space:nowrap">Refunds: 80 EUR</span>
+      </div>`);
+    const hit = await runIntegrityCheck({ source: graze, viewports: ONE_VIEWPORT });
+    assert.equal(
+      hit.findings.filter((f) => f.kind === "text-collision").length, 1,
+      JSON.stringify(hit.findings.map((f) => `${f.kind} ${f.selector}`)),
+    );
+
+    // A solid-set stack (line-height 1, tall metrics) overlaps line boxes by
+    // construction and must stay clean.
+    const solid = page("ink-solid.html", `
+      <div style="font:24px/1 'Noto Sans','DejaVu Sans',Verdana,sans-serif;max-width:560px">
+        <p style="margin:0">Line one of a block set solid.</p>
+        <p style="margin:0">Line two directly beneath it.</p>
+        <p style="margin:0">Line three completes the stack.</p>
+      </div>`);
+    const clean = await runIntegrityCheck({ source: solid, viewports: ONE_VIEWPORT });
+    assert.equal(
+      clean.findings.filter((f) => f.kind === "text-collision").length, 0,
+      JSON.stringify(clean.findings.map((f) => `${f.kind} ${f.selector}`)),
+    );
+  });
+
   test("maxFindings caps text-collision rows (Codex #100 P2)", { timeout: 120_000 }, async () => {
     const rows = Array.from({ length: 5 }, (_, i) =>
       `<p style="position:absolute;top:${20 + i * 40}px;left:20px;width:220px;margin:0">Row ${i} left column text</p>

--- a/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
@@ -513,6 +513,23 @@ test("M14 opaque sibling painted over text is occluded-text", { timeout: 120_000
   assert.ok(!report.findings.some((f) => f.selector === "#clear"));
 });
 
+// The S19 class plus one declaration: decorative art that paints over text
+// but opts out of hit-testing. elementFromPoint skips pointer-events:none,
+// so the probe forces hit-testing back on page-wide while sampling.
+test("M14a2 pointer-events:none decorative overlay is still occluded-text", { timeout: 120_000 }, async () => {
+  const file = page("m14a2.html", `
+    <div style="position:relative;width:600px;height:120px;background:#eee">
+      <p id="covered" style="position:absolute;left:20px;top:40px;color:#111">Covered readout text</p>
+      <div style="position:absolute;left:0;top:20px;width:280px;height:80px;background:#c94;z-index:2;pointer-events:none"></div>
+      <p id="clear" style="position:absolute;left:320px;top:40px;color:#111">Clear readout text</p>
+    </div>
+    <div style="width:600px;height:200px;background:#456;margin-top:12px"></div>`);
+  const report = await runIntegrityCheck({ source: file, viewports: ONE_VIEWPORT });
+  const hit = report.findings.find((f) => f.kind === "occluded-text" && f.selector === "#covered");
+  assert.ok(hit, JSON.stringify(report.findings.map((f) => `${f.kind} ${f.selector}`)));
+  assert.ok(!report.findings.some((f) => f.selector === "#clear"));
+});
+
 test("M14b transparent stretched-link overlay is NOT occluded-text", { timeout: 120_000 }, async () => {
   const file = page("m14b.html", `
     <div style="position:relative;width:400px;height:140px;background:#fff;border:1px solid #ccc;padding:16px">

--- a/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
@@ -590,3 +590,54 @@ test("M14d aria-hidden decorative text under a figure is exempted", { timeout: 1
   assert.ok(!report.findings.some((f) => f.kind === "occluded-text"), JSON.stringify(report.findings));
   assert.ok(report.exempted.some((e) => e.kind === "occluded-text" && /aria-hidden/.test(e.reason)));
 });
+
+// Auth support (2026-08-01 hard-target audit). Before this, pointing a gate
+// at a session-protected route followed the 302 and reported the LOGIN page
+// as CLEAN — a green verdict for a page that never rendered. Now: no
+// session => reported as a defect; with a storage state => the real page is
+// measured, defects and all.
+test("storage state unlocks a session-protected page; without it the redirect is a defect", { timeout: 120_000 }, async () => {
+  const { createServer } = await import("node:http");
+  const server = createServer((req, res) => {
+    const authed = /sid=good/.test(req.headers.cookie || "");
+    if (req.url === "/private" && !authed) {
+      res.writeHead(302, { location: "/login" });
+      return res.end();
+    }
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end(req.url === "/private"
+      ? `<!doctype html><body style="margin:0"><h1>Private figures</h1>
+         <div style="width:900px;background:#eef">wide protected panel</div></body>`
+      : `<!doctype html><body style="margin:0"><h1>Sign in</h1><p>Session required.</p></body>`);
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as { port: number }).port;
+  const url = `http://127.0.0.1:${port}/private`;
+  const stateFile = join(DIR, "auth-state.json");
+  writeFileSync(stateFile, JSON.stringify({
+    cookies: [{
+      name: "sid", value: "good", domain: "127.0.0.1", path: "/",
+      expires: -1, httpOnly: false, secure: false, sameSite: "Lax",
+    }],
+    origins: [],
+  }));
+  try {
+    const anon = await runIntegrityCheck({ source: url, viewports: [{ width: 375, height: 700 }] });
+    assert.equal(anon.verdict, "defects");
+    const redirect = anon.findings.find((f) => f.kind === "redirected");
+    assert.ok(redirect, `expected a redirected finding, got: ${kinds(anon)}`);
+    assert.match(redirect!.message, /login wall/i);
+
+    const authed = await runIntegrityCheck({
+      source: url,
+      viewports: [{ width: 375, height: 700 }],
+      storageState: stateFile,
+    });
+    // The real page was measured: no redirect finding, and its own defect shows.
+    assert.ok(!authed.findings.some((f) => f.kind === "redirected"), JSON.stringify(authed.findings));
+    const overflow = authed.findings.find((f) => f.kind === "page-overflow-x");
+    assert.ok(overflow, `expected the protected page's overflow, got: ${kinds(authed)}`);
+  } finally {
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+});

--- a/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
@@ -320,6 +320,31 @@ describe("S14b mutation battery", () => {
     assert.equal(overflow?.severity, "fail");
   });
 
+  // 2026-08-01 hard-target audit: in a grid shell, one rigid child
+  // stretches the track, so every stretched ancestor and sibling outranks
+  // the culprit by right edge. The kickback named the sidebar and the page
+  // shell — three selectors, none of them the thing to edit. The cause is
+  // now measured (constrain the element, re-read scrollWidth) rather than
+  // guessed from box geometry.
+  test("M7b grid shell: overflow blames the rigid child, not the stretched shell", { timeout: 120_000 }, async () => {
+    const file = page("m7b.html", `
+      <div class="shell" style="display:grid;grid-template-columns:200px 1fr">
+        <nav class="side"><strong>Nav</strong></nav>
+        <main class="main" style="padding:20px">
+          <h1>Report</h1>
+          <p class="lede">Body copy that stretches to whatever the track allows.</p>
+          <div class="rigid" style="width:900px;background:#eef">fixed 900px wide</div>
+        </main>
+      </div>`);
+    const report = await runIntegrityCheck({ source: file, viewports: [{ width: 375, height: 700 }] });
+    const overflow = report.findings.find((f) => f.kind === "page-overflow-x");
+    assert.equal(overflow?.severity, "fail");
+    assert.match(overflow!.message, /caused by:/);
+    assert.match(overflow!.message, /\.rigid/);
+    // The stretched shell must not be presented as the thing to fix.
+    assert.doesNotMatch(overflow!.message, /caused by:[^.]*nav\.side/);
+  });
+
   test("M8 404 stylesheet with no fallback: failed-stylesheet + unstyled-page fail", { timeout: 120_000 }, async () => {
     const file = page("m8.html", `<h1>Heading</h1><p>Body text long enough to paint.</p><a href="#x">a link</a>`,
       `<link rel="stylesheet" href="./missing.css">`);

--- a/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
@@ -556,6 +556,29 @@ describe("S14c false-positive audit", () => {
     );
   });
 
+  // Found by the real-page A/B for the graze gate (2026-08-01): MDN's
+  // collapsed sidebar keeps layout boxes for items inside a CLOSED <details>
+  // (measured 184x56 at y=9137), and stacked hidden items overlap perfectly.
+  // Self-style checks miss it because content-visibility skipping is not
+  // visibility/display/opacity; checkVisibility() is the test that catches it.
+  test("text inside a closed <details> is not a collision candidate", { timeout: 120_000 }, async () => {
+    const file = page("closed-details.html", `
+      <details>
+        <summary>Reference</summary>
+        <ul style="margin:0;padding:0;list-style:none">
+          <li><a href="#a">scroll-padding-block</a></li>
+          <li><a href="#b">scroll-padding-inline</a></li>
+          <li><a href="#c">scroll-margin-block</a></li>
+        </ul>
+      </details>
+      <p>Visible body copy under the collapsed section.</p>`);
+    const report = await runIntegrityCheck({ source: file, viewports: ONE_VIEWPORT });
+    assert.equal(
+      report.findings.filter((f) => f.kind === "text-collision").length, 0,
+      JSON.stringify(report.findings.map((f) => `${f.kind} ${f.selector}`)),
+    );
+  });
+
   test("maxFindings caps text-collision rows (Codex #100 P2)", { timeout: 120_000 }, async () => {
     const rows = Array.from({ length: 5 }, (_, i) =>
       `<p style="position:absolute;top:${20 + i * 40}px;left:20px;width:220px;margin:0">Row ${i} left column text</p>

--- a/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
@@ -494,6 +494,35 @@ describe("S14c false-positive audit", () => {
       `the missing @import child itself is still reported: ${JSON.stringify(report.findings.map((f) => `${f.kind} ${f.message}`))}`);
   });
 
+  // Found by fixtures/collision-fp-corpus (2026-08-01): the kicker/heading
+  // pull-up is idiomatic markup whose line BOXES overlap 7px while the
+  // glyphs keep a measured 2px gap — the box test called it a collision.
+  // Blocks are now shrunk to their measured ink band before the overlap
+  // test, which can only remove findings.
+  test("designed negative leading and pull-ups are not collisions; real overlap still is", { timeout: 120_000 }, async () => {
+    const pullUp = page("ink-pullup.html", `
+      <p class="kicker" style="font-size:13px;text-transform:uppercase;letter-spacing:.08em;color:#5b6270;margin:0">Quarterly report</p>
+      <h1 style="font-size:40px;margin:-0.18em 0 0.4em">Settlement volume grew nineteen percent</h1>
+      <p style="max-width:620px">A lede paragraph under the heading.</p>`);
+    const clean = await runIntegrityCheck({ source: pullUp, viewports: ONE_VIEWPORT });
+    assert.equal(
+      clean.findings.filter((f) => f.kind === "text-collision").length, 0,
+      JSON.stringify(clean.findings.map((f) => `${f.kind} ${f.selector}`)),
+    );
+
+    // The filter must not blind the gate: a genuine overlap still fails.
+    const real = page("ink-real.html", `
+      <div style="position:relative;height:60px;font:16px monospace">
+        <span style="position:absolute;left:0;top:20px">Total: 1,240,000 EUR</span>
+        <span style="position:absolute;left:60px;top:24px">Refunds: 80 EUR</span>
+      </div>`);
+    const dirty = await runIntegrityCheck({ source: real, viewports: ONE_VIEWPORT });
+    assert.ok(
+      dirty.findings.some((f) => f.kind === "text-collision"),
+      JSON.stringify(dirty.findings.map((f) => f.kind)),
+    );
+  });
+
   test("maxFindings caps text-collision rows (Codex #100 P2)", { timeout: 120_000 }, async () => {
     const rows = Array.from({ length: 5 }, (_, i) =>
       `<p style="position:absolute;top:${20 + i * 40}px;left:20px;width:220px;margin:0">Row ${i} left column text</p>

--- a/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.test.ts
@@ -584,6 +584,27 @@ test("M14a2 pointer-events:none decorative overlay is still occluded-text", { ti
   assert.ok(!report.findings.some((f) => f.selector === "#clear"));
 });
 
+// Found on a real authenticated app (2026-08-01 Swag Labs audit): the
+// styled-select pattern layers a native <select> at opacity 0.001 over a
+// visible span so the control keeps native keyboard/AT behaviour while the
+// span carries the styling. Its background-color alpha is 1, so an
+// alpha-only opacity test called that invisible overlay an opaque occluder.
+test("M14b2 an opacity:0.001 overlay (styled-select pattern) is NOT an occluder", { timeout: 120_000 }, async () => {
+  const file = page("m14b2.html", `
+    <div style="position:relative;width:300px;height:40px">
+      <span class="active_option" style="position:absolute;left:8px;top:10px;color:#111">Name (A to Z)</span>
+      <select class="sorter" style="position:absolute;inset:0;width:100%;opacity:0.001;background:#efefef">
+        <option>Name (A to Z)</option><option>Price (low to high)</option>
+      </select>
+    </div>
+    <div style="width:600px;height:200px;background:#456;margin-top:12px"></div>`);
+  const report = await runIntegrityCheck({ source: file, viewports: ONE_VIEWPORT });
+  assert.ok(
+    !report.findings.some((f) => f.kind === "occluded-text"),
+    JSON.stringify(report.findings.map((f) => `${f.kind} ${f.selector}`)),
+  );
+});
+
 test("M14b transparent stretched-link overlay is NOT occluded-text", { timeout: 120_000 }, async () => {
   const file = page("m14b.html", `
     <div style="position:relative;width:400px;height:140px;background:#fff;border:1px solid #ccc;padding:16px">

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -866,7 +866,25 @@ export const COLLECT_OCCLUSIONS = `(() => {
     return p.length >= 4 ? p[3] : 1;
   };
   const OPAQUE_TAGS = new Set(["IMG", "CANVAS", "VIDEO", "SVG", "PICTURE"]);
+  // Effective opacity: CSS opacity multiplies down the ancestor chain, and an
+  // element that paints nothing cannot occlude anything. Found on a real
+  // authenticated app (2026-08-01 Swag Labs audit): the styled-select pattern
+  // puts a native <select> with opacity 0.001 over a visible span, and its
+  // background-color alpha is 1 — so an alpha-only test called a deliberately
+  // invisible overlay an opaque occluder.
+  const effectiveOpacity = (el) => {
+    let o = 1;
+    for (let p = el; p && p.nodeType === 1; p = p.parentElement) {
+      const cs = getComputedStyle(p);
+      if (cs.visibility === "hidden" || cs.display === "none") return 0;
+      const v = parseFloat(cs.opacity);
+      if (Number.isFinite(v)) o *= v;
+      if (o < 0.05) return o;
+    }
+    return o;
+  };
   const paintsOpaquely = (el) => {
+    if (effectiveOpacity(el) < 0.5) return false;
     if (OPAQUE_TAGS.has(el.tagName)) return true;
     const cs = getComputedStyle(el);
     if ((cs.backgroundImage || "none") !== "none") return true;

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -1061,6 +1061,13 @@ export const COLLECT_INTEGRITY_TEXT = `(() => {
     if (!el || SKIP.has(el.tagName)) continue;
     const style = getComputedStyle(el);
     if (style.visibility === "hidden" || style.display === "none" || style.opacity === "0") continue;
+    // Self-style checks miss content-visibility skipping, which is how a
+    // CLOSED <details> hides its subtree: the descendants keep layout boxes
+    // (measured 184x56 at y=9137 inside MDN's collapsed sidebar) while being
+    // invisible. Stacked hidden items overlap perfectly, so they read as
+    // collisions. checkVisibility() is the only reliable test for it.
+    if (typeof el.checkVisibility === "function"
+      && !el.checkVisibility({ visibilityProperty: true, opacityProperty: true, contentVisibilityAuto: true })) continue;
     let block = el;
     while (block && block !== document.body) {
       const d = getComputedStyle(block).display;

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -39,6 +39,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { PNG } from "pngjs";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { extractComponentsFromRgba } from "../component/component-bbox.ts";
 import { analyzeScrollSamples, COLLECT_SCROLL_SCRIPT, type ScrollScanInput } from "./scroll-scan.ts";
@@ -60,7 +61,8 @@ export type IntegrityFindingKind =
   | "invisible-text"
   | "low-contrast-text"
   | "near-misalignment"
-  | "occluded-text";
+  | "occluded-text"
+  | "redirected";
 
 export interface IntegrityFinding {
   kind: IntegrityFindingKind;
@@ -1408,6 +1410,18 @@ export async function runIntegrityCheck(options: IntegrityOptions): Promise<Inte
       // there are no webfonts (already-resolved promise).
       await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => undefined) : undefined));
       await page.waitForTimeout(250); // let post-load timers throw before judging
+
+      // Never report on a URL we did not measure. An auth-walled route
+      // 302s to /login and everything below would judge the login page —
+      // previously yielding a CLEAN verdict for a page that never
+      // rendered. Fail, don't warn: a green gate on the wrong page is the
+      // worst outcome this tool can produce.
+      if (vi === 0) {
+        const redirect = describeRedirect(url, page.url());
+        if (redirect) {
+          push([{ kind: "redirected", severity: "fail", viewport: viewport.width, message: redirect }]);
+        }
+      }
 
       // A1
       push(classifyRuntimeEvents(events, viewport.width));

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -38,6 +38,7 @@ import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { PNG } from "pngjs";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
@@ -1332,6 +1333,11 @@ export const COLLECT_STYLE_FINGERPRINT = `(() => {
 // Runner
 
 export interface IntegrityOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   /** Sweep widths (default 1280, 768, 375). */
   viewports?: { width: number; height: number }[];
@@ -1379,7 +1385,7 @@ export async function runIntegrityCheck(options: IntegrityOptions): Promise<Inte
     const url = isUrl(options.source) ? options.source : pathToFileURL(resolve(options.source)).href;
     for (let vi = 0; vi < viewports.length; vi++) {
       const viewport = viewports[vi]!;
-      const page = await browser.newPage({ viewport });
+      const page = await browser.newPage(withAuthState({ viewport }, options.storageState));
       const events: RuntimeEvent[] = [];
       const netFailures: NetworkFailure[] = [];
       let loaded = false;
@@ -1608,6 +1614,8 @@ Options:
   --viewports <w,w,...>  Sweep widths (default: 1280,768,375)
   --max-findings <n>     Per-class report cap (default: 12)
   --json                 Print JSON report
+  --storage-state <file> Playwright storage state, to measure pages behind
+                         a login (or set VLMKIT_STORAGE_STATE)
 Exit code is non-zero when the verdict is "defects".`);
   process.exit(exitCode);
 }
@@ -1617,11 +1625,13 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   let json = false;
   let maxFindings: number | undefined;
   let widths: number[] | undefined;
+  let storageState: string | undefined;
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--json") json = true;
     else if (arg === "--max-findings") maxFindings = Number.parseInt(argv[++i] ?? "12", 10);
+    else if (arg === "--storage-state") storageState = argv[++i];
     else if (arg === "--viewports") {
       widths = (argv[++i] ?? "").split(",").map((w) => Number.parseInt(w, 10)).filter((w) => w > 0);
       if (widths.length === 0) printUsage(1);
@@ -1634,6 +1644,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     source,
     ...(widths ? { viewports: widths.map((w) => ({ width: w, height: heights[w] ?? 800 })) } : {}),
     ...(maxFindings !== undefined ? { maxFindings } : {}),
+    ...(storageState ? { storageState } : {}),
   });
   if (json) console.log(JSON.stringify(report, null, 2));
   else console.log(formatIntegrityReport(report));

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -346,6 +346,15 @@ export interface IntegrityTextBlock {
   zIndex: number;
   /** Inside an aria-hidden="true" subtree (decorative). */
   ariaHidden: boolean;
+  /**
+   * Vertical slack (px) between this block's line box and the actual glyph
+   * ink inside it, per edge — half of (line-box height - (ascent+descent))
+   * from canvas font metrics. Used to shrink boxes to their ink band before
+   * the overlap test, which is what keeps a `line-height: 0.8` or negative
+   * `margin-bottom` pull-up from reading as a collision. Absent (0) when
+   * the metrics were unavailable.
+   */
+  inkInset?: number;
 }
 
 export interface TextCollisionOptions {
@@ -377,16 +386,33 @@ export function findTextCollisions(
       // One block containing the other is nesting (a wrapper block whose
       // own text and a child block both bucketed), not a collision.
       const ox = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x);
-      const oy = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y);
+      // Compare INK bands vertically, not line boxes. Designed negative
+      // leading (`line-height: 0.8`) and the kicker/heading pull-up
+      // (`margin-bottom: -0.15em`) overlap boxes by several px while the
+      // glyphs keep a clear gap — measured 2px on the kicker idiom, which
+      // this gate used to report as a collision. Shrinking each block to its
+      // measured ink band can only REMOVE findings, so it carries none of
+      // the cry-wolf risk of lowering the floor itself.
+      const aInk = a.inkInset ?? 0;
+      const bInk = b.inkInset ?? 0;
+      const aTop = a.y + aInk, aBottom = a.y + a.height - aInk;
+      const bTop = b.y + bInk, bBottom = b.y + b.height - bInk;
+      const oy = Math.min(aBottom, bBottom) - Math.max(aTop, bTop);
       if (ox < minPx || oy < minPx) continue;
       const contains = (o: IntegrityTextBlock, p: IntegrityTextBlock) =>
         o.x <= p.x && o.y <= p.y && o.x + o.width >= p.x + p.width && o.y + o.height >= p.y + p.height;
       if (contains(a, b) || contains(b, a)) continue;
       const area = ox * oy;
-      const smaller = Math.min(a.width * a.height, b.width * b.height);
+      // Both sides of the ratio must use the SAME units. Measuring overlap
+      // on the ink band while dividing by the box area silently tightened
+      // the gate (a real collision fell from 0.32 to 0.19 and vanished), so
+      // the denominator is the ink band too.
+      const aInkArea = a.width * Math.max(1, a.height - 2 * aInk);
+      const bInkArea = b.width * Math.max(1, b.height - 2 * bInk);
+      const smaller = Math.min(aInkArea, bInkArea);
       if (smaller <= 0 || area / smaller < minRatio) continue;
 
-      const pair = { a, b, ox, oy, area };
+      const pair = { a, b, ox, oy: Math.round(oy * 10) / 10, area };
       if (a.ariaHidden || b.ariaHidden) {
         exempted.push({
           kind: "text-collision",
@@ -970,6 +996,27 @@ export function findOccludedText(
 }
 
 export const COLLECT_INTEGRITY_TEXT = `(() => {
+  // Glyph ink is smaller than the line box it sits in. Measure the slack so
+  // the collision test can compare ink bands instead of boxes: a designed
+  // negative-leading or pull-up overlaps boxes while the glyphs keep a clear
+  // gap (measured 2px on the kicker/heading idiom, which the box test
+  // reported as a collision).
+  const inkCtx = (() => { try { return document.createElement("canvas").getContext("2d"); } catch { return null; } })();
+  const inkInsetOf = (el, text) => {
+    if (!inkCtx || !text) return 0;
+    try {
+      const cs = getComputedStyle(el);
+      inkCtx.font = [cs.fontStyle, cs.fontWeight, cs.fontSize, cs.fontFamily].filter(Boolean).join(" ");
+      const m = inkCtx.measureText(text.slice(0, 200));
+      const ink = (m.actualBoundingBoxAscent || 0) + (m.actualBoundingBoxDescent || 0);
+      if (!(ink > 0)) return 0;
+      const fontSize = parseFloat(cs.fontSize) || 0;
+      const lh = cs.lineHeight === "normal" ? fontSize * 1.2 : (parseFloat(cs.lineHeight) || fontSize);
+      // Never claim more slack than the box has, never negative (tight
+      // leading makes lh < ink, i.e. zero slack rather than anti-slack).
+      return Math.max(0, Math.min((lh - ink) / 2, fontSize * 0.5));
+    } catch { return 0; }
+  };
   ${STABLE_SELECTOR_FN}
   const SKIP = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE"]);
   const buckets = new Map();
@@ -1027,6 +1074,7 @@ export const COLLECT_INTEGRITY_TEXT = `(() => {
       overlay: b.overlay,
       zIndex: b.zIndex,
       ariaHidden: b.ariaHidden,
+      inkInset: inkInsetOf(b.el, b.parts.join(" ")),
     }))
     .filter((t) => t.text.length > 0 && t.width > 1 && t.height > 1)
     .sort((a, b) => a.y - b.y || a.x - b.x);

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -358,9 +358,22 @@ export interface IntegrityTextBlock {
 }
 
 export interface TextCollisionOptions {
-  /** Minimum overlap on each axis (px) before a pair is considered. Default 6. */
+  /** Minimum horizontal ink overlap (px) before a pair is considered. Default 6. */
   minOverlapPx?: number;
-  /** Overlap area / smaller-block area ratio to count as collision. Default 0.25. */
+  /**
+   * Vertical ink overlap as a fraction of the SHORTER block's ink height.
+   * Default 0.5 — the two glyph bands must genuinely sit on top of each
+   * other, not merely graze.
+   *
+   * This replaced an overlap-area / smaller-block-area ratio (0.25), which
+   * measured the wrong thing: the corpus in
+   * fixtures/collision-fp-corpus shows a real 25x12px graze scoring 0.172
+   * by area while a legitimate `line-height: 1` stack scores 0.077 and a
+   * designed pull-up 0.137 — overlapping populations. By ink fraction the
+   * same three are 1.000 / 0.077 / 0.137: a 7x gap around this threshold.
+   */
+  minInkOverlapFraction?: number;
+  /** @deprecated Superseded by minInkOverlapFraction; accepted and ignored. */
   minOverlapRatio?: number;
   maxFindings?: number;
 }
@@ -375,7 +388,7 @@ export function findTextCollisions(
   options: TextCollisionOptions = {},
 ): { findings: IntegrityFinding[]; exempted: IntegrityExemption[] } {
   const minPx = options.minOverlapPx ?? 6;
-  const minRatio = options.minOverlapRatio ?? 0.25;
+  const minInkFraction = options.minInkOverlapFraction ?? 0.5;
   const maxFindings = options.maxFindings ?? 12;
   const raw: { a: IntegrityTextBlock; b: IntegrityTextBlock; ox: number; oy: number; area: number }[] = [];
   const exempted: IntegrityExemption[] = [];
@@ -403,14 +416,15 @@ export function findTextCollisions(
         o.x <= p.x && o.y <= p.y && o.x + o.width >= p.x + p.width && o.y + o.height >= p.y + p.height;
       if (contains(a, b) || contains(b, a)) continue;
       const area = ox * oy;
-      // Both sides of the ratio must use the SAME units. Measuring overlap
-      // on the ink band while dividing by the box area silently tightened
-      // the gate (a real collision fell from 0.32 to 0.19 and vanished), so
-      // the denominator is the ink band too.
-      const aInkArea = a.width * Math.max(1, a.height - 2 * aInk);
-      const bInkArea = b.width * Math.max(1, b.height - 2 * bInk);
-      const smaller = Math.min(aInkArea, bInkArea);
-      if (smaller <= 0 || area / smaller < minRatio) continue;
+      // Require the glyph bands to genuinely intersect vertically, measured
+      // against the shorter block's ink height. An area ratio cannot express
+      // this: a real graze and a designed negative-leading stack land in the
+      // same range by area, but are 1.000 vs 0.077-0.137 by ink fraction.
+      const minInkHeight = Math.min(
+        Math.max(1, a.height - 2 * aInk),
+        Math.max(1, b.height - 2 * bInk),
+      );
+      if (oy < Math.max(2, minInkFraction * minInkHeight)) continue;
 
       const pair = { a, b, ox, oy: Math.round(oy * 10) / 10, area };
       if (a.ariaHidden || b.ariaHidden) {

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -40,6 +40,12 @@ import { PNG } from "pngjs";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import {
+  ALLOW_HELP,
+  applyAllowRules,
+  type IntegrityAllowRule,
+  parseAllowRules,
+} from "./integrity-exemption.ts";
 import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { extractComponentsFromRgba } from "../component/component-bbox.ts";
@@ -100,6 +106,12 @@ export interface IntegrityViewportStats {
 export interface IntegrityReport {
   source: string;
   verdict: "clean" | "defects";
+  /**
+   * `--allow` rules that matched nothing this run. Surfaced so an exemption
+   * outliving the pattern it covered gets deleted instead of quietly widening
+   * the blind spot.
+   */
+  unusedAllowRules?: IntegrityAllowRule[];
   findings: IntegrityFinding[];
   exempted: IntegrityExemption[];
   viewports: IntegrityViewportStats[];
@@ -1430,6 +1442,11 @@ export interface IntegrityOptions {
   viewports?: { width: number; height: number }[];
   maxFindings?: number;
   collision?: TextCollisionOptions;
+  /**
+   * User-declared exemptions for intentional patterns. Matched findings move
+   * into `exempted` with the caller's reason; see integrity-exemption.ts.
+   */
+  allow?: readonly IntegrityAllowRule[];
 }
 
 export const DEFAULT_INTEGRITY_VIEWPORTS = [
@@ -1634,6 +1651,14 @@ export async function runIntegrityCheck(options: IntegrityOptions): Promise<Inte
     await browser.close();
   }
 
+  // User exemptions apply BEFORE the verdict, and every exempted finding is
+  // moved into `exempted` rather than dropped — the suppression stays visible in
+  // the report and in --json.
+  const allowed = applyAllowRules(findings, options.allow ?? []);
+  findings.length = 0;
+  findings.push(...allowed.findings);
+  exempted.push(...allowed.exempted);
+
   const order: Record<"fail" | "warn", number> = { fail: 0, warn: 1 };
   findings.sort((a, b) => order[a.severity] - order[b.severity] || a.viewport - b.viewport);
   const kickback = findings.map((f) =>
@@ -1649,7 +1674,15 @@ export async function runIntegrityCheck(options: IntegrityOptions): Promise<Inte
       exempted: exempted.length,
     },
   });
-  return { source: options.source, verdict, findings, exempted, viewports: stats, kickback };
+  return {
+    source: options.source,
+    verdict,
+    findings,
+    exempted,
+    viewports: stats,
+    kickback,
+    ...(allowed.unusedRules.length > 0 ? { unusedAllowRules: allowed.unusedRules } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1678,12 +1711,31 @@ export function formatIntegrityReport(report: IntegrityReport): string {
     lines.push(`${GREEN}No integrity defects detected.${RESET}`);
   }
   if (report.exempted.length > 0) {
-    lines.push("");
-    lines.push(`Exempted candidates (the tool's call — audit the rule, not the page):`);
-    for (const e of report.exempted.slice(0, 15)) {
-      lines.push(`  ${DIM}- [${e.kind}] ${e.selector ?? ""} @${e.viewport}: ${e.reason}${RESET}`);
+    const user = report.exempted.filter((e) => e.reason.startsWith("user exemption"));
+    const tool = report.exempted.filter((e) => !e.reason.startsWith("user exemption"));
+    // Split by who decided. A reviewer auditing a tool exemption is checking the
+    // rule; auditing a user exemption is checking a colleague's judgement call,
+    // and conflating the two hides which is which.
+    for (const [label, rows] of [
+      ["Exempted candidates (the tool's call — audit the rule, not the page)", tool],
+      ["Exempted by --allow (your call — the finding was real and accepted)", user],
+    ] as const) {
+      if (rows.length === 0) continue;
+      lines.push("");
+      lines.push(`${label}:`);
+      for (const e of rows.slice(0, 15)) {
+        lines.push(`  ${DIM}- [${e.kind}] ${e.selector ?? ""} @${e.viewport}: ${e.reason}${RESET}`);
+      }
+      if (rows.length > 15) lines.push(`  ${DIM}… ${rows.length - 15} more${RESET}`);
     }
-    if (report.exempted.length > 15) lines.push(`  ${DIM}… ${report.exempted.length - 15} more${RESET}`);
+  }
+  if (report.unusedAllowRules && report.unusedAllowRules.length > 0) {
+    lines.push("");
+    lines.push(`${YELLOW}${report.unusedAllowRules.length} --allow rule(s) matched nothing${RESET}`);
+    for (const r of report.unusedAllowRules) {
+      lines.push(`  ${DIM}- ${r.raw}${RESET}`);
+    }
+    lines.push(`${DIM}Delete them: an exemption kept past the pattern it covered only widens the blind spot.${RESET}`);
   }
   return lines.join("\n");
 }
@@ -1703,6 +1755,7 @@ Options:
   --json                 Print JSON report
   --storage-state <file> Playwright storage state, to measure pages behind
                          a login (or set VLMKIT_STORAGE_STATE)
+${ALLOW_HELP}
 Exit code is non-zero when the verdict is "defects".`);
   process.exit(exitCode);
 }
@@ -1713,12 +1766,14 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   let maxFindings: number | undefined;
   let widths: number[] | undefined;
   let storageState: string | undefined;
+  const allowSpecs: string[] = [];
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--json") json = true;
     else if (arg === "--max-findings") maxFindings = Number.parseInt(argv[++i] ?? "12", 10);
     else if (arg === "--storage-state") storageState = argv[++i];
+    else if (arg === "--allow") allowSpecs.push(argv[++i] ?? "");
     else if (arg === "--viewports") {
       widths = (argv[++i] ?? "").split(",").map((w) => Number.parseInt(w, 10)).filter((w) => w > 0);
       if (widths.length === 0) printUsage(1);
@@ -1727,11 +1782,15 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   const source = positional[0];
   if (!source) printUsage(1);
   const heights: Record<number, number> = { 1280: 800, 768: 900, 375: 700 };
+  // Parsed before the browser starts, so a typo in an exemption fails in
+  // milliseconds instead of after a three-viewport sweep.
+  const allow = parseAllowRules(allowSpecs);
   const report = await runIntegrityCheck({
     source,
     ...(widths ? { viewports: widths.map((w) => ({ width: w, height: heights[w] ?? 800 })) } : {}),
     ...(maxFindings !== undefined ? { maxFindings } : {}),
     ...(storageState ? { storageState } : {}),
+    ...(allow.length > 0 ? { allow } : {}),
   });
   if (json) console.log(JSON.stringify(report, null, 2));
   else console.log(formatIntegrityReport(report));

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -799,6 +799,16 @@ const STABLE_SELECTOR_FN = `
 // is what kept this probe demand-gated until a real case appeared.
 // Coverage note: samples only what is inside the viewport at load (no
 // scroll sweep), which matches how the defect class was observed.
+//
+// Hit-testing has one blind spot that has to be closed deliberately:
+// `elementFromPoint` skips `pointer-events: none` elements, and that is
+// exactly how decorative overlays are built (gradient scrims, absolutely
+// positioned SVG/CSS art, ::before washes). An occluder that paints over
+// text but opts out of hit-testing would be invisible to the probe — the
+// S19 defect class with one extra declaration. So sampling runs with
+// pointer-events forced back on page-wide, then restores. False positives
+// stay closed by the opaque-paint requirement: a transparent click-catcher
+// now hit-tests on top but still never flags.
 
 export interface OcclusionCandidate {
   selector: string;
@@ -834,6 +844,12 @@ export const COLLECT_OCCLUSIONS = `(() => {
     return alphaOf(cs.backgroundColor) >= 0.5;
   };
   const out = [];
+  // Force hit-testing back on so pointer-events:none overlays are visible
+  // to elementFromPoint (see the note above). Removed in the finally.
+  const peOverride = document.createElement("style");
+  peOverride.textContent = "*, *::before, *::after { pointer-events: auto !important; }";
+  document.head.appendChild(peOverride);
+  try {
   const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
   let node;
   while ((node = walker.nextNode())) {
@@ -908,6 +924,9 @@ export const COLLECT_OCCLUSIONS = `(() => {
     }
   }
   return out;
+  } finally {
+    peOverride.remove();
+  }
 })()`;
 
 export function findOccludedText(
@@ -1382,6 +1401,12 @@ export async function runIntegrityCheck(options: IntegrityOptions): Promise<Inte
         }
       });
       await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+      // Network idle is not font-ready: with `font-display: swap` the text
+      // reflows AFTER idle, so every geometry probe below would measure
+      // fallback metrics on some runs and webfont metrics on others — the
+      // exact non-determinism the gate promises not to have. Cheap when
+      // there are no webfonts (already-resolved promise).
+      await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => undefined) : undefined));
       await page.waitForTimeout(250); // let post-load timers throw before judging
 
       // A1

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -75,8 +75,18 @@ export interface IntegrityFinding {
   kind: IntegrityFindingKind;
   /** fail = defect (flips the verdict); warn = suspicious but not conclusive. */
   severity: "fail" | "warn";
-  /** Viewport width the finding was first observed at. */
+  /**
+   * Canonical viewport width for this finding: the WIDEST width it was observed
+   * at. Widest rather than "first swept" because the sweep is sorted internally
+   * — attribution must not depend on the order the caller listed its widths in.
+   */
   viewport: number;
+  /**
+   * Every swept width where this finding appeared, widest first. A defect
+   * present everywhere reads very differently from a mobile-only one, and the
+   * single `viewport` field could not tell them apart.
+   */
+  viewports?: number[];
   selector?: string;
   message: string;
   evidence?: Record<string, unknown>;
@@ -1469,18 +1479,31 @@ function dedupeKey(f: IntegrityFinding): string {
 }
 
 export async function runIntegrityCheck(options: IntegrityOptions): Promise<IntegrityReport> {
-  const viewports = options.viewports ?? DEFAULT_INTEGRITY_VIEWPORTS;
+  // Sorted widest-first, whatever order the caller gave. Findings are deduped
+  // across the sweep, so the retained one used to be whichever width came
+  // first: `--viewports 375,768,1280` attributed a page-wide defect to 375 and
+  // `1280,768,375` to 1280. That made `--allow "...@1280"` silently
+  // order-dependent, and read as "mobile only" for something present everywhere.
+  const viewports = [...(options.viewports ?? DEFAULT_INTEGRITY_VIEWPORTS)]
+    .sort((a, b) => b.width - a.width);
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   const findings: IntegrityFinding[] = [];
   const exempted: IntegrityExemption[] = [];
   const stats: IntegrityViewportStats[] = [];
-  const seen = new Set<string>();
+  // key -> the retained finding, so a repeat at a narrower width records its
+  // width instead of being dropped without trace.
+  const seen = new Map<string, IntegrityFinding>();
   const push = (list: IntegrityFinding[]) => {
     for (const f of list) {
       const key = dedupeKey(f);
-      if (seen.has(key)) continue;
-      seen.add(key);
+      const existing = seen.get(key);
+      if (existing) {
+        existing.viewports ??= [existing.viewport];
+        if (!existing.viewports.includes(f.viewport)) existing.viewports.push(f.viewport);
+        continue;
+      }
+      seen.set(key, f);
       findings.push(f);
     }
   };
@@ -1662,7 +1685,9 @@ export async function runIntegrityCheck(options: IntegrityOptions): Promise<Inte
   const order: Record<"fail" | "warn", number> = { fail: 0, warn: 1 };
   findings.sort((a, b) => order[a.severity] - order[b.severity] || a.viewport - b.viewport);
   const kickback = findings.map((f) =>
-    `[${f.kind}]${f.selector ? ` ${f.selector}` : ""} (viewport ${f.viewport}): ${f.message}`);
+    `[${f.kind}]${f.selector ? ` ${f.selector}` : ""} (viewport ${
+      f.viewports && f.viewports.length > 1 ? f.viewports.join(",") : f.viewport
+    }): ${f.message}`);
   const verdict = findings.some((f) => f.severity === "fail") ? "defects" : "clean";
   appendRunLedger({
     tool: "integrity-check",
@@ -1704,7 +1729,10 @@ export function formatIntegrityReport(report: IntegrityReport): string {
     lines.push("Findings:");
     for (const f of report.findings) {
       const icon = f.severity === "fail" ? `${RED}x${RESET}` : `${YELLOW}!${RESET}`;
-      lines.push(`  ${icon} [${f.kind}]${f.selector ? ` ${f.selector}` : ""} @${f.viewport}: ${f.message}`);
+      // Show every width it appeared at: "@1280" and "@1280,768,375" are
+      // different bugs to fix, and the caller cannot tell them apart otherwise.
+      const at = f.viewports && f.viewports.length > 1 ? f.viewports.join(",") : String(f.viewport);
+      lines.push(`  ${icon} [${f.kind}]${f.selector ? ` ${f.selector}` : ""} @${at}: ${f.message}`);
     }
   } else {
     lines.push("");

--- a/packages/vlmkit-markup/src/inspect/integrity-exemption.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-exemption.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { IntegrityFinding } from "./integrity-check.ts";
+import {
+  applyAllowRules,
+  parseAllowRule,
+  parseAllowRules,
+  ruleMatches,
+} from "./integrity-exemption.ts";
+
+const finding = (over: Partial<IntegrityFinding> = {}): IntegrityFinding => ({
+  kind: "near-misalignment",
+  severity: "warn",
+  viewport: 1280,
+  selector: "main>div.card>button.btn-b",
+  message: "off by 2px",
+  ...over,
+});
+
+describe("parseAllowRule", () => {
+  it("parses kind, selector, viewport and reason", () => {
+    assert.deepEqual(parseAllowRule("text-collision@.kicker@1280;deliberate pull-up"), {
+      kind: "text-collision",
+      selector: ".kicker",
+      viewport: 1280,
+      reason: "deliberate pull-up",
+      raw: "text-collision@.kicker@1280;deliberate pull-up",
+    });
+  });
+
+  it("accepts a selector containing an ID", () => {
+    // `#` was the original reason delimiter, which split at the selector's own
+    // `#` and silently produced an empty selector — a far broader exemption than
+    // the one written.
+    const rule = parseAllowRule("text-collision@#refund;the labels are meant to graze");
+    assert.equal(rule.selector, "#refund");
+    assert.equal(rule.reason, "the labels are meant to graze");
+  });
+
+  it("keeps later semicolons in the reason", () => {
+    assert.equal(parseAllowRule("invisible-text@.sr;a; b; c").reason, "a; b; c");
+  });
+
+  it("treats kind-only as every selector and viewport", () => {
+    const rule = parseAllowRule("low-contrast-text;brand grey signed off");
+    assert.equal(rule.selector, undefined);
+    assert.equal(rule.viewport, undefined);
+  });
+
+  it("requires a reason, and points at the right delimiter", () => {
+    assert.throws(() => parseAllowRule("text-collision@.kicker"), /needs a reason/);
+    assert.throws(
+      () => parseAllowRule("text-collision@#refund#because"),
+      /separated by ";", not "#"/,
+    );
+    assert.throws(() => parseAllowRule("text-collision;   "), /reason is empty/);
+  });
+
+  it("rejects an unknown kind rather than silencing nothing", () => {
+    // A typo that quietly exempts nothing is the worst outcome for a
+    // suppression flag: it looks applied and changes nothing.
+    assert.throws(() => parseAllowRule("low-contrast-txt;typo"), /unknown finding kind "low-contrast-txt"/);
+    assert.throws(() => parseAllowRule("low-contrast-txt;typo"), /Valid kinds: .*low-contrast-text/);
+  });
+
+  it("refuses to exempt the kinds that mean the page is broken", () => {
+    for (const kind of ["js-error", "degenerate-render", "unstyled-page", "redirected"]) {
+      assert.throws(
+        () => parseAllowRule(`${kind};too noisy`),
+        /cannot exempt/,
+        `expected ${kind} to be non-exemptable`,
+      );
+    }
+  });
+
+  it("skips blank specs in a list", () => {
+    assert.equal(parseAllowRules(["", "  ", "text-collision;r"]).length, 1);
+  });
+});
+
+describe("ruleMatches", () => {
+  const rule = parseAllowRule("near-misalignment@.btn-b@1280;optical");
+
+  it("matches on kind, selector substring and viewport", () => {
+    assert.equal(ruleMatches(rule, finding()), true);
+  });
+
+  it("does not match a different kind, selector or viewport", () => {
+    assert.equal(ruleMatches(rule, finding({ kind: "text-collision" })), false);
+    assert.equal(ruleMatches(rule, finding({ selector: "main>button.btn-c" })), false);
+    assert.equal(ruleMatches(rule, finding({ viewport: 375 })), false);
+  });
+
+  it("matches every viewport when none is given", () => {
+    const anyViewport = parseAllowRule("near-misalignment@.btn-b;optical");
+    assert.equal(ruleMatches(anyViewport, finding({ viewport: 375 })), true);
+  });
+
+  it("matches by substring, so an added ancestor class does not break it", () => {
+    const anySelector = parseAllowRule("near-misalignment@.btn-b;optical");
+    assert.equal(ruleMatches(anySelector, finding({ selector: "main>div.card.new>button.btn-b" })), true);
+  });
+
+  it("never matches a selector-scoped rule against a finding with no selector", () => {
+    assert.equal(ruleMatches(rule, finding({ selector: undefined })), false);
+  });
+});
+
+describe("applyAllowRules", () => {
+  it("moves a matched finding into exempted, with the reason attached", () => {
+    const rules = parseAllowRules(["near-misalignment@.btn-b;icon is optically centred"]);
+    const result = applyAllowRules([finding(), finding({ selector: "main>button.btn-c" })], rules);
+    assert.equal(result.findings.length, 1);
+    assert.equal(result.findings[0]!.selector, "main>button.btn-c");
+    assert.equal(result.exempted.length, 1);
+    assert.match(result.exempted[0]!.reason, /^user exemption \(near-misalignment@\.btn-b\): icon is optically/);
+    // The suppression stays in the report rather than vanishing.
+    assert.equal(result.exempted[0]!.kind, "near-misalignment");
+    assert.equal(result.exempted[0]!.viewport, 1280);
+  });
+
+  it("reports a rule that matched nothing", () => {
+    const rules = parseAllowRules(["text-collision@.gone;covered a defect that is now fixed"]);
+    const result = applyAllowRules([finding()], rules);
+    assert.equal(result.findings.length, 1);
+    assert.deepEqual(result.unusedRules.map((r) => r.raw), ["text-collision@.gone;covered a defect that is now fixed"]);
+  });
+
+  it("counts a rule as used once, however many findings it covers", () => {
+    const rules = parseAllowRules(["near-misalignment;grid is optical"]);
+    const result = applyAllowRules([finding(), finding({ viewport: 375 })], rules);
+    assert.equal(result.exempted.length, 2);
+    assert.deepEqual(result.unusedRules, []);
+  });
+
+  it("is a no-op with no rules, and does not alias the input", () => {
+    const input = [finding()];
+    const result = applyAllowRules(input, []);
+    assert.deepEqual(result.findings, input);
+    assert.notEqual(result.findings, input);
+    assert.deepEqual(result.exempted, []);
+  });
+
+  it("can exempt a fail-severity finding, which is the point", () => {
+    // An accepted `fail` flips the verdict — that is what the flag is for, and
+    // why it is listed in the report instead of being dropped.
+    const rules = parseAllowRules(["text-collision@#refund;the labels are meant to graze"]);
+    const result = applyAllowRules(
+      [finding({ kind: "text-collision", severity: "fail", selector: "#total x #refund" })],
+      rules,
+    );
+    assert.deepEqual(result.findings, []);
+    assert.equal(result.exempted.length, 1);
+  });
+});

--- a/packages/vlmkit-markup/src/inspect/integrity-exemption.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-exemption.ts
@@ -1,0 +1,183 @@
+/**
+ * User-declared exemptions for `check integrity`.
+ *
+ * The gate already exempts candidates it recognises as intentional patterns,
+ * and lists them so the exemption is auditable. What was missing was the other
+ * half: when a *new* intentional pattern trips a probe, the only options were to
+ * change the markup or file an issue. `check copy` has had per-class acceptance
+ * (`--allow-invisible`) since the silencing battery; this is the same idea for
+ * integrity.
+ *
+ * Three rules keep an exemption from becoming a blindfold:
+ *
+ *   1. **A reason is required.** `--allow "text-collision@.kicker"` alone is
+ *      rejected; the pattern must carry `;<reason>`. An exemption without a
+ *      stated reason is the thing that gets re-approved forever.
+ *   2. **An unknown kind is an error**, listing the valid kinds. `--allow
+ *      text-colision` would otherwise silence nothing while looking like it
+ *      worked — the worst outcome for a suppression flag.
+ *   3. **Exempted findings stay in the report**, moved into `exempted` with the
+ *      user's reason attached, and an exemption that matched nothing is
+ *      reported too, so dead config gets deleted instead of accumulating.
+ *
+ * Lifecycle (owner, expiry, review) belongs in `vlmkit.gates.json`, which
+ * already carries reason/owner/expires per suppression and stops applying an
+ * expired one. This module is deliberately just the matcher.
+ */
+import { UsageError } from "@mizchi/vlmkit-core/cli-error.ts";
+import type { IntegrityExemption, IntegrityFinding, IntegrityFindingKind } from "./integrity-check.ts";
+
+export const INTEGRITY_FINDING_KINDS: IntegrityFindingKind[] = [
+  "broken-image",
+  "failed-stylesheet",
+  "broken-font",
+  "text-collision",
+  "text-clipped",
+  "collapsed-container",
+  "page-overflow-x",
+  "clipped-content",
+  "nested-scroll",
+  "container-protrusion",
+  "invisible-text",
+  "low-contrast-text",
+  "near-misalignment",
+  "occluded-text",
+];
+
+/**
+ * Kinds that may never be exempted: they are not judgement calls about
+ * intentional design, they are the page being broken or unmeasurable. Allowing
+ * them would let a project silence "your JS threw" or "we followed a redirect
+ * to the login page", which is how a gate becomes decoration.
+ */
+export const NON_EXEMPTABLE_KINDS: readonly string[] = [
+  "js-error",
+  "degenerate-render",
+  "unstyled-page",
+  "redirected",
+];
+
+export interface IntegrityAllowRule {
+  kind: IntegrityFindingKind;
+  /** Substring the finding's selector must contain. Omitted = any selector. */
+  selector?: string;
+  /** Viewport width this applies to. Omitted = every viewport. */
+  viewport?: number;
+  reason: string;
+  /** The pattern as written, for reporting an unused rule back verbatim. */
+  raw: string;
+}
+
+/**
+ * `;` separates the reason, NOT `#`.
+ *
+ * `#` was the first choice and it is unusable: a selector with an ID
+ * (`text-collision@#refund;...`) split at the selector's own `#`, silently
+ * producing an empty selector — an exemption far broader than what was written.
+ * A semicolon never appears in a CSS selector, and the reason may contain as
+ * many as it likes since only the first one delimits.
+ */
+const SYNTAX = "<kind>[@<selector>][@<viewport>];<reason>";
+
+/**
+ * Parse `text-collision@.kicker@1280;negative leading is deliberate`.
+ *
+ * `@` separates the optional selector and viewport, the first `;` starts the
+ * reason. Chosen over JSON on the command line because this has to be typable,
+ * and over a bare `kind:selector` because the reason has to be non-optional.
+ */
+export function parseAllowRule(spec: string): IntegrityAllowRule {
+  const cut = spec.indexOf(";");
+  if (cut < 0) {
+    throw new UsageError(
+      `--allow needs a reason: ${SYNTAX} (got "${spec}").`
+      + (spec.includes("#")
+        ? ` The reason is separated by ";", not "#" — "#" is part of an ID selector.`
+        : "")
+      + ` An exemption without a stated reason cannot be reviewed.`,
+    );
+  }
+  const reason = spec.slice(cut + 1).trim();
+  if (!reason) throw new UsageError(`--allow reason is empty in "${spec}". Say why this pattern is intentional.`);
+  const parts = spec.slice(0, cut).split("@").map((p) => p.trim());
+  const kind = parts[0] ?? "";
+  if (!INTEGRITY_FINDING_KINDS.includes(kind as IntegrityFindingKind)) {
+    if (NON_EXEMPTABLE_KINDS.includes(kind)) {
+      throw new UsageError(
+        `--allow cannot exempt "${kind}": it reports the page being broken or unmeasurable,`
+        + ` not an intentional design pattern. Fix the page.`,
+      );
+    }
+    throw new UsageError(
+      `--allow: unknown finding kind "${kind}". Valid kinds: ${INTEGRITY_FINDING_KINDS.join(", ")}`,
+    );
+  }
+  const rule: IntegrityAllowRule = { kind: kind as IntegrityFindingKind, reason, raw: spec };
+  for (const part of parts.slice(1)) {
+    if (!part) continue;
+    if (/^\d+$/.test(part)) rule.viewport = Number.parseInt(part, 10);
+    else rule.selector = part;
+  }
+  return rule;
+}
+
+export function parseAllowRules(specs: readonly string[]): IntegrityAllowRule[] {
+  return specs.filter((s) => s.trim()).map(parseAllowRule);
+}
+
+export function ruleMatches(rule: IntegrityAllowRule, finding: IntegrityFinding): boolean {
+  if (rule.kind !== finding.kind) return false;
+  if (rule.viewport !== undefined && rule.viewport !== finding.viewport) return false;
+  if (rule.selector !== undefined) {
+    // Substring, not an exact match: the finding's selector is a generated path
+    // (`main>div.card>p.kicker`), so equality would break the moment an
+    // unrelated ancestor gained a class.
+    if (!finding.selector?.includes(rule.selector)) return false;
+  }
+  return true;
+}
+
+export interface AppliedExemptions {
+  findings: IntegrityFinding[];
+  /** Findings moved out, with the user's reason recorded. */
+  exempted: IntegrityExemption[];
+  /**
+   * Rules that matched nothing. Reported so a rule kept alive past the defect
+   * it covered gets deleted rather than quietly widening the blind spot.
+   */
+  unusedRules: IntegrityAllowRule[];
+}
+
+export function applyAllowRules(
+  findings: readonly IntegrityFinding[],
+  rules: readonly IntegrityAllowRule[],
+): AppliedExemptions {
+  if (rules.length === 0) return { findings: [...findings], exempted: [], unusedRules: [] };
+  const kept: IntegrityFinding[] = [];
+  const exempted: IntegrityExemption[] = [];
+  const used = new Set<string>();
+  for (const finding of findings) {
+    const rule = rules.find((r) => ruleMatches(r, finding));
+    if (!rule) {
+      kept.push(finding);
+      continue;
+    }
+    used.add(rule.raw);
+    exempted.push({
+      kind: finding.kind,
+      viewport: finding.viewport,
+      ...(finding.selector ? { selector: finding.selector } : {}),
+      reason: `user exemption (${rule.raw.split(";")[0]}): ${rule.reason}`,
+    });
+  }
+  return { findings: kept, exempted, unusedRules: rules.filter((r) => !used.has(r.raw)) };
+}
+
+export const ALLOW_HELP = `  --allow <rule>      Exempt an intentional pattern, repeatable. Syntax:
+                        ${SYNTAX}
+                      e.g. --allow "near-misalignment@.badge;optically centred"
+                           --allow "text-collision@#refund@1280;deliberate graze"
+                      A reason is required; an unknown kind is an error; an
+                      exempted finding is still listed under "exempted"; a rule
+                      matching nothing is reported. Kinds that mean the page is
+                      broken (${NON_EXEMPTABLE_KINDS.join(", ")}) cannot be exempted.`;

--- a/packages/vlmkit-markup/src/inspect/integrity-exemption.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-exemption.ts
@@ -127,7 +127,12 @@ export function parseAllowRules(specs: readonly string[]): IntegrityAllowRule[] 
 
 export function ruleMatches(rule: IntegrityAllowRule, finding: IntegrityFinding): boolean {
   if (rule.kind !== finding.kind) return false;
-  if (rule.viewport !== undefined && rule.viewport !== finding.viewport) return false;
+  if (rule.viewport !== undefined) {
+    // Against every width the finding appeared at, not just the canonical one:
+    // a finding present at 1280/768/375 must be exemptable by any of them.
+    const observed = finding.viewports ?? [finding.viewport];
+    if (!observed.includes(rule.viewport)) return false;
+  }
   if (rule.selector !== undefined) {
     // Substring, not an exact match: the finding's selector is a generated path
     // (`main>div.card>p.kicker`), so equality would break the moment an

--- a/packages/vlmkit-markup/src/inspect/interact.ts
+++ b/packages/vlmkit-markup/src/inspect/interact.ts
@@ -30,7 +30,7 @@
  *   - A markdown report showing the sequence + delta table
  *
  * Usage:
- *   vrt interact <html-or-url> --sequence <path-to-sequence.json>
+ *   vlmkit inspect interact <html-or-url> --sequence <path-to-sequence.json>
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
@@ -364,7 +364,7 @@ export async function runInteract(options: InteractOptions): Promise<InteractRep
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt interact${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit inspect interact${RESET}`);
   console.log(`  ${DIM}source: ${options.source}  sequence: ${options.sequencePath}${RESET}`);
   console.log(`  ${DIM}captured ${snapshots.length} snapshot(s), ${transitions.length} transition(s)${RESET}`);
   for (const t of transitions) {
@@ -508,7 +508,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, sequence, outputDir, report, threshold, healAll } = parseArgs(argv);
   if (positional.length === 0 || !sequence) {
-    console.log("Usage: vrt interact <html-or-url> --sequence <path.json> [options]");
+    console.log("Usage: vlmkit inspect interact <html-or-url> --sequence <path.json> [options]");
     console.log("Options:");
     console.log("  --sequence <path>   JSON file describing the action sequence.");
     console.log("  --output-dir <dir>  Default: ./test-results/interact");

--- a/packages/vlmkit-markup/src/inspect/interaction-map.ts
+++ b/packages/vlmkit-markup/src/inspect/interaction-map.ts
@@ -40,6 +40,7 @@
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import type { Page } from "playwright";
@@ -647,6 +648,11 @@ function describeKey(key: string): string {
 // The probe driver
 
 export interface InteractionMapOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   maxElements?: number;
   settleMs?: number;
@@ -692,7 +698,7 @@ export async function buildInteractionMap(options: InteractionMapOptions): Promi
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   try {
-    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+    const page = await browser.newPage(withAuthState({ viewport: { width: 1280, height: 800 } }, options.storageState));
     await gotoSource(page, options.source);
     const discovered = await page.evaluate(DISCOVER_SCRIPT) as DiscoveredElement[];
     const capped = Math.max(0, discovered.length - maxElements);

--- a/packages/vlmkit-markup/src/inspect/interaction-map.ts
+++ b/packages/vlmkit-markup/src/inspect/interaction-map.ts
@@ -665,6 +665,25 @@ interface DiscoveredElement {
 async function gotoSource(page: Page, source: string): Promise<void> {
   const url = /^(https?|file):\/\//.test(source) ? source : pathToFileURL(resolve(source)).href;
   await page.goto(url, { waitUntil: "load", timeout: 30000 });
+  await settleAfterLoad(page);
+}
+
+/**
+ * `load` fires before a client-rendered app paints: the 2026-08-01
+ * hard-target audit caught this gate reporting "interactive elements: 0"
+ * on a React page that has a button, two links and a scroller — it was
+ * measuring the "Loading…" placeholder. Wait for the network to go quiet
+ * and give the framework a commit tick.
+ *
+ * Both waits are bounded and swallowed on purpose: a page that never goes
+ * idle (polling, websockets) must not turn this into a 30s hang, and a
+ * static file must not pay for a long wait it does not need.
+ */
+export async function settleAfterLoad(page: Page, settleMs = 250): Promise<void> {
+  await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+  await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => undefined) : undefined))
+    .catch(() => {});
+  await page.waitForTimeout(settleMs);
 }
 
 export async function buildInteractionMap(options: InteractionMapOptions): Promise<InteractionMapResult> {

--- a/packages/vlmkit-markup/src/inspect/interaction-map.ts
+++ b/packages/vlmkit-markup/src/inspect/interaction-map.ts
@@ -42,6 +42,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import type { Page } from "playwright";
 
@@ -671,25 +672,7 @@ interface DiscoveredElement {
 async function gotoSource(page: Page, source: string): Promise<void> {
   const url = /^(https?|file):\/\//.test(source) ? source : pathToFileURL(resolve(source)).href;
   await page.goto(url, { waitUntil: "load", timeout: 30000 });
-  await settleAfterLoad(page);
-}
-
-/**
- * `load` fires before a client-rendered app paints: the 2026-08-01
- * hard-target audit caught this gate reporting "interactive elements: 0"
- * on a React page that has a button, two links and a scroller — it was
- * measuring the "Loading…" placeholder. Wait for the network to go quiet
- * and give the framework a commit tick.
- *
- * Both waits are bounded and swallowed on purpose: a page that never goes
- * idle (polling, websockets) must not turn this into a 30s hang, and a
- * static file must not pay for a long wait it does not need.
- */
-export async function settleAfterLoad(page: Page, settleMs = 250): Promise<void> {
-  await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
-  await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => undefined) : undefined))
-    .catch(() => {});
-  await page.waitForTimeout(settleMs);
+  await settlePage(page);
 }
 
 export async function buildInteractionMap(options: InteractionMapOptions): Promise<InteractionMapResult> {

--- a/packages/vlmkit-markup/src/inspect/layout-contract.test.ts
+++ b/packages/vlmkit-markup/src/inspect/layout-contract.test.ts
@@ -78,3 +78,32 @@ describe("integration on the S14a-stress attempt", () => {
     assert.equal(broken.results[0]!.checks[0]!.measured, "260px");
   });
 });
+
+test("minHeight checks EVERY visible match (touch-target rule)", async () => {
+  const { mkdtemp, rm, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = await mkdtemp(join(tmpdir(), "layout-minheight-"));
+  try {
+    const page = join(dir, "page.html");
+    await writeFile(page, `<!doctype html><body>
+      <button style="display:block;height:48px">OK</button>
+      <button style="display:block;height:30px">Too short</button>
+    </body>`);
+    const failing = await runLayoutVerify({
+      source: page,
+      contract: { rules: [{ selector: "button", at: 375, minHeight: 48 }] },
+    });
+    const check = failing.results[0]!.checks.find((c) => c.name === "minHeight")!;
+    assert.equal(check.passed, false);
+    assert.match(check.measured, /shortest 30px of 2/);
+
+    const passing = await runLayoutVerify({
+      source: page,
+      contract: { rules: [{ selector: "button", at: 375, minHeight: 24 }] },
+    });
+    assert.equal(passing.results[0]!.checks.find((c) => c.name === "minHeight")!.passed, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/vlmkit-markup/src/inspect/layout-contract.ts
+++ b/packages/vlmkit-markup/src/inspect/layout-contract.ts
@@ -40,6 +40,7 @@ import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -102,6 +103,13 @@ export interface LayoutReport {
   passed: number;
   total: number;
   done: boolean;
+  /**
+   * Set when the URL redirected — almost always a login wall. Measured
+   * 2026-08-02: against an auth-walled route this gate reported
+   * `VIOLATED: count expected 2, measured 0`, which reads as "your markup is
+   * wrong" when the real cause is that the session expired.
+   */
+  redirected?: string;
 }
 
 /** Cluster row tops (±8px) and return the modal row size. */
@@ -230,6 +238,7 @@ export async function runLayoutVerify(options: LayoutVerifyOptions): Promise<Lay
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   const results: LayoutRuleResult[] = [];
+  let redirected: string | undefined;
   try {
     const url = /^(https?|file):\/\//.test(options.source)
       ? options.source
@@ -239,6 +248,9 @@ export async function runLayoutVerify(options: LayoutVerifyOptions): Promise<Lay
       const height = options.heights?.[width] ?? DEFAULT_HEIGHTS[width] ?? 800;
       const page = await browser.newPage(withAuthState({ viewport: { width, height } }, options.storageState));
       await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+      redirected ??= /^https?:\/\//.test(options.source)
+        ? describeRedirect(options.source, page.url()) ?? undefined
+        : undefined;
       const rules = options.contract.rules.filter((r) => r.at === width);
       const selectors = [...new Set(rules.flatMap((r) => r.above ? [r.selector, r.above] : [r.selector]))];
       const rectMap = await page.evaluate(collectRects, selectors);
@@ -255,13 +267,23 @@ export async function runLayoutVerify(options: LayoutVerifyOptions): Promise<Lay
     await browser.close();
   }
   const passed = results.filter((r) => r.passed).length;
-  const done = passed === results.length;
+  // A redirect cannot be `done`: the rules were evaluated against a page the
+  // caller did not ask for, so even "all passed" would be a claim about the
+  // login screen.
+  const done = passed === results.length && !redirected;
   appendRunLedger({
     tool: "layout-contract",
     source: options.source,
-    headline: { done, passed, total: results.length },
+    headline: { done, passed, total: results.length, ...(redirected ? { redirected: true } : {}) },
   });
-  return { source: options.source, results, passed, total: results.length, done };
+  return {
+    source: options.source,
+    results,
+    passed,
+    total: results.length,
+    done,
+    ...(redirected ? { redirected } : {}),
+  };
 }
 
 export function formatLayoutReport(report: LayoutReport): string {
@@ -270,6 +292,12 @@ export function formatLayoutReport(report: LayoutReport): string {
   lines.push(`${DIM}source: ${report.source}${RESET}`);
   lines.push("");
   lines.push(`verdict: ${report.done ? `${GREEN}SATISFIED${RESET}` : `${RED}VIOLATED${RESET}`} (${report.passed}/${report.total} rules)`);
+  if (report.redirected) {
+    // Ahead of the per-rule list: without this a stale session reads as
+    // "your cards are missing", sending the reader to debug their markup.
+    lines.push(`${RED}x ${report.redirected}${RESET}`);
+    lines.push(`${DIM}  Every rule below was evaluated against that page.${RESET}`);
+  }
   lines.push("");
   for (const r of report.results) {
     const mark = r.passed ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;

--- a/packages/vlmkit-markup/src/inspect/layout-contract.ts
+++ b/packages/vlmkit-markup/src/inspect/layout-contract.ts
@@ -39,6 +39,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -212,6 +213,11 @@ function collectRects(selectors: string[]): Record<string, LayoutRect[]> {
 }
 
 export interface LayoutVerifyOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   contract: LayoutContract;
   /** Height per viewport width (defaults match check integrity). */
@@ -231,7 +237,7 @@ export async function runLayoutVerify(options: LayoutVerifyOptions): Promise<Lay
     const widths = [...new Set(options.contract.rules.map((r) => r.at))].sort((a, b) => b - a);
     for (const width of widths) {
       const height = options.heights?.[width] ?? DEFAULT_HEIGHTS[width] ?? 800;
-      const page = await browser.newPage({ viewport: { width, height } });
+      const page = await browser.newPage(withAuthState({ viewport: { width, height } }, options.storageState));
       await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
       const rules = options.contract.rules.filter((r) => r.at === width);
       const selectors = [...new Set(rules.flatMap((r) => r.above ? [r.selector, r.above] : [r.selector]))];

--- a/packages/vlmkit-markup/src/inspect/layout-contract.ts
+++ b/packages/vlmkit-markup/src/inspect/layout-contract.ts
@@ -59,6 +59,12 @@ export interface LayoutRule {
   tolerance?: number;
   minWidth?: number;
   maxWidth?: number;
+  /**
+   * Minimum height (px) of EVERY visible match — unlike the width
+   * assertions (first match), this checks all matches because its use
+   * case is touch-target rules like "every button >= 48px tall".
+   */
+  minHeight?: number;
   /** Modal number of matches per visual row (tops clustered within 8px). */
   perRow?: number;
   /** First match spans >= 95% of the viewport width. */
@@ -151,6 +157,14 @@ export function evaluateLayoutRule(rule: LayoutRule, m: LayoutMeasurement): Layo
   if (rule.maxWidth !== undefined) {
     push("maxWidth", `<=${rule.maxWidth}px`, first ? `${Math.round(first.width)}px` : "(no match)",
       !!first && first.width <= rule.maxWidth);
+  }
+  if (rule.minHeight !== undefined) {
+    const shortest = m.rects.length > 0
+      ? m.rects.reduce((a, b) => (b.height < a.height ? b : a))
+      : undefined;
+    push("minHeight", `every match >=${rule.minHeight}px`,
+      shortest ? `shortest ${Math.round(shortest.height)}px of ${m.rects.length}` : "(no match)",
+      !!shortest && shortest.height >= rule.minHeight);
   }
   if (rule.fullWidth) {
     push("fullWidth", `>=${Math.round(m.viewport * 0.95)}px (95% of ${m.viewport})`,

--- a/packages/vlmkit-markup/src/inspect/region-judge.ts
+++ b/packages/vlmkit-markup/src/inspect/region-judge.ts
@@ -35,6 +35,7 @@ import { PNG } from "pngjs";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
+import { readEnv } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 export interface JudgeRegion {
   left: number;
@@ -326,7 +327,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   if (vlm !== undefined) {
     const { createVlmClient, resolveModel } = await import("@mizchi/vlmkit-ai/vlm-client.ts");
     const modelId = vlm === true
-      ? (process.env.VRT_VLM_MODEL ?? "anthropic/claude-haiku-4-5")
+      ? (readEnv("VLM_MODEL") ?? "anthropic/claude-haiku-4-5")
       : vlm;
     const model = await resolveModel(modelId);
     const client = await createVlmClient(model);

--- a/packages/vlmkit-markup/src/inspect/scroll-behavior.ts
+++ b/packages/vlmkit-markup/src/inspect/scroll-behavior.ts
@@ -25,6 +25,7 @@
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -81,6 +82,11 @@ export interface ScrollBehaviorReport extends ScrollBehaviorInput {
 }
 
 export interface ScrollBehaviorOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   html?: string;
   viewport?: { width: number; height: number };
@@ -269,7 +275,7 @@ export async function runScrollBehavior(options: ScrollBehaviorOptions): Promise
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   try {
-    const page = await browser.newPage({ viewport });
+    const page = await browser.newPage(withAuthState({ viewport }, options.storageState));
     if (options.html !== undefined) {
       await page.setContent(options.html, { waitUntil: "networkidle" });
     } else if (isUrl(options.source)) {

--- a/packages/vlmkit-markup/src/inspect/scroll-behavior.ts
+++ b/packages/vlmkit-markup/src/inspect/scroll-behavior.ts
@@ -27,6 +27,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { applyGateExit } from "@mizchi/vlmkit-core/gate-exit.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -65,6 +66,13 @@ export interface ScrollBehaviorInput {
 }
 
 export type ScrollBehaviorIssueKind =
+  /**
+   * A URL that redirected somewhere meaningful — almost always a login wall.
+   * Measured 2026-08-02: pointed at an auth-walled route with no session, this
+   * gate reported `status: ok` for the login page while naming the requested
+   * URL as its source. Reported as a suspect issue so the pass cannot be silent.
+   */
+  | "redirected"
   | "fixed-drifts"
   | "sticky-not-sticking"
   | "snap-not-snapping";
@@ -284,10 +292,19 @@ export async function runScrollBehavior(options: ScrollBehaviorOptions): Promise
     } else {
       await page.goto(pathToFileURL(resolve(options.source)).href, { waitUntil: "networkidle", timeout: 30000 });
     }
+    // A redirect here is almost always a login wall. Without this the gate
+    // measured the login page and reported `status: ok` while naming the
+    // requested URL as its source (measured 2026-08-02).
+    const redirectNote = isUrl(options.source) ? describeRedirect(options.source, page.url()) : null;
     const collected = await page.evaluate(COLLECT_SCRIPT(options.maxElements ?? 20)) as
       Omit<ScrollBehaviorInput, "source">;
     await page.close();
     const report = analyzeScrollBehavior({ source: options.source, ...collected }, options);
+    // Pushed as a suspect ISSUE, not just printed: the status line is derived
+    // from the issue list, so a note alone would have left `status: ok`.
+    if (redirectNote) {
+      report.issues.unshift({ kind: "redirected", severity: "suspect", selector: "", message: redirectNote });
+    }
     appendRunLedger({
       tool: "check-scroll",
       source: options.source,

--- a/packages/vlmkit-markup/src/inspect/scroll-behavior.ts
+++ b/packages/vlmkit-markup/src/inspect/scroll-behavior.ts
@@ -25,6 +25,7 @@
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { applyGateExit } from "@mizchi/vlmkit-core/gate-exit.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
@@ -354,20 +355,21 @@ inventory is \`vlmkit scan scroll\`.)
 Options:
   --viewport <WxH>    Viewport (default 1280x720)
   --json              Print JSON report
-  --fail-on-suspect   Exit non-zero when suspect issues are found`);
+  --advisory          Print findings but exit 0 (default: a suspect exits 1)`);
   process.exit(exitCode);
 }
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
   if (argv.includes("--help") || argv.includes("-h")) printUsage(0);
   let json = false;
-  let failOnSuspect = false;
+  let advisory = false;
   let viewport: { width: number; height: number } | undefined;
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--json") json = true;
-    else if (arg === "--fail-on-suspect") failOnSuspect = true;
+    else if (arg === "--fail-on-suspect") { /* accepted no-op: suspects already fail */ }
+    else if (arg === "--advisory") advisory = true;
     else if (arg === "--viewport") {
       const m = (argv[++i] ?? "").match(/^(\d+)x(\d+)$/);
       if (m) viewport = { width: Number(m[1]), height: Number(m[2]) };
@@ -377,7 +379,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   const report = await runScrollBehavior({ source: positional[0]!, ...(viewport ? { viewport } : {}) });
   if (json) console.log(JSON.stringify(report, null, 2));
   else console.log(formatScrollBehaviorReport(report));
-  if (failOnSuspect && report.issues.some((i) => i.severity === "suspect")) process.exit(1);
+  applyGateExit(report.issues.some((i) => i.severity === "suspect"), { advisory });
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "scroll-behavior" ||

--- a/packages/vlmkit-markup/src/inspect/scroll-scan.ts
+++ b/packages/vlmkit-markup/src/inspect/scroll-scan.ts
@@ -481,13 +481,14 @@ Options:
                         entries pasteable into a UI Contract)
   --viewport <WxH>      Viewport (default: 1280x720)
   --clip-threshold <n>  Hidden px below which clipping is ignored (default: 16)
-  --fail-on-suspect     Exit non-zero when suspect issues are found`);
+  --advisory            Print findings but exit 0 (default: a suspect exits 1)`);
   process.exit(exitCode);
 }
 
 function parseArgs(argv: string[]) {
   let json = false;
   let failOnSuspect = false;
+  let advisory = false;
   let clipThreshold: number | undefined;
   let viewport: { width: number; height: number } | undefined;
   const positional: string[] = [];
@@ -495,7 +496,8 @@ function parseArgs(argv: string[]) {
     const arg = argv[i]!;
     if (arg === "--help" || arg === "-h" || arg === "help") printUsage(0);
     else if (arg === "--json") json = true;
-    else if (arg === "--fail-on-suspect") failOnSuspect = true;
+    else if (arg === "--fail-on-suspect") failOnSuspect = true; // accepted no-op
+    else if (arg === "--advisory") advisory = true;
     else if (arg === "--clip-threshold") clipThreshold = Number.parseInt(argv[++i] ?? "16", 10);
     else if (arg === "--viewport") {
       const m = (argv[++i] ?? "").match(/^(\d+)x(\d+)$/);
@@ -504,7 +506,7 @@ function parseArgs(argv: string[]) {
     } else positional.push(arg);
   }
   if (positional.length === 0) printUsage(1);
-  return { source: positional[0]!, json, failOnSuspect, clipThreshold, viewport };
+  return { source: positional[0]!, json, failOnSuspect, advisory, clipThreshold, viewport };
 }
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
@@ -528,7 +530,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   } else {
     console.log(formatScrollScanReport(report));
   }
-  if (parsed.failOnSuspect && report.issues.some((issue) => issue.severity === "suspect")) {
+  if (!parsed.advisory && report.issues.some((issue) => issue.severity === "suspect")) {
     process.exit(1);
   }
 }

--- a/packages/vlmkit-markup/src/inspect/scroll-scan.ts
+++ b/packages/vlmkit-markup/src/inspect/scroll-scan.ts
@@ -27,6 +27,7 @@ import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import type { UiExpectedScrollportContract } from "../contract/ui-contract.ts";
@@ -90,6 +91,13 @@ export interface ScrollContainer {
 }
 
 export type ScrollScanIssueKind =
+  /**
+   * A URL that redirected somewhere meaningful — almost always a login wall.
+   * Measured 2026-08-02: pointed at an auth-walled route with no session, this
+   * gate reported `status: ok` for the login page while naming the requested
+   * URL as its source. Reported as a suspect issue so the pass cannot be silent.
+   */
+  | "redirected"
   | "page-overflow-x"
   | "clipped-content"
   | "nested-scroll";
@@ -410,12 +418,22 @@ export async function runScrollScan(options: ScrollScanOptions): Promise<ScrollS
       // setContent gives the document an about:blank base URL.
       await page.goto(pathToFileURL(resolve(options.source)).href, { waitUntil: "networkidle", timeout: 30000 });
     }
+    // A redirect here is almost always a login wall. Without this the gate
+    // measured the login page and reported `status: ok` while naming the
+    // requested URL as its source (measured 2026-08-02).
+    const redirectNote = isUrl(options.source) ? describeRedirect(options.source, page.url()) : null;
     const collected = await page.evaluate(COLLECT_SCROLL_SCRIPT) as Omit<ScrollScanInput, "source">;
     await page.close();
-    return analyzeScrollSamples(
+    const report = analyzeScrollSamples(
       { source: options.source, ...collected },
       options,
     );
+    // Pushed as a suspect ISSUE, not just printed: the status line is derived
+    // from the issue list, so a note alone would have left `status: ok`.
+    if (redirectNote) {
+      report.issues.unshift({ kind: "redirected", severity: "suspect",  message: redirectNote });
+    }
+    return report;
   } finally {
     await browser.close();
   }

--- a/packages/vlmkit-markup/src/inspect/scroll-scan.ts
+++ b/packages/vlmkit-markup/src/inspect/scroll-scan.ts
@@ -56,7 +56,18 @@ export interface ScrollPageSample {
   scrollWidth: number;
   scrollHeight: number;
   /** Elements whose border box sticks out past the right viewport edge. */
-  overflowOffenders: { selector: string; right: number; width: number }[];
+  overflowOffenders: {
+    selector: string;
+    right: number;
+    width: number;
+    /**
+     * Page overflow (px) that disappears when this element's own width /
+     * min-width rigidity is neutralized. High = this element is a cause;
+     * 0 = it was merely stretched by something else. Absent when the
+     * measurement was not run (only the top candidates are probed).
+     */
+    relieves?: number;
+  }[];
 }
 
 export interface ScrollScanInput {
@@ -184,15 +195,27 @@ export function analyzeScrollSamples(
 
   const issues: ScrollScanIssue[] = [];
   if (horizontalOverflow >= minOverflow) {
-    const offenders = input.page.overflowOffenders
+    // Lead with measured causes when we have them: constraining these is
+    // what actually removes the overflow. Fall back to the widest boxes
+    // when nothing was probed or nothing relieved anything.
+    const causes = input.page.overflowOffenders
+      // 10% keeps co-causes visible (two rigid siblings splitting the
+      // blame) without promoting rounding noise into a "cause".
+      .filter((o) => (o.relieves ?? 0) >= Math.max(minOverflow, horizontalOverflow * 0.1))
+      .sort((a, b) => (b.relieves ?? 0) - (a.relieves ?? 0))
+      .slice(0, 3);
+    const widest = input.page.overflowOffenders
       .slice(0, 3)
       .map((o) => `${o.selector} (right edge ${o.right}px)`)
       .join(", ");
+    const detail = causes.length > 0
+      ? ` — caused by: ${causes.map((o) => `${o.selector} (${o.width}px wide; constraining it removes ${o.relieves}px of the overflow)`).join(", ")}`
+      : (widest ? ` — sticking out: ${widest}` : "");
     issues.push({
       kind: "page-overflow-x",
       severity: "suspect",
       message: `The page scrolls horizontally by ${horizontalOverflow}px at ${input.page.viewportWidth}px viewport width` +
-        (offenders ? ` — sticking out: ${offenders}` : "") + ".",
+        detail + ".",
     });
   }
   for (const clip of clipped.slice(0, maxFindings)) {
@@ -310,13 +333,48 @@ export const COLLECT_SCROLL_SCRIPT = `(() => {
   const viewportWidth = window.innerWidth;
   const offenders = [];
   if (doc.scrollWidth > viewportWidth + 1) {
+    const cands = [];
     for (const el of Array.from(document.querySelectorAll("body *"))) {
       const rect = el.getBoundingClientRect();
       if (rect.right > viewportWidth + 1 && rect.width > 0) {
-        offenders.push({ selector: stableSelector(el), right: Math.round(rect.right), width: Math.round(rect.width) });
+        cands.push({ el, selector: stableSelector(el), right: Math.round(rect.right), width: Math.round(rect.width) });
       }
     }
-    offenders.sort((a, b) => b.right - a.right);
+    cands.sort((a, b) => b.right - a.right);
+    // Ranking by right edge names symptoms, not causes: in a grid/flex
+    // shell one rigid child stretches the track, so every stretched
+    // ancestor and sibling reports a larger right edge than the element
+    // actually at fault (2026-08-01 hard-target audit: a 760px table made
+    // the gate blame the sidebar and the page shell). So measure instead
+    // of ranking — neutralize each candidate's own rigidity and see how
+    // much page overflow disappears; that delta is the "relieves" value.
+    // Probe generously: the culprit is often ranked LOW by right edge
+    // (stretched ancestors and siblings outrank it), so a small window
+    // would reproduce the very bug this measurement exists to fix.
+    const baseline = doc.scrollWidth;
+    for (const c of cands.slice(0, 40)) {
+      const el = c.el;
+      const prevW = el.style.getPropertyValue("width");
+      const prevWP = el.style.getPropertyPriority("width");
+      const prevMin = el.style.getPropertyValue("min-width");
+      const prevMinP = el.style.getPropertyPriority("min-width");
+      el.style.setProperty("width", "0", "important");
+      el.style.setProperty("min-width", "0", "important");
+      const after = doc.scrollWidth;
+      if (prevW) el.style.setProperty("width", prevW, prevWP); else el.style.removeProperty("width");
+      if (prevMin) el.style.setProperty("min-width", prevMin, prevMinP); else el.style.removeProperty("min-width");
+      c.relieves = Math.max(0, baseline - after);
+    }
+    // Measured causes must survive the report's top-N slice, so order by
+    // how much overflow each element accounts for and fall back to right
+    // edge (which keeps the pre-measurement ordering when nothing relieved).
+    cands.sort((a, b) => ((b.relieves || 0) - (a.relieves || 0)) || (b.right - a.right));
+    for (const c of cands) {
+      offenders.push({
+        selector: c.selector, right: c.right, width: c.width,
+        ...(c.relieves !== undefined ? { relieves: c.relieves } : {}),
+      });
+    }
   }
 
   return {

--- a/packages/vlmkit-markup/src/inspect/scroll-scan.ts
+++ b/packages/vlmkit-markup/src/inspect/scroll-scan.ts
@@ -26,6 +26,7 @@
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import type { UiExpectedScrollportContract } from "../contract/ui-contract.ts";
@@ -121,6 +122,11 @@ export interface ScrollScanReport {
 }
 
 export interface ScrollScanOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   html?: string;
   viewport?: { width: number; height: number };
@@ -394,7 +400,7 @@ export async function runScrollScan(options: ScrollScanOptions): Promise<ScrollS
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   try {
-    const page = await browser.newPage({ viewport });
+    const page = await browser.newPage(withAuthState({ viewport }, options.storageState));
     if (options.html !== undefined) {
       await page.setContent(options.html, { waitUntil: "networkidle" });
     } else if (isUrl(options.source)) {

--- a/packages/vlmkit-markup/src/inspect/selector-heal-calibration.ts
+++ b/packages/vlmkit-markup/src/inspect/selector-heal-calibration.ts
@@ -1,4 +1,4 @@
-/** Empirically calibrated reporting thresholds for `vrt interact --heal-all`.
+/** Empirically calibrated reporting thresholds for `vlmkit inspect interact --heal-all`.
  *
  * See docs/reports/data/2026-07-30-selector-heal-calibration.json.
  * The strong cutoff intentionally favours precision: the corpus has no false

--- a/packages/vlmkit-markup/src/inspect/smoke-runner.ts
+++ b/packages/vlmkit-markup/src/inspect/smoke-runner.ts
@@ -17,15 +17,16 @@ import type {
   A11ySnapshot, A11yNodeCompact,
 } from "./smoke-types.ts";
 
-import { getArg, args } from "@mizchi/vlmkit-core/cli-args.ts";
+import { getArg, getIntArg, getRawArgs } from "@mizchi/vlmkit-core/cli-args.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
 // ---- Config ----
 
 const URL_ARG = getArg("url", "");
-const FILE_ARG = getArg("file", args[0] && !args[0].startsWith("--") ? args[0] : "");
-const MAX_ACTIONS = parseInt(getArg("max-actions", "30"), 10);
-const SEED = parseInt(getArg("seed", String(Date.now())), 10);
+const rawArgs = getRawArgs();
+const FILE_ARG = getArg("file", rawArgs[0] && !rawArgs[0].startsWith("--") ? rawArgs[0] : "");
+const MAX_ACTIONS = getIntArg("max-actions", 30, { min: 1 });
+const SEED = getIntArg("seed", Date.now());
 const MODE = getArg("mode", "random") as "random" | "reasoning";
 const RECORD_VIDEO_DIR = getArg("record-video", "");
 const VIEWPORT = { width: 1280, height: 900 };

--- a/packages/vlmkit-markup/src/json-contract.test.ts
+++ b/packages/vlmkit-markup/src/json-contract.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `--json` must put nothing but JSON on stdout.
+ *
+ * The 2026-08-02 truncation pass added `--json` to these four gates because the
+ * console caps its list and the new "… N more (see the report, or --json for
+ * all)" notice had to point somewhere real. It shipped broken: the JSON was
+ * printed *after* the human block, so stdout looked like
+ *
+ *   vlmkit check a11y contrast
+ *   html: /tmp/…/page.html
+ *   ✗ 1 contrast failure(s)
+ *   { "html": …                  <- and JSON.parse throws on line 1
+ *
+ * Caught by running the built CLI during release prep. The original
+ * verification had asserted `report.failures.length` from the run function,
+ * which never touches stdout — so it proved the data existed and said nothing
+ * about whether an agent could read it. These tests spawn the real CLI.
+ *
+ * The gates that already had `--json` use `if (json) … else …`; these four now
+ * pass `quiet` into the run function to get the same mutual exclusion.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = fileURLToPath(new URL(".", import.meta.url));
+
+/** More rows than any of these gates prints, so truncation is always in play. */
+const PAGE = (() => {
+  const rows = Array.from({ length: 12 }, (_, i) => `<p class="low${i}">Low contrast line ${i}</p>`).join("");
+  const taps = Array.from({ length: 12 }, (_, i) => `<a class="tap${i}" href="#${i}" aria-label="tap ${i}"></a>`).join("");
+  const wide = Array.from({ length: 12 }, (_, i) => `<div class="box${i}"><span>Overflowing label ${i}</span></div>`).join("");
+  const css = Array.from({ length: 12 }, (_, i) =>
+    `.low${i}{color:#bbb}`
+    + `.tap${i}{display:inline-block;width:18px;height:18px;background:#333;margin:2px}`
+    + `.box${i}{width:80px;overflow:auto;white-space:nowrap}`).join("");
+  const dir = mkdtempSync(join(tmpdir(), "json-contract-"));
+  const file = join(dir, "page.html");
+  writeFileSync(file, `<!doctype html><meta charset="utf-8"><title>rows</title><style>body{background:#fff;font:16px sans-serif}${css}</style><body>${rows}${taps}${wide}</body>`);
+  return file;
+})();
+
+/**
+ * Colour codes have to come off before matching. `\bvrt\s` looked right and was
+ * vacuous: the header is `\x1b[36mvrt a11y-contrast`, and the escape ends in
+ * `m`, a word character — so there is no word boundary before `vrt` and the
+ * assertion passed against the very output it was written to reject. (`NO_COLOR`
+ * is set below and these helpers emit colour anyway, so stripping is the only
+ * reliable route.)
+ */
+const plain = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+/** Run a gate module's CLI entry directly, the way the bundled binary does. */
+function runGate(module: string, args: string[]): { stdout: string; stderr: string; status: number | null } {
+  const out = mkdtempSync(join(tmpdir(), "json-contract-out-"));
+  const r = spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", join(SRC, module), PAGE, "--output-dir", out, ...args],
+    { encoding: "utf8", env: { ...process.env, NO_COLOR: "1" } },
+  );
+  return { stdout: plain(r.stdout ?? ""), stderr: plain(r.stderr ?? ""), status: r.status };
+}
+
+const GATES: { label: string; module: string; rowsKey: string }[] = [
+  { label: "check a11y contrast", module: "a11y-contrast.ts", rowsKey: "failures" },
+  { label: "check a11y touch", module: "a11y-touch.ts", rowsKey: "failures" },
+  { label: "check a11y focus", module: "a11y-focus-order.ts", rowsKey: "findings" },
+  { label: "stress i18n", module: "stress/i18n-stress.ts", rowsKey: "overflowing" },
+];
+
+describe("--json puts nothing but JSON on stdout", () => {
+  for (const gate of GATES) {
+    it(`${gate.label} --json parses as a whole`, () => {
+      const { stdout } = runGate(gate.module, ["--json"]);
+      // The whole stream, not a scraped tail: an agent pipes this to a parser.
+      const parsed = JSON.parse(stdout) as Record<string, unknown>;
+      assert.ok(Array.isArray(parsed[gate.rowsKey]), `expected ${gate.rowsKey}[] in the JSON`);
+    });
+
+    it(`${gate.label} without --json prints the human block`, () => {
+      // `quiet` must be opt-in — the default output is what a person reads.
+      const { stdout } = runGate(gate.module, []);
+      assert.match(stdout, /vlmkit/, "expected the human header");
+      assert.throws(() => JSON.parse(stdout), "human output is deliberately not JSON");
+    });
+  }
+
+  it("the JSON carries every row the console truncates", () => {
+    // The point of the flag: the notice promises the full list lives here.
+    const { stdout: human } = runGate("a11y-contrast.ts", []);
+    const { stdout: json } = runGate("a11y-contrast.ts", ["--json"]);
+    const rows = (JSON.parse(json) as { failures: unknown[] }).failures;
+    assert.equal(rows.length, 12);
+    const shown = human.split("\n").filter((l) => /\d+\.\d+:1/.test(l)).length;
+    assert.ok(shown < rows.length, "this fixture is meant to exceed the console cap");
+    assert.match(human, /… \d+ more \(see the report, or --json for all\)/);
+  });
+
+  it("stress i18n discloses its cut too", () => {
+    // It was the one gate the truncation pass gave `--json` but not the notice,
+    // so a seventh issue still vanished silently.
+    const { stdout } = runGate("stress/i18n-stress.ts", []);
+    const rows = (JSON.parse(runGate("stress/i18n-stress.ts", ["--json"]).stdout) as { overflowing: unknown[] }).overflowing;
+    if (rows.length > 6) assert.match(stdout, /… \d+ more \(see the report, or --json for all\)/);
+    else assert.ok(rows.length > 0, "fixture produced no i18n findings to cap");
+  });
+});
+
+describe("gate output names a command that exists", () => {
+  for (const gate of GATES) {
+    it(`${gate.label} never prints \`vrt\``, () => {
+      // There is no `vrt` binary, and the old subcommand names are deprecated:
+      // `vrt a11y-contrast` was wrong twice over. A fix instruction the reader
+      // cannot paste is worse than none.
+      const { stdout, stderr } = runGate(gate.module, []);
+      assert.doesNotMatch(stdout + stderr, /vrt[ -]/, "user-facing output still says vrt");
+    });
+  }
+});

--- a/packages/vlmkit-markup/src/json-contract.test.ts
+++ b/packages/vlmkit-markup/src/json-contract.test.ts
@@ -47,7 +47,7 @@ const PAGE = (() => {
 /**
  * Colour codes have to come off before matching. `\bvrt\s` looked right and was
  * vacuous: the header is `\x1b[36mvrt a11y-contrast`, and the escape ends in
- * `m`, a word character — so there is no word boundary before `vrt` and the
+ * `m`, a word character — so there is no word boundary before `vlmkit` and the
  * assertion passed against the very output it was written to reject. (`NO_COLOR`
  * is set below and these helpers emit colour anyway, so stripping is the only
  * reliable route.)
@@ -117,7 +117,7 @@ describe("gate output names a command that exists", () => {
       // `vrt a11y-contrast` was wrong twice over. A fix instruction the reader
       // cannot paste is worse than none.
       const { stdout, stderr } = runGate(gate.module, []);
-      assert.doesNotMatch(stdout + stderr, /vrt[ -]/, "user-facing output still says vrt");
+      assert.doesNotMatch(stdout + stderr, /vrt[ -]/, "user-facing output still says vlmkit");
     });
   }
 });

--- a/packages/vlmkit-markup/src/json-contract.test.ts
+++ b/packages/vlmkit-markup/src/json-contract.test.ts
@@ -47,7 +47,7 @@ const PAGE = (() => {
 /**
  * Colour codes have to come off before matching. `\bvrt\s` looked right and was
  * vacuous: the header is `\x1b[36mvrt a11y-contrast`, and the escape ends in
- * `m`, a word character — so there is no word boundary before `vlmkit` and the
+ * `m`, a word character — so there is no word boundary before `vrt` and the
  * assertion passed against the very output it was written to reject. (`NO_COLOR`
  * is set below and these helpers emit colour anyway, so stripping is the only
  * reliable route.)
@@ -117,7 +117,7 @@ describe("gate output names a command that exists", () => {
       // `vrt a11y-contrast` was wrong twice over. A fix instruction the reader
       // cannot paste is worse than none.
       const { stdout, stderr } = runGate(gate.module, []);
-      assert.doesNotMatch(stdout + stderr, /vrt[ -]/, "user-facing output still says vlmkit");
+      assert.doesNotMatch(stdout + stderr, /vrt[ -]/, "user-facing output still says vrt");
     });
   }
 });

--- a/packages/vlmkit-markup/src/output-consistency.test.ts
+++ b/packages/vlmkit-markup/src/output-consistency.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Differential audit of three "two paths must agree" axes, kept as a test so a
+ * regression on any of them fails loudly.
+ *
+ * The same instrument found the external-asset load defect a few hours earlier;
+ * these are the remaining axes it was pointed at.
+ *
+ *   1. **Viewport sweep order.** Findings are deduped across the sweep, so the
+ *      retained one used to be whichever width came first: `--viewports
+ *      375,768,1280` attributed a page-wide defect to 375 and `1280,768,375` to
+ *      1280. That made `--allow "…@1280"` silently order-dependent and read as
+ *      "mobile only" for something present everywhere. The sweep is now sorted
+ *      widest-first internally and every observed width is recorded.
+ *   2. **Console vs data.** `check a11y contrast|touch|focus` printed a headline
+ *      count and then five rows with no note — 12 findings looked like 5.
+ *   3. **`--json` completeness.** The truncation notices point at `--json`, so
+ *      `--json` has to exist on those gates and carry every row. It did not
+ *      exist at all until the notices were written; this test is what keeps the
+ *      claim honest.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runA11yContrast } from "./a11y-contrast.ts";
+import { runA11yTouch } from "./a11y-touch.ts";
+import { runIntegrityCheck } from "./inspect/integrity-check.ts";
+import { parseAllowRules, ruleMatches } from "./inspect/integrity-exemption.ts";
+
+const FIXTURE = join(
+  fileURLToPath(new URL("../../../fixtures/external-assets", import.meta.url)),
+  "page.html",
+);
+const outDir = () => mkdtempSync(join(tmpdir(), "output-consistency-"));
+
+const VIEWPORTS = [
+  { width: 1280, height: 800 },
+  { width: 768, height: 900 },
+  { width: 375, height: 700 },
+];
+
+/** Order-insensitive identity of a finding, including every width it hit. */
+const shape = (report: Awaited<ReturnType<typeof runIntegrityCheck>>) =>
+  report.findings
+    .map((f) => `${f.kind}|${f.selector ?? ""}|${(f.viewports ?? [f.viewport]).join(",")}|${f.severity}`)
+    .sort();
+
+describe("viewport sweep order does not change the verdict", () => {
+  it("reports the same findings, with the same widths, in either order", async () => {
+    const wide = await runIntegrityCheck({ source: FIXTURE, viewports: VIEWPORTS });
+    const narrow = await runIntegrityCheck({ source: FIXTURE, viewports: [...VIEWPORTS].reverse() });
+    assert.equal(wide.verdict, narrow.verdict);
+    assert.deepEqual(shape(wide), shape(narrow));
+  });
+
+  it("attributes a finding to the widest width it was seen at, not the first swept", async () => {
+    const narrowFirst = await runIntegrityCheck({ source: FIXTURE, viewports: [...VIEWPORTS].reverse() });
+    const contrast = narrowFirst.findings.find((f) => f.kind === "low-contrast-text");
+    assert.ok(contrast, "the fixture declares a 1.92:1 pair");
+    assert.equal(contrast.viewport, 1280);
+    assert.deepEqual(contrast.viewports, [1280, 768, 375]);
+  });
+
+  it("records every width, so page-wide and mobile-only are distinguishable", async () => {
+    // Previously both collapsed to a single width and read identically.
+    const report = await runIntegrityCheck({ source: FIXTURE, viewports: VIEWPORTS });
+    const widths = report.findings.map((f) => (f.viewports ?? [f.viewport]).length);
+    assert.ok(widths.some((n) => n > 1), "expected at least one finding present at several widths");
+  });
+
+  it("lets --allow match any width the finding appeared at", async () => {
+    // A rule scoped to @375 must work for a finding whose canonical width is
+    // 1280 but which was also observed at 375 — otherwise the exemption is
+    // order-dependent in exactly the way the sort was meant to fix.
+    const report = await runIntegrityCheck({ source: FIXTURE, viewports: VIEWPORTS });
+    const finding = report.findings.find((f) => (f.viewports ?? []).includes(375));
+    assert.ok(finding);
+    const [rule] = parseAllowRules([`${finding.kind}@375;present at every width`]);
+    assert.equal(ruleMatches(rule!, finding), true);
+  });
+});
+
+describe("console output does not hide rows", () => {
+  const manyFindings = (): string => {
+    const rows = Array.from({ length: 12 }, (_, i) => `<p class="low${i}">Low contrast line ${i}</p>`).join("");
+    const taps = Array.from({ length: 12 }, (_, i) => `<a class="tap${i}" href="#${i}" aria-label="tap ${i}"></a>`).join("");
+    const css = Array.from({ length: 12 }, (_, i) =>
+      `.low${i}{color:#bbbbbb}.tap${i}{display:inline-block;width:18px;height:18px;background:#333;margin:2px}`).join("");
+    const dir = mkdtempSync(join(tmpdir(), "many-findings-"));
+    const file = join(dir, "many.html");
+    writeFileSync(file, `<!doctype html><meta charset="utf-8"><style>body{background:#fff;font:16px sans-serif}${css}</style><body>${rows}${taps}</body>`);
+    return file;
+  };
+  const MANY = manyFindings();
+
+  it("a11y contrast keeps every finding in the returned report", async () => {
+    const report = await runA11yContrast({ htmlPath: MANY, outputDir: outDir() });
+    // The console prints five; the data must still hold all twelve, which is
+    // what the "… N more" notice promises.
+    assert.equal(report.failures.length, 12);
+  });
+
+  it("a11y touch keeps every finding in the returned report", async () => {
+    const report = await runA11yTouch({ source: MANY, outputDir: outDir() });
+    assert.equal(report.failures.length, 12);
+  });
+});

--- a/packages/vlmkit-markup/src/png-diff.ts
+++ b/packages/vlmkit-markup/src/png-diff.ts
@@ -48,7 +48,7 @@ class PngDiffCliError extends Error {
 }
 
 export function formatPngDiffUsage(): string {
-  return `vrt png-diff <baseline.png> <current.png>
+  return `vlmkit diff png <baseline.png> <current.png>
 
 Compare two existing PNG screenshots without launching Playwright.
 

--- a/packages/vlmkit-markup/src/region-selector-match.ts
+++ b/packages/vlmkit-markup/src/region-selector-match.ts
@@ -10,6 +10,7 @@
  */
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 import { DOM_BBOX_BROWSER_SCRIPT } from "./shift-origin.ts";
 
 export interface RectBox {
@@ -255,11 +256,10 @@ export async function captureRegionElementsFromHtml(
       deviceScaleFactor: 1,
     });
     await page.goto(resolveRegionElementsTargetUrl(target), { waitUntil: "load" });
-    try {
-      await page.evaluate(() => document.fonts ? document.fonts.ready.then(() => undefined) : undefined);
-    } catch {
-      // Font readiness is best-effort; bbox capture should still work.
-    }
+    // Was a bare `fonts.ready` — the two thirds of settling it was missing
+    // (network idle, one frame) are what a client-rendered page needs before
+    // its element rects mean anything.
+    await settlePage(page);
     const raw = await page.evaluate(DOM_BBOX_BROWSER_SCRIPT);
     return parseRegionElementsJson(raw as string);
   } finally {

--- a/packages/vlmkit-markup/src/settle-consistency.test.ts
+++ b/packages/vlmkit-markup/src/settle-consistency.test.ts
@@ -1,0 +1,258 @@
+/**
+ * A gate that navigates and does not settle measures the wrong document — and
+ * reports it as a defect in the page.
+ *
+ * The remaining page-open work was labelled "cosmetic: `waitUntil` levelling"
+ * (71 networkidle / 8 load / 2 domcontentloaded). Measured 2026-08-02 against a
+ * page that renders its cards 350ms after `load`:
+ *
+ *   check layout   (networkidle)  count .card = 2          <- correct
+ *   verify flow    (load, no settle)
+ *                                count .card = 0, FAIL     <- blames the markup
+ *   build page     (load, no settle)
+ *                                5.3% of the settled ink   <- every component
+ *                                                             reported missing
+ *
+ * Playwright *actions* auto-wait, which is why this hid for so long: a click on
+ * a late-rendered element is safe. Reads are not — `page.evaluate`,
+ * `page.screenshot` and `getBoundingClientRect` sample the DOM at that instant,
+ * and all three gates above read.
+ *
+ * `waitUntil` turned out not to be the axis at all: `goto(load)` followed by
+ * `settlePage` waits for network idle anyway. The fix was to settle at the five
+ * call sites that did not, not to rewrite any load state.
+ */
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PNG } from "pngjs";
+import { FLOW_ACTIONS, FLOW_ASSERTS, runFlowVerify, validateFlow } from "./inspect/flow-verify.ts";
+import { runLayoutVerify } from "./inspect/layout-contract.ts";
+import { buildHandlerSurface } from "./inspect/handler-map.ts";
+import { renderHtmlToPng } from "./component/page-compose.ts";
+import { introspectUiContractFromHtml } from "./contract/introspect-contract.ts";
+
+const RENDER_DELAY_MS = 350;
+
+const LATE_MARKUP = [
+  "<h1>Filters</h1>",
+  '<div class="card">Revenue</div>',
+  '<div class="card">Costs</div>',
+  '<button id="apply">Apply filters</button>',
+].join("");
+
+/** A client-rendered view: `load` fires on the placeholder, content follows. */
+const HTML = `<!doctype html><meta charset="utf-8"><title>Filters</title>
+<style>body{margin:0;font:16px system-ui,sans-serif;background:#fff;color:#111;padding:24px}
+.card{width:320px;border:1px solid #ccc;padding:12px;margin:0 0 8px}button{font:inherit;padding:8px 12px}</style>
+<body>
+  <button id="toggle">Show panel</button>
+  <main id="root"><p>Loading…</p></main>
+<script>
+setTimeout(() => {
+  document.getElementById("root").innerHTML = ${JSON.stringify(LATE_MARKUP)};
+  document.getElementById("apply").addEventListener("click", () => {});
+}, ${RENDER_DELAY_MS});
+</script>`;
+
+function startServer(): Promise<{ server: Server; url: string }> {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/html", "cache-control": "no-store" });
+    res.end(HTML);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({ server, url: `http://127.0.0.1:${port}/` });
+    });
+  });
+}
+
+/** The flow's action targets an element present at `load`; its post-conditions
+ *  are on content that arrives later. That split is what exposes a missing
+ *  settle — the action's auto-wait cannot cover for it. */
+const LATE_FLOW = {
+  steps: [{
+    label: "panel shows two cards",
+    do: { action: "click", selector: "#toggle" },
+    expect: [
+      { assert: "count", selector: ".card", equals: 2 },
+      { assert: "visible", selector: "#apply" },
+    ],
+  }],
+} as const;
+
+describe("gates settle before reading a client-rendered page", () => {
+  let server: Server;
+  let url = "";
+  let file = "";
+
+  before(async () => {
+    const started = await startServer();
+    server = started.server;
+    url = started.url;
+    file = join(mkdtempSync(join(tmpdir(), "settle-consistency-")), "page.html");
+    writeFileSync(file, HTML);
+  });
+  after(() => server.close());
+
+  it("verify flow agrees with check layout on how many cards exist", async () => {
+    // These two disagreed: 0 vs 2, same page, same instant. `verify flow`
+    // reported it as an unmet post-condition, i.e. as the markup's fault.
+    const layout = await runLayoutVerify({
+      source: url,
+      contract: { rules: [{ selector: ".card", at: 1280, count: 2 }] },
+    });
+    const flow = await runFlowVerify({ source: url, flow: structuredClone(LATE_FLOW) as never });
+
+    assert.equal(layout.results?.[0]?.checks?.[0]?.measured, "2");
+    assert.equal(flow.done, true, JSON.stringify(flow.steps, null, 1));
+    for (const a of flow.steps[0]!.assertions) assert.equal(a.passed, true, `${JSON.stringify(a.assert)} -> ${a.actual}`);
+  });
+
+  it("verify flow needs no hand-written wait step to see late content", async () => {
+    // The only workaround was for the flow author to guess at a leading
+    // {"action":"wait"} — undiscoverable, and duplicating what the other gates
+    // already do for free.
+    const withoutWait = await runFlowVerify({ source: file, flow: structuredClone(LATE_FLOW) as never });
+    const withWait = await runFlowVerify({
+      source: file,
+      flow: { steps: [{ label: "wait", do: { action: "wait", ms: RENDER_DELAY_MS + 200 } }, ...structuredClone(LATE_FLOW).steps] } as never,
+    });
+    assert.equal(withoutWait.done, withWait.done);
+    assert.equal(withoutWait.done, true);
+  });
+
+  it("build page renders the settled candidate, not its placeholder", async () => {
+    // 5.3% of the settled ink before the fix: it screenshotted "Loading…", so
+    // `build page` reported every component missing.
+    const shot = await renderHtmlToPng(file, 900, 500);
+    const inkOf = (data: Uint8Array | Buffer): number => {
+      let n = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        if (data[i]! < 240 || data[i + 1]! < 240 || data[i + 2]! < 240) n++;
+      }
+      return n;
+    };
+    const rendered = inkOf(shot.data);
+
+    const { chromium } = await import("playwright");
+    const browser = await chromium.launch();
+    try {
+      const page = await browser.newPage({ viewport: { width: 900, height: 500 } });
+      await page.goto(`file://${file}`, { waitUntil: "networkidle" });
+      await page.waitForTimeout(RENDER_DELAY_MS + 250);
+      const settled = inkOf(PNG.sync.read(await page.screenshot({ animations: "disabled" })).data);
+      // Exact equality would be brittle; the defect was a 19x shortfall.
+      assert.ok(
+        rendered > settled * 0.9,
+        `rendered ${rendered} px of ink vs ${settled} settled — the capture is still early`,
+      );
+    } finally {
+      await browser.close();
+    }
+  });
+
+  it("scan contract finds the landmarks of a built SPA opened as a file", async () => {
+    // The likeliest fix to get reverted for being slow (241ms -> 986ms), so pin
+    // the reason: local files used `load` with no settle deliberately, and
+    // returned ZERO landmarks on a page that renders after load — the input
+    // every downstream contract command reads.
+    const spa = join(mkdtempSync(join(tmpdir(), "settle-spa-")), "dist-index.html");
+    writeFileSync(spa, `<!doctype html><meta charset="utf-8"><title>App</title>
+<style>body{margin:0;font:16px system-ui,sans-serif}main{padding:24px}</style>
+<body><div id="root">Loading…</div>
+<script>setTimeout(() => { document.getElementById("root").outerHTML =
+  '<header><nav>Nav</nav></header><main><h1>Dashboard</h1><p>Body</p></main><footer>F</footer>';
+}, ${RENDER_DELAY_MS});</script>`);
+    const contract = await introspectUiContractFromHtml({
+      input: spa,
+      viewports: [{ label: "desktop", width: 1280, height: 800 }],
+    });
+    const roles = contract.screens[0]!.landmarks.map((l) => l.role);
+    assert.deepEqual(roles, ["banner", "navigation", "main", "contentinfo"]);
+  });
+
+  it("scan handlers still inventories handlers registered after load", async () => {
+    // Regression guard on the settleAfterLoad -> settlePage collapse: the two
+    // were byte-for-byte identical, but this gate is what the original was
+    // written for.
+    const surface = await buildHandlerSurface({ source: url });
+    assert.equal(surface.elements.length, 1, JSON.stringify(surface.elements));
+    assert.ok(surface.totalRegistrations >= 1);
+  });
+});
+
+describe("a malformed flow is a usage error, not a page defect", () => {
+  it("rejects an unknown assert name and lists the valid ones", () => {
+    assert.throws(
+      () => validateFlow({ steps: [{ do: { action: "wait", ms: 1 }, expect: [{ assert: "visble", selector: "#a" } as never] }] }),
+      (e: Error) => {
+        // Previously: FAIL with actual "unknown assert" — read as a page defect.
+        assert.match(e.message, /unknown assert "visble"/);
+        assert.match(e.message, /attr, visible, hidden, focused, text, count/);
+        return true;
+      },
+    );
+  });
+
+  it("rejects an unknown action, which used to return done: true", () => {
+    // The worst of the two: `runAction`'s switch had no default, so the step
+    // performed nothing, had no post-conditions to fail, and the run was green.
+    assert.throws(
+      () => validateFlow({ steps: [{ label: "typo", do: { action: "clik", selector: "#b" } as never }] }),
+      /unknown action "clik".*click, press, fill, type, focus, hover, wait/s,
+    );
+  });
+
+  it("names the offending step, so a long flow is debuggable", () => {
+    assert.throws(
+      () => validateFlow({
+        steps: [
+          { do: { action: "wait", ms: 1 } },
+          { label: "open menu", do: { action: "hover", selector: "#m" }, expect: [{ assert: "shown", selector: "#p" } as never] },
+        ],
+      }),
+      /step 1 \("open menu"\), expect\[0\]/,
+    );
+  });
+
+  it("rejects an empty flow rather than reporting done on zero steps", () => {
+    assert.throws(() => validateFlow({ steps: [] }), /flow has no steps/);
+  });
+
+  it("validates against the whole type union, with no drift", () => {
+    // The validator's lists are string literals, so a name added to FlowAction
+    // or FlowAssert without a list entry would start rejecting a *valid* flow.
+    // Loud rather than silent, but still wrong — pin it.
+    const source = readFileSync(
+      fileURLToPath(new URL("./inspect/flow-verify.ts", import.meta.url)),
+      "utf8",
+    );
+    const union = (kind: "action" | "assert") =>
+      [...new Set([...source.matchAll(new RegExp(`\\{ ${kind}: "(\\w+)"`, "g"))].map((m) => m[1]!))].sort();
+    assert.deepEqual([...FLOW_ACTIONS].sort(), union("action"));
+    assert.deepEqual([...FLOW_ASSERTS].sort(), union("assert"));
+  });
+
+  it("accepts every documented action and assert name", () => {
+    // Keeps the validator honest against the type union: a name added to
+    // FlowAction/FlowAssert but not to the list would start being rejected.
+    validateFlow({
+      steps: [
+        { do: { action: "click", selector: "#a" }, expect: [{ assert: "attr", selector: "#a", name: "aria-expanded", equals: "true" }] },
+        { do: { action: "press", key: "Enter" }, expect: [{ assert: "visible", selector: "#a" }] },
+        { do: { action: "fill", selector: "#a", value: "x" }, expect: [{ assert: "hidden", selector: "#a" }] },
+        { do: { action: "type", selector: "#a", text: "x" }, expect: [{ assert: "focused", selector: "#a" }] },
+        { do: { action: "focus", selector: "#a" }, expect: [{ assert: "text", selector: "#a", contains: "x" }] },
+        { do: { action: "hover", selector: "#a" }, expect: [{ assert: "count", selector: "#a", equals: 1 }] },
+        { do: { action: "wait", ms: 1 } },
+      ],
+    });
+  });
+});

--- a/packages/vlmkit-markup/src/stress/breakpoint-check.ts
+++ b/packages/vlmkit-markup/src/stress/breakpoint-check.ts
@@ -35,6 +35,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { extractBreakpoints } from "@mizchi/vlmkit-capture/viewport-discovery.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -82,6 +83,13 @@ export interface BreakpointResult {
 }
 
 export type BreakpointCheckIssueKind =
+  /**
+   * A URL that redirected somewhere meaningful — almost always a login wall.
+   * Measured 2026-08-02: pointed at an auth-walled route with no session, this
+   * gate reported `status: ok` for the login page while naming the requested
+   * URL as its source. Reported as a suspect issue so the pass cannot be silent.
+   */
+  | "redirected"
   | "boundary-spike"
   | "boundary-gap"
   | "overflow-at-boundary"
@@ -401,6 +409,12 @@ export async function runBreakpointCheck(options: BreakpointCheckOptions): Promi
       await page.goto(pathToFileURL(resolve(options.source)).href, { waitUntil: "networkidle", timeout: 30000 });
     }
 
+
+    // A redirect here is almost always a login wall. Without this the gate
+    // measured the login page and reported `status: ok` while naming the
+    // requested URL as its source (measured 2026-08-02).
+    const redirectNote = isUrl(options.source) ? describeRedirect(options.source, page.url()) : null;
+
     let values: number[];
     let rawByValue = new Map<number, string[]>();
     let stylesheets: BreakpointCheckReport["stylesheets"];
@@ -537,7 +551,15 @@ export async function runBreakpointCheck(options: BreakpointCheckOptions): Promi
       checkedValues: values,
       ...(stylesheets ? { stylesheets } : {}),
       ...(sweep ? { sweep } : {}),
-      issues: [...deriveBreakpointIssues(results), ...(sweep ? deriveSweepIssues(sweep) : [])],
+      issues: [
+        // First, and suspect: the status line is derived from the issue list, so
+        // a printed note alone would have left `status: ok` on a login page.
+        ...(redirectNote
+          ? [{ kind: "redirected" as const, severity: "suspect" as const, message: redirectNote }]
+          : []),
+        ...deriveBreakpointIssues(results),
+        ...(sweep ? deriveSweepIssues(sweep) : []),
+      ],
     };
   } finally {
     await browser.close();
@@ -553,6 +575,12 @@ export function formatBreakpointCheckReport(report: BreakpointCheckReport): stri
   lines.push(`${DIM}source: ${report.source}${RESET}`);
   lines.push("");
   lines.push(`status: ${status}`);
+  // Before anything else, and before the sweep early-return below: a redirect
+  // means every number under it describes a different page. Without this the
+  // status flipped to `suspect` with no stated reason.
+  for (const issue of report.issues.filter((i) => i.kind === "redirected")) {
+    lines.push(`${RED}x ${issue.message}${RESET}`);
+  }
   if (report.stylesheets && report.stylesheets.fetched < report.stylesheets.crossOrigin) {
     lines.push(`${YELLOW}note: ${report.stylesheets.crossOrigin - report.stylesheets.fetched} of ${report.stylesheets.crossOrigin} cross-origin stylesheet(s) could not be read — their breakpoints are not covered${RESET}`);
   }

--- a/packages/vlmkit-markup/src/stress/breakpoint-check.ts
+++ b/packages/vlmkit-markup/src/stress/breakpoint-check.ts
@@ -613,13 +613,14 @@ Options:
   --json                Print JSON report
   --height <px>         Render height (default: 900)
   --max-elements <n>    Elements sampled per width (default: 400)
-  --fail-on-suspect     Exit non-zero when suspect issues are found`);
+  --advisory            Print findings but exit 0 (default: a suspect exits 1)`);
   process.exit(exitCode);
 }
 
 function parseArgs(argv: string[]) {
   let json = false;
   let failOnSuspect = false;
+  let advisory = false;
   let breakpoints: number[] | undefined;
   let height: number | undefined;
   let maxElements: number | undefined;
@@ -630,7 +631,8 @@ function parseArgs(argv: string[]) {
     const arg = argv[i]!;
     if (arg === "--help" || arg === "-h" || arg === "help") printUsage(0);
     else if (arg === "--json") json = true;
-    else if (arg === "--fail-on-suspect") failOnSuspect = true;
+    else if (arg === "--fail-on-suspect") failOnSuspect = true; // accepted no-op
+    else if (arg === "--advisory") advisory = true;
     else if (arg === "--sweep") sweep = true;
     else if (arg === "--sweep-step") sweepStep = Number.parseInt(argv[++i] ?? "25", 10);
     else if (arg === "--breakpoints") {
@@ -640,7 +642,7 @@ function parseArgs(argv: string[]) {
     else positional.push(arg);
   }
   if (positional.length === 0) printUsage(1);
-  return { source: positional[0]!, json, failOnSuspect, breakpoints, height, maxElements, sweep, sweepStep };
+  return { source: positional[0]!, json, failOnSuspect, advisory, breakpoints, height, maxElements, sweep, sweepStep };
 }
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
@@ -667,7 +669,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   } else {
     console.log(formatBreakpointCheckReport(report));
   }
-  if (parsed.failOnSuspect && report.issues.some((issue) => issue.severity === "suspect")) {
+  if (!parsed.advisory && report.issues.some((issue) => issue.severity === "suspect")) {
     process.exit(1);
   }
 }

--- a/packages/vlmkit-markup/src/stress/breakpoint-check.ts
+++ b/packages/vlmkit-markup/src/stress/breakpoint-check.ts
@@ -34,6 +34,7 @@ import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { extractBreakpoints } from "@mizchi/vlmkit-capture/viewport-discovery.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -158,6 +159,11 @@ export interface BreakpointCheckReport {
 }
 
 export interface BreakpointCheckOptions {
+  /**
+   * Playwright storage-state file so gates can measure pages behind a
+   * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
+   */
+  storageState?: string;
   source: string;
   html?: string;
   /** Override discovered breakpoints (px values). */
@@ -383,7 +389,7 @@ export async function runBreakpointCheck(options: BreakpointCheckOptions): Promi
   const { chromium } = await import("playwright");
   const browser = await chromium.launch();
   try {
-    const page = await browser.newPage({ viewport: { width: 1280, height } });
+    const page = await browser.newPage(withAuthState({ viewport: { width: 1280, height } }, options.storageState));
     if (options.html !== undefined) {
       await page.setContent(options.html, { waitUntil: "networkidle" });
     } else if (isUrl(options.source)) {

--- a/packages/vlmkit-markup/src/stress/cross-browser.ts
+++ b/packages/vlmkit-markup/src/stress/cross-browser.ts
@@ -17,8 +17,8 @@
  * install hint — the tool stays useful in a Chromium-only sandbox.
  *
  * Usage:
- *   vrt cross-browser <html-or-url>
- *   vrt cross-browser <url> --engines chromium,firefox
+ *   vlmkit diff browsers <html-or-url>
+ *   vlmkit diff browsers <url> --engines chromium,firefox
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -230,7 +230,7 @@ export async function runCrossBrowser(
   const usable = engineResults.filter((r) => r.status === "ok").length;
   const skipped = engineResults.filter((r) => r.status === "skipped").length;
 
-  console.log(`  ${BOLD}${CYAN}vrt cross-browser${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit diff browsers${RESET}`);
   console.log(`  ${DIM}source: ${options.source}${RESET}`);
   if (reference) {
     console.log(`  ${DIM}reference: ${reference}${RESET}`);
@@ -358,7 +358,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, engines, threshold, allowSkipped } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt cross-browser <html-or-url> [options]");
+    console.log("Usage: vlmkit diff browsers <html-or-url> [options]");
     console.log("Options:");
     console.log("  --engines <list>    Comma-separated subset (default: chromium,firefox,webkit)");
     console.log("  --output-dir <dir>  Default: ./test-results/cross-browser");

--- a/packages/vlmkit-markup/src/stress/i18n-stress.ts
+++ b/packages/vlmkit-markup/src/stress/i18n-stress.ts
@@ -344,6 +344,7 @@ function renderReport(r: Omit<I18nStressReport, "reportPath">): string {
       const aw = `${o.after.width.toFixed(0)}×${o.after.height.toFixed(0)}`;
       lines.push(`| ${o.kind} | \`${o.path}\` | \`${o.text}\` | ${bw} | ${aw} | ${detail} |`);
     }
+    if (r.overflowing.length > 20) lines.push(`\n_… ${r.overflowing.length - 20} more row(s) omitted; the JSON report has all of them._`);
   }
   lines.push("");
   lines.push("## Suggested next step");
@@ -377,14 +378,20 @@ async function main(argv = process.argv.slice(2)) {
     console.log("  --inflate <N>        Word-length inflation factor. Default 1.4.");
     console.log("  --output-dir <dir>   Default: ./test-results/i18n-stress");
     console.log("  --report <path>      Markdown report path");
+    console.log("  --json               Print the full report as JSON (every row, no cut)");
     process.exit(1);
   }
-  await runI18nStress({
+  // `--json` so the console/markdown row caps stay a display choice rather than
+
+  // the only view of the data — the truncation notices point here.
+
+  const result = await runI18nStress({
     htmlPath: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "i18n-stress"),
     reportPath: report || undefined,
     inflateFactor: inflate,
   });
+  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "i18n-stress" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/stress/i18n-stress.ts
+++ b/packages/vlmkit-markup/src/stress/i18n-stress.ts
@@ -23,13 +23,13 @@
  * Usage:
  *   vrt i18n-stress <html> [--inflate 1.4]
  */
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { writeFile, mkdir } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
-import { openSource } from "@mizchi/vlmkit-core/page-open.ts";
+import { openSource, resolveSource } from "@mizchi/vlmkit-core/page-open.ts";
 
 export interface I18nStressOptions {
   htmlPath: string;
@@ -167,8 +167,9 @@ export async function runI18nStress(
 ): Promise<I18nStressReport> {
   const outputDir = resolve(options.outputDir);
   await mkdir(outputDir, { recursive: true });
-  const htmlPath = resolve(options.htmlPath);
-  const html = await readFile(htmlPath, "utf-8");
+  // A URL is a valid source now that loading goes through `openSource`;
+  // `resolve()` would have turned it into `<cwd>/http:/host/page.html`.
+  const htmlPath = resolveSource(options.htmlPath);
   const inflateFactor = options.inflateFactor ?? 1.4;
   const viewport = options.viewport ?? { width: 1280, height: 900 };
   const wrapThreshold = options.wrapThreshold ?? 0.15;

--- a/packages/vlmkit-markup/src/stress/i18n-stress.ts
+++ b/packages/vlmkit-markup/src/stress/i18n-stress.ts
@@ -29,6 +29,7 @@ import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { openSource } from "@mizchi/vlmkit-core/page-open.ts";
 
 export interface I18nStressOptions {
   htmlPath: string;
@@ -174,8 +175,9 @@ export async function runI18nStress(
 
   const browser = await chromium.launch();
   try {
-    const page = await browser.newPage({ viewport });
-    await page.setContent(html, { waitUntil: "networkidle" });
+    // Navigate: inflating text on an unstyled document measured a layout that
+    // does not exist (card height 21->86 unstyled vs 95->185 styled).
+    const { page } = await openSource(browser, htmlPath, { viewport, settleMs: 0 });
     await page.addStyleTag({
       content: `*, *::before, *::after { transition: none !important; animation: none !important; }`,
     });

--- a/packages/vlmkit-markup/src/stress/i18n-stress.ts
+++ b/packages/vlmkit-markup/src/stress/i18n-stress.ts
@@ -21,7 +21,7 @@
  * exercise it.
  *
  * Usage:
- *   vrt i18n-stress <html> [--inflate 1.4]
+ *   vlmkit stress i18n <html> [--inflate 1.4]
  */
 import { writeFile, mkdir } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
@@ -40,6 +40,13 @@ export interface I18nStressOptions {
   viewport?: { width: number; height: number };
   /** Min height delta % to count as "wrap induced". Default 0.15 (15%). */
   wrapThreshold?: number;
+  /**
+   * Suppress the human-readable console block. Set by `--json`: the console
+   * output caps its list, so mixing it into stdout ahead of the JSON left
+   * `--json` unparseable — while the truncation notice pointed the reader at
+   * exactly that stream.
+   */
+  quiet?: boolean;
 }
 
 export interface OverflowingElement {
@@ -276,19 +283,28 @@ export async function runI18nStress(
     });
     await writeFile(reportPath, md);
 
-    console.log(`  ${BOLD}${CYAN}vrt i18n-stress${RESET}`);
-    console.log(`  ${DIM}html: ${htmlPath}  inflate: ${inflateFactor}x${RESET}`);
-    const icon = filtered.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
-    console.log(`  ${icon} ${filtered.length} overflow / wrap issue(s) across ${before.length} inspected element(s)`);
-    for (const o of filtered.slice(0, 6)) {
-      const detail = o.kind === "horizontal-overflow"
-        ? `scrollW ${o.after.scrollWidth.toFixed(0)} > clientW ${o.after.clientWidth.toFixed(0)}`
-        : o.kind === "vertical-wrap"
-          ? `h ${o.before.height.toFixed(0)} → ${o.after.height.toFixed(0)}`
-          : "extends beyond parent right edge";
-      console.log(`    ${DIM}[${o.kind}] ${o.path} — ${detail}${RESET}`);
+    if (!options.quiet) {
+      console.log(`  ${BOLD}${CYAN}vlmkit stress i18n${RESET}`);
+      console.log(`  ${DIM}html: ${htmlPath}  inflate: ${inflateFactor}x${RESET}`);
+      const icon = filtered.length === 0 ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+      console.log(`  ${icon} ${filtered.length} overflow / wrap issue(s) across ${before.length} inspected element(s)`);
+      const CONSOLE_ROWS = 6;
+      for (const o of filtered.slice(0, CONSOLE_ROWS)) {
+        const detail = o.kind === "horizontal-overflow"
+          ? `scrollW ${o.after.scrollWidth.toFixed(0)} > clientW ${o.after.clientWidth.toFixed(0)}`
+          : o.kind === "vertical-wrap"
+            ? `h ${o.before.height.toFixed(0)} → ${o.after.height.toFixed(0)}`
+            : "extends beyond parent right edge";
+        console.log(`    ${DIM}[${o.kind}] ${o.path} — ${detail}${RESET}`);
+      }
+      // This gate kept its silent cut when the other three were fixed: the
+      // 2026-08-02 truncation pass added `--json` here but not the notice, so a
+      // seventh issue still vanished without a trace.
+      if (filtered.length > CONSOLE_ROWS) {
+        console.log(`    ${DIM}… ${filtered.length - CONSOLE_ROWS} more (see the report, or --json for all)${RESET}`);
+      }
+      console.log(`  ${DIM}report: ${reportPath}${RESET}`);
     }
-    console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
     return {
       html: htmlPath,
@@ -363,7 +379,7 @@ function renderReport(r: Omit<I18nStressReport, "reportPath">): string {
     lines.push("4. For `extends-beyond-parent` rows: the element's content escapes its parent " +
       "via `position: absolute`, negative margins, or a `width: 100vw` that ignores " +
       "container constraints. Audit width-related declarations.");
-    lines.push("5. Re-run `vrt i18n-stress`. The overflow list should empty out.");
+    lines.push("5. Re-run `vlmkit stress i18n`. The overflow list should empty out.");
   }
   lines.push("");
   return lines.join("\n");
@@ -373,7 +389,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, inflate } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt i18n-stress <html> [--inflate 1.4] [--output-dir dir]");
+    console.log("Usage: vlmkit stress i18n <html> [--inflate 1.4] [--output-dir dir]");
     console.log("Options:");
     console.log("  --inflate <N>        Word-length inflation factor. Default 1.4.");
     console.log("  --output-dir <dir>   Default: ./test-results/i18n-stress");
@@ -385,13 +401,15 @@ async function main(argv = process.argv.slice(2)) {
 
   // the only view of the data — the truncation notices point here.
 
+  const json = argv.includes("--json");
   const result = await runI18nStress({
     htmlPath: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "i18n-stress"),
     reportPath: report || undefined,
     inflateFactor: inflate,
+    quiet: json,
   });
-  if (argv.includes("--json")) console.log(JSON.stringify(result, null, 2));
+  if (json) console.log(JSON.stringify(result, null, 2));
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "i18n-stress" || (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);

--- a/packages/vlmkit-markup/src/stress/media-variants.ts
+++ b/packages/vlmkit-markup/src/stress/media-variants.ts
@@ -34,6 +34,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
+import { sourceToUrl } from "@mizchi/vlmkit-core/page-open.ts";
 import { compareScreenshots } from "@mizchi/vlmkit-core/heatmap.ts";
 import type { VrtSnapshot } from "@mizchi/vlmkit-core/types.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
@@ -98,14 +99,16 @@ function parseArgs(argv: string[]) {
   return { positional, outputDir, report, variants, threshold };
 }
 
-async function loadPage(
-  page: Page, source: string, html: string | null,
-): Promise<void> {
-  if (isUrl(source)) {
-    await page.goto(source, { waitUntil: "networkidle", timeout: 30000 });
-  } else {
-    await page.setContent(html!, { waitUntil: "networkidle" });
-  }
+/**
+ * Always navigate. The file branch used to `setContent` the read bytes, which
+ * leaves the document without a base URL so an external stylesheet never loads
+ * — and this gate compares screenshots across media emulations, so an unstyled
+ * document inverts its verdict. Measured on fixtures/external-assets:
+ * forced-colors read `Delta 0.36% -> fails` unstyled and `Delta 1.46% -> passes`
+ * with the CSS actually applied.
+ */
+async function loadPage(page: Page, source: string): Promise<void> {
+  await page.goto(sourceToUrl(source), { waitUntil: "networkidle", timeout: 30000 });
 }
 
 /** Read all of the page's stylesheet text. Falls back to empty on errors. */
@@ -149,7 +152,7 @@ export async function runMediaVariants(
     // intentionally NOT disabled here because the reduced-motion
     // variant needs a fair comparison.
     const defaultPage = await browser.newPage({ viewport });
-    await loadPage(defaultPage, options.source, html);
+    await loadPage(defaultPage, options.source);
     defaultScreenshot = join(outputDir, "default.png");
     await defaultPage.screenshot({ path: defaultScreenshot, fullPage: false });
     // Read all stylesheets — used for reduced-motion static check.
@@ -177,7 +180,7 @@ export async function runMediaVariants(
         } else if (variant === "print") {
           await page.emulateMedia({ media: "print" });
         }
-        await loadPage(page, options.source, html);
+        await loadPage(page, options.source);
         if (variant === "rtl") {
           await page.evaluate(() => { document.documentElement.dir = "rtl"; });
           await page.waitForLoadState("networkidle").catch(() => {});

--- a/packages/vlmkit-markup/src/stress/media-variants.ts
+++ b/packages/vlmkit-markup/src/stress/media-variants.ts
@@ -27,8 +27,8 @@
  * and "animation correctly suppressed" yield identical screenshots.
  *
  * Usage:
- *   vrt media-variants <html-or-url>
- *   vrt media-variants <url> --variants forced-colors,print,rtl
+ *   vlmkit stress media <html-or-url>
+ *   vlmkit stress media <url> --variants forced-colors,print,rtl
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -353,7 +353,7 @@ export async function runMediaVariants(
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt media-variants${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit stress media${RESET}`);
   console.log(`  ${DIM}source: ${options.source}${RESET}`);
   for (const v of variantResults) {
     const icon = v.verdict === "ok" ? `${GREEN}✓${RESET}`
@@ -437,7 +437,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, variants, threshold } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt media-variants <html-or-url> [options]");
+    console.log("Usage: vlmkit stress media <html-or-url> [options]");
     console.log("Options:");
     console.log("  --variants <list>   Comma-separated subset (default: all 5)");
     console.log(`                      Available: ${ALL_VARIANTS.join(", ")}`);

--- a/packages/vlmkit-markup/src/stress/multi-page-consistency.ts
+++ b/packages/vlmkit-markup/src/stress/multi-page-consistency.ts
@@ -23,8 +23,8 @@
  *     surrounding content unique to each page.
  *
  * Usage:
- *   vrt multi-page-consistency --selector .footer --urls URL1 URL2 ...
- *   vrt multi-page-consistency --selector .footer --files A.html B.html ...
+ *   vlmkit check drift pages --selector .footer --urls URL1 URL2 ...
+ *   vlmkit check drift pages --selector .footer --files A.html B.html ...
  */
 import { readFile, writeFile, mkdir, copyFile } from "node:fs/promises";
 import { basename, join, resolve, extname } from "node:path";
@@ -256,7 +256,7 @@ export async function runMultiPageConsistency(
   await writeFile(reportPath, md);
 
   // Console summary.
-  console.log(`  ${BOLD}${CYAN}vrt multi-page-consistency${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit check drift pages${RESET}`);
   console.log(`  ${DIM}selector: ${options.selector}${RESET}`);
   console.log(`  ${DIM}reference: ${reference.label}${RESET}`);
   for (const d of deltas) {
@@ -319,8 +319,8 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { selector, urls, files, outputDir, report, threshold } = parseArgs(argv);
   if (!selector || (urls.length === 0 && files.length === 0)) {
-    console.log("Usage: vrt multi-page-consistency --selector <sel> --urls URL1 URL2 ...");
-    console.log("       vrt multi-page-consistency --selector <sel> --files A.html B.html ...");
+    console.log("Usage: vlmkit check drift pages --selector <sel> --urls URL1 URL2 ...");
+    console.log("       vlmkit check drift pages --selector <sel> --files A.html B.html ...");
     console.log("Options:");
     console.log("  --output-dir <dir>       Output directory (default: ./test-results/consistency)");
     console.log("  --report <path>          Markdown report path");

--- a/packages/vlmkit-markup/src/stress/multi-state.ts
+++ b/packages/vlmkit-markup/src/stress/multi-state.ts
@@ -101,7 +101,7 @@ export async function applyForcedPseudoState(
       const bboxes: Array<{ x: number; y: number; width: number; height: number }> = [];
       for (let i = 0; i < capped.length; i++) {
         const el = capped[i] as HTMLElement;
-        el.setAttribute("data-vrt-state-marker", String(i));
+        el.setAttribute("data-vlmkit-state-marker", String(i));
         const tag = el.tagName.toLowerCase();
         const cls = el.className && typeof el.className === "string"
           ? `.${el.className.trim().split(/\s+/).slice(0, 3).join(".")}`
@@ -141,7 +141,7 @@ export async function applyForcedPseudoState(
   const { root } = await cdp.send("DOM.getDocument", { depth: -1, pierce: true });
   const { nodeIds } = await cdp.send("DOM.querySelectorAll", {
     nodeId: root.nodeId,
-    selector: "[data-vrt-state-marker]",
+    selector: "[data-vlmkit-state-marker]",
   });
   let forcedCount = 0;
   for (const nodeId of nodeIds) {
@@ -165,13 +165,13 @@ export async function applyForcedPseudoState(
 }
 
 /**
- * Remove the `data-vrt-state-marker` attributes left behind by
+ * Remove the `data-vlmkit-state-marker` attributes left behind by
  * `applyForcedPseudoState`. Call before re-running the same probe in
  * a different state.
  */
 export async function clearStateMarkers(page: Page): Promise<void> {
   await page.evaluate(() => {
-    document.querySelectorAll("[data-vrt-state-marker]")
-      .forEach((el) => el.removeAttribute("data-vrt-state-marker"));
+    document.querySelectorAll("[data-vlmkit-state-marker]")
+      .forEach((el) => el.removeAttribute("data-vlmkit-state-marker"));
   });
 }

--- a/packages/vlmkit-markup/src/style/design-policy.test.ts
+++ b/packages/vlmkit-markup/src/style/design-policy.test.ts
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type DesignPolicyInput,
+  type DesignSample,
+  type DesignSpacingSample,
+  formatDesignReport,
+  judgeDesignPolicy,
+  runDesignPolicyCheck,
+} from "./design-policy.ts";
+
+const sample = (role: string, signature: string, selector = `.${role}-${signature}`): DesignSample => ({
+  role,
+  selector,
+  signature,
+  described: `style ${signature}`,
+});
+
+const spacing = (value: number, uses: number, property = "paddingTop"): DesignSpacingSample[] =>
+  Array.from({ length: uses }, (_, i) => ({ selector: `.s${value}-${i}`, property, value }));
+
+const input = (over: Partial<DesignPolicyInput> = {}): DesignPolicyInput => ({
+  samples: [],
+  spacing: [],
+  skipped: 0,
+  statefulSkipped: 0,
+  ...over,
+});
+
+describe("judgeDesignPolicy — component drift", () => {
+  it("reports a role whose styles are barely reused", () => {
+    // Agent fixture shape: 6 buttons, 3 styles, reuse 2.0.
+    const report = judgeDesignPolicy(input({
+      samples: [
+        sample("button", "a"), sample("button", "a"),
+        sample("button", "b"), sample("button", "b"),
+        sample("button", "c"), sample("button", "c"),
+      ],
+    }));
+    assert.equal(report.verdict, "drift");
+    const drift = report.findings.filter((f) => f.kind === "component-drift");
+    assert.equal(drift.length, 1);
+    assert.equal(drift[0]!.role, "button");
+    assert.equal(drift[0]!.severity, "warn");
+    assert.match(drift[0]!.message, /6 "button" elements render 3 distinct styles/);
+    assert.equal(report.roles[0]!.reuse, 2);
+    assert.equal(report.roles[0]!.singletons, 0);
+  });
+
+  it("stays quiet when one style carries the role", () => {
+    // MDN shape: 8 buttons, 1 style, reuse 8.0.
+    const report = judgeDesignPolicy(input({
+      samples: Array.from({ length: 8 }, () => sample("button", "a")),
+    }));
+    assert.deepEqual(report.findings, []);
+    assert.equal(report.verdict, "coherent");
+    assert.equal(report.roles[0]!.reuse, 8);
+  });
+
+  it("refuses to judge a role below the instance floor", () => {
+    // 2 buttons / 2 styles is reuse 1.0, but "every style is unique" is
+    // trivially true at n=2 and says nothing about the design system.
+    const report = judgeDesignPolicy(input({
+      samples: [sample("button", "a"), sample("button", "b")],
+    }));
+    assert.deepEqual(report.findings, []);
+    assert.equal(report.roles[0]!.instances, 2);
+  });
+
+  it("names the dominant style and the deviations, never a correct value", () => {
+    const report = judgeDesignPolicy(input({
+      samples: [
+        ...Array.from({ length: 4 }, () => sample("button", "dom")),
+        sample("button", "x", ".btn-ghost"),
+        sample("button", "y", ".btn-link"),
+        sample("button", "z", ".btn-icon"),
+        sample("button", "w", ".btn-tiny"),
+      ],
+    }));
+    const message = report.findings.find((f) => f.kind === "component-drift")!.message;
+    assert.match(message, /Dominant style, used 4x/);
+    assert.match(message, /\.btn-ghost/);
+    assert.match(message, /and 1 more\./);
+    assert.match(message, /reports inconsistency, not which style is correct/);
+  });
+
+  it("keeps roles independent", () => {
+    const report = judgeDesignPolicy(input({
+      samples: [
+        ...Array.from({ length: 5 }, () => sample("h2", "h")),
+        sample("button", "a"), sample("button", "b"), sample("button", "c"),
+      ],
+    }));
+    const roles = report.findings.filter((f) => f.kind === "component-drift").map((f) => f.role);
+    assert.deepEqual(roles, ["button"]);
+  });
+
+  it("honours thresholds passed by the caller", () => {
+    const samples = [
+      ...Array.from({ length: 4 }, () => sample("button", "a")),
+      ...Array.from({ length: 2 }, () => sample("button", "b")),
+    ];
+    assert.equal(judgeDesignPolicy(input({ samples })).verdict, "coherent"); // reuse 3.0
+    assert.equal(judgeDesignPolicy(input({ samples }), { minReuse: 4 }).verdict, "drift");
+  });
+});
+
+describe("judgeDesignPolicy — scale outliers", () => {
+  const established = [...spacing(16, 12), ...spacing(24, 9), ...spacing(32, 7)];
+
+  it("reports a one-off value next to an established neighbour", () => {
+    const report = judgeDesignPolicy(input({ spacing: [...established, ...spacing(23, 1)] }));
+    const outlier = report.findings.find((f) => f.kind === "scale-outlier");
+    assert.ok(outlier, "expected a scale-outlier finding");
+    assert.match(outlier.message, /23px \(1x\) next to 24px \(9x\)/);
+  });
+
+  it("does not let a spacing straggler decide the verdict", () => {
+    // Measured on MDN: one authored 43px padding against twelve 40px ones.
+    // True, worth printing, and not evidence that the page is incoherent —
+    // the study found spacing concentration overlaps between designed and
+    // generated pages, so it cannot carry a verdict alone.
+    const report = judgeDesignPolicy(input({ spacing: [...established, ...spacing(23, 1)] }));
+    assert.equal(report.findings.find((f) => f.kind === "scale-outlier")!.severity, "info");
+    assert.equal(report.verdict, "coherent");
+  });
+
+  it("ignores sub-pixel neighbours produced by rem arithmetic", () => {
+    // web.dev tripped the first implementation with "21.4px, nearest common
+    // 21.3px" — two rem-derived values, zero design content.
+    const report = judgeDesignPolicy(input({
+      spacing: [...spacing(21.3, 9), ...spacing(16, 12), ...spacing(32, 7), ...spacing(21.4, 2)],
+    }));
+    assert.equal(report.findings.filter((f) => f.kind === "scale-outlier").length, 0);
+  });
+
+  it("ignores values below the spacing-scale floor", () => {
+    // MDN's only outlier rows were 2/2.5/5/6px paddings on inline <code>.
+    const report = judgeDesignPolicy(input({
+      spacing: [...spacing(4, 20), ...spacing(8, 12), ...spacing(16, 9), ...spacing(5, 2), ...spacing(6, 2)],
+    }));
+    assert.equal(report.findings.filter((f) => f.kind === "scale-outlier").length, 0);
+  });
+
+  it("treats a distant value as a separate scale step, not drift", () => {
+    // 48 next to 32 is a second step; 33 next to 32 is drift.
+    const far = judgeDesignPolicy(input({ spacing: [...established, ...spacing(48, 1)] }));
+    assert.equal(far.findings.filter((f) => f.kind === "scale-outlier").length, 0);
+    const near = judgeDesignPolicy(input({ spacing: [...established, ...spacing(33, 1)] }));
+    assert.equal(near.findings.filter((f) => f.kind === "scale-outlier").length, 1);
+  });
+
+  it("scales the window with the value so large steps stay reportable", () => {
+    const report = judgeDesignPolicy(input({
+      spacing: [...spacing(64, 10), ...spacing(16, 9), ...spacing(24, 8), ...spacing(60, 1)],
+    }));
+    assert.match(report.findings.find((f) => f.kind === "scale-outlier")!.message, /60px \(1x\) next to 64px/);
+  });
+
+  it("requires the reference to be genuinely established", () => {
+    // 2 uses vs 3 uses is not a majority worth snapping to.
+    const report = judgeDesignPolicy(input({
+      spacing: [...spacing(16, 3), ...spacing(24, 3), ...spacing(32, 3), ...spacing(23, 2)],
+    }));
+    assert.equal(report.findings.filter((f) => f.kind === "scale-outlier").length, 0);
+  });
+
+  it("stays quiet when the page has no vocabulary to deviate from", () => {
+    const report = judgeDesignPolicy(input({ spacing: [...spacing(16, 12), ...spacing(23, 1)] }));
+    assert.equal(report.findings.length, 0);
+    assert.equal(report.spacingValues, 2);
+  });
+});
+
+describe("judgeDesignPolicy — coverage reporting", () => {
+  it("carries skip counts through so coverage gaps are never silent", () => {
+    const report = judgeDesignPolicy(input({ skipped: 1490, statefulSkipped: 4 }));
+    assert.equal(report.skipped, 1490);
+    assert.equal(report.statefulSkipped, 4);
+  });
+});
+
+describe("formatDesignReport", () => {
+  it("separates verdict-carrying findings from informational ones", () => {
+    const judged = judgeDesignPolicy(input({
+      samples: [sample("button", "a"), sample("button", "b"), sample("button", "c")],
+      spacing: [...spacing(16, 12), ...spacing(24, 9), ...spacing(32, 7), ...spacing(23, 1)],
+    }));
+    const text = formatDesignReport({ source: "fixture.html", ...judged });
+    assert.match(text, /DRIFT/);
+    assert.match(text, /Findings/);
+    assert.match(text, /Informational/);
+    assert.match(text, /does not carry the verdict/);
+    assert.ok(text.indexOf("component-drift") < text.indexOf("Informational"));
+  });
+
+  it("says so plainly when nothing drifted", () => {
+    const judged = judgeDesignPolicy(input({ samples: Array.from({ length: 5 }, () => sample("button", "a")) }));
+    const text = formatDesignReport({ source: "fixture.html", ...judged });
+    assert.match(text, /COHERENT/);
+    assert.match(text, /No design drift detected/);
+  });
+});
+
+const DIR = mkdtempSync(join(tmpdir(), "design-policy-"));
+
+const page = (name: string, body: string, css = ""): string => {
+  const file = join(DIR, `${name}.html`);
+  writeFileSync(file, `<!doctype html><meta charset="utf-8"><title>${name}</title>
+<style>body { margin: 0; font: 16px/1.5 sans-serif; }
+button { padding: 12px 20px; border-radius: 8px; font-size: 14px; border: 1px solid #333; background: #fff; }
+${css}</style>
+${body}`);
+  return file;
+};
+
+describe("runDesignPolicyCheck (browser collection)", () => {
+  it("reports drift when buttons are styled three ways", async () => {
+    const file = page(
+      "drift",
+      `<main>${Array.from({ length: 3 }, (_, i) => `<button class="a${i}">Buy</button>`).join("")}
+       <button class="ghost">Ghost</button><button class="link">Link</button><button class="tiny">Tiny</button></main>`,
+      `.ghost { padding: 10px 18px; border-radius: 6px; }
+       .link { padding: 14px 22px; border-radius: 0; }
+       .tiny { padding: 8px 12px; font-size: 12px; }`,
+    );
+    const report = await runDesignPolicyCheck({ source: file });
+    const drift = report.findings.find((f) => f.kind === "component-drift");
+    assert.ok(drift, `expected component-drift, got ${JSON.stringify(report.findings)}`);
+    assert.equal(drift.role, "button");
+    assert.equal(report.verdict, "drift");
+    assert.match(drift.message, /6 "button" elements render 4 distinct styles/);
+  });
+
+  it("passes a page that reuses one button style", async () => {
+    const file = page("uniform", `<main>${Array.from({ length: 6 }, () => "<button>Buy</button>").join("")}</main>`);
+    const report = await runDesignPolicyCheck({ source: file });
+    assert.deepEqual(report.findings, []);
+    assert.equal(report.verdict, "coherent");
+    assert.equal(report.roles.find((r) => r.role === "button")!.reuse, 6);
+  });
+
+  it("excludes non-resting states instead of counting them as drift", async () => {
+    // A disabled or pressed button legitimately looks different. Without this
+    // exclusion the S19 fixture read as 6 signatures where 3 were real.
+    const file = page(
+      "states",
+      `<main>${Array.from({ length: 4 }, () => "<button>Buy</button>").join("")}
+       <button disabled>Sold out</button><button aria-pressed="true">Pinned</button></main>`,
+      `button:disabled { padding: 2px 4px; border-radius: 0; background: #eee; }
+       button[aria-pressed="true"] { padding: 30px 40px; border-radius: 99px; background: #000; }`,
+    );
+    const report = await runDesignPolicyCheck({ source: file });
+    assert.equal(report.statefulSkipped, 2);
+    assert.equal(report.roles.find((r) => r.role === "button")!.instances, 4);
+    assert.equal(report.verdict, "coherent");
+  });
+
+  it("keeps input, select and textarea as separate roles", async () => {
+    // Grouping them as one "field" role produced a false drift signal in the
+    // study: the browser styles them differently by design.
+    const file = page(
+      "fields",
+      `<form>${Array.from({ length: 3 }, () => '<input type="text" value="x">').join("")}
+       ${Array.from({ length: 3 }, () => "<select><option>a</option></select>").join("")}
+       ${Array.from({ length: 3 }, () => "<textarea>y</textarea>").join("")}</form>`,
+    );
+    const report = await runDesignPolicyCheck({ source: file });
+    const roles = report.roles.map((r) => r.role).sort();
+    assert.deepEqual(roles, ["input:text", "select", "textarea"]);
+    assert.equal(report.verdict, "coherent");
+  });
+
+  it("counts elements it could not classify rather than hiding them", async () => {
+    const file = page("skips", `<main><div><span>a</span><p>b</p></div><button>Go</button></main>`);
+    const report = await runDesignPolicyCheck({ source: file });
+    assert.ok(report.skipped >= 3, `expected skipped >= 3, got ${report.skipped}`);
+  });
+});

--- a/packages/vlmkit-markup/src/style/design-policy.ts
+++ b/packages/vlmkit-markup/src/style/design-policy.ts
@@ -1,0 +1,476 @@
+#!/usr/bin/env node
+/**
+ * `check design` — conformance to the design system the page itself implies.
+ *
+ * The functional gates answer "is this broken". This one answers "is this
+ * *coherent*", which generated markup routinely is not: every S15-S19
+ * zero-shot fixture passed every functional gate while rendering its buttons
+ * in three different styles.
+ *
+ * The line this gate does NOT cross: it never judges which value is right.
+ * "Is 24px the correct gap" is taste and stays with humans. "You used 23px
+ * once and 24px forty times" is a measurement, and that is all this reports.
+ *
+ * Feasibility study, with the measurements that shaped every threshold here:
+ * docs/design/design-policy-metrics.md. Two findings from it are load-bearing:
+ *
+ *   - 4px/8px grid conformance was REJECTED as a quality signal. Agent-built
+ *     pages score 0.86-1.00 on it while MDN scores 0.857 and web.dev 0.716,
+ *     because LLM-written CSS uses round numbers religiously. Declared-scale
+ *     conformance lives in `check tokens`; it is not evidence of coherence.
+ *   - Signature REUSE discriminates. Measured reuse factors (instances per
+ *     distinct signature): MDN buttons 8.0, web.dev menuitems 42, Wikipedia
+ *     buttons 12.5 — versus agent buttons 2.0-2.3. Wikipedia's `navigation`
+ *     role sits at 2.0 and is genuine organic drift, so the rule holds on
+ *     both sides.
+ *
+ * CLI:
+ *   vlmkit check design <html-or-url> [--min-reuse 3] [--json] [--advisory]
+ */
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { applyGateExit } from "@mizchi/vlmkit-core/gate-exit.ts";
+import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
+import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
+import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
+
+/** One visible element's style signature within its inferred role. */
+export interface DesignSample {
+  role: string;
+  selector: string;
+  /** Style tuple that defines "the same component", rendered. */
+  signature: string;
+  /** Human-readable form of the signature for kickbacks. */
+  described: string;
+}
+
+export interface DesignSpacingSample {
+  selector: string;
+  property: string;
+  value: number;
+}
+
+export interface DesignPolicyInput {
+  samples: DesignSample[];
+  spacing: DesignSpacingSample[];
+  /**
+   * Elements skipped because no role could be inferred deterministically.
+   * Reported, never silent — the gate's coverage has to be legible.
+   */
+  skipped: number;
+  /** Elements skipped for being in a non-resting state. */
+  statefulSkipped: number;
+}
+
+export type DesignFindingKind = "component-drift" | "scale-outlier" | "redirected";
+
+export interface DesignFinding {
+  kind: DesignFindingKind;
+  /**
+   * `warn` for design drift — information for a human, never a build failure.
+   * `info` for rows that are true but do not carry the verdict: the study
+   * measured spacing-vocabulary concentration as overlapping between designed
+   * and generated pages (top-6 coverage 0.81-0.99 in both groups), so a
+   * spacing straggler on its own is not evidence of incoherence. MDN authors
+   * exactly one 43px padding against twelve 40px ones; reporting that is
+   * useful, calling the page incoherent for it is not.
+   */
+  severity: "info" | "warn" | "suspect";
+  role?: string;
+  message: string;
+}
+
+export interface DesignPolicyReport {
+  source: string;
+  roles: {
+    role: string;
+    instances: number;
+    signatures: number;
+    /** instances / signatures — how often the average signature is reused. */
+    reuse: number;
+    singletons: number;
+  }[];
+  findings: DesignFinding[];
+  skipped: number;
+  statefulSkipped: number;
+  spacingValues: number;
+  verdict: "coherent" | "drift";
+}
+
+export interface DesignPolicyOptions {
+  source: string;
+  /**
+   * Minimum times a signature must be reused before the role counts as
+   * systematic. Default 3 — measured: designed roles sit at 5-42, drifting
+   * ones at 2.0-2.3.
+   */
+  minReuse?: number;
+  /**
+   * Minimum instances before a role is judged at all. Default 3: with one or
+   * two instances "every signature is unique" is trivially true and says
+   * nothing.
+   */
+  minInstances?: number;
+  /** Spacing values used less than this often are reported as outliers. Default 2. */
+  outlierMaxUses?: number;
+  storageState?: string;
+}
+
+const DEFAULT_MIN_REUSE = 3;
+const DEFAULT_MIN_INSTANCES = 3;
+const DEFAULT_OUTLIER_MAX_USES = 2;
+
+/**
+ * Below this, a spacing value is not a scale decision. Measured: the only
+ * `scale-outlier` rows MDN and web.dev produced were 2/2.5/5/6px paddings on
+ * inline `<code>` and hairline offsets — none of them design choices. A real
+ * spacing scale starts around 8px.
+ */
+const SCALE_FLOOR_PX = 8;
+
+/**
+ * A design decision is expressed as a whole pixel. Fractional computed values
+ * come from rem/em/percentage arithmetic (web.dev's `21.4px` next to a
+ * "common" `21.3px` was the reductio: two rem-derived neighbours, zero design
+ * content). Both the outlier and its reference must be integral.
+ */
+const isScaleValue = (v: number): boolean =>
+  v >= SCALE_FLOOR_PX && Math.abs(v - Math.round(v)) < 0.05;
+
+/**
+ * How far off the scale still counts as "just off" rather than "a different
+ * step". 23-vs-24 is drift; 12-vs-8 is a second step in the scale. Scales with
+ * itself so 60-vs-64 stays reportable.
+ */
+const scaleWindow = (reference: number): number => Math.max(2, Math.round(reference * 0.1));
+
+/**
+ * Collect role-grouped style signatures and spacing usage.
+ *
+ * Role inference is deliberately narrow: an explicit `role`, or a tag whose
+ * semantics are unambiguous. `input`, `select` and `textarea` are kept as
+ * SEPARATE roles — grouping them as one "field" role produced a false drift
+ * signal in the study, because the browser styles them differently by design.
+ *
+ * Non-resting states (disabled, pressed, expanded, current, selected,
+ * checked) are excluded: a pressed button legitimately differs from an
+ * unpressed one. Measured impact — this alone took the S19 fixture from 6
+ * apparent signatures to 3 real ones.
+ */
+export const COLLECT_DESIGN_SAMPLES = `(() => {
+  const visible = (el) => typeof el.checkVisibility === "function"
+    ? el.checkVisibility({ visibilityProperty: true, opacityProperty: true, contentVisibilityAuto: true })
+    : getComputedStyle(el).display !== "none" && getComputedStyle(el).visibility !== "hidden";
+  const px = (v) => { const n = parseFloat(v); return Number.isFinite(n) ? Math.round(n * 10) / 10 : 0; };
+  const STATE = ":disabled,[aria-disabled=true],[aria-pressed=true],[aria-expanded=true],[aria-current],[aria-selected=true],:checked";
+  const path = (el) => {
+    const parts = [];
+    for (let cur = el; cur && cur !== document.body && parts.length < 3; cur = cur.parentElement) {
+      let p = cur.tagName.toLowerCase();
+      if (cur.id) { parts.unshift(p + "#" + cur.id); break; }
+      if (typeof cur.className === "string" && cur.className.trim()) p += "." + cur.className.trim().split(/\\s+/)[0];
+      parts.unshift(p);
+    }
+    return parts.join(">");
+  };
+  const roleOf = (el) => {
+    const explicit = el.getAttribute("role");
+    if (explicit) return explicit.trim();
+    const tag = el.tagName.toLowerCase();
+    if (tag === "button") return "button";
+    if (tag === "input") {
+      const t = (el.type || "text").toLowerCase();
+      return /^(button|submit|reset)$/.test(t) ? "button" : "input:" + t;
+    }
+    if (tag === "select" || tag === "textarea") return tag;
+    if (/^h[1-6]$/.test(tag)) return tag;
+    return null;
+  };
+  const samples = [], spacing = [];
+  let skipped = 0, statefulSkipped = 0;
+  for (const el of document.querySelectorAll("body *")) {
+    if (!visible(el)) continue;
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 2 || rect.height < 2) continue;
+    const cs = getComputedStyle(el);
+    for (const prop of ["paddingTop","paddingBottom","paddingLeft","paddingRight","marginTop","marginBottom","rowGap","columnGap"]) {
+      const v = px(cs[prop]);
+      if (v > 0) spacing.push({ selector: path(el), property: prop, value: v });
+    }
+    const role = roleOf(el);
+    if (!role) { skipped++; continue; }
+    if (el.matches && el.matches(STATE)) { statefulSkipped++; continue; }
+    // Rendered height is deliberately NOT in the signature: a button that is
+    // taller only because its label wrapped is not a design inconsistency.
+    const sig = [
+      px(cs.paddingTop), px(cs.paddingRight), px(cs.paddingBottom), px(cs.paddingLeft),
+      px(cs.borderTopLeftRadius), px(cs.fontSize), cs.fontWeight,
+      px(cs.borderTopWidth), cs.backgroundColor,
+    ];
+    samples.push({
+      role,
+      selector: path(el),
+      signature: sig.join("|"),
+      described: "padding " + sig.slice(0, 4).join("/") + ", radius " + sig[4]
+        + ", " + sig[5] + "px/" + sig[6] + ", border " + sig[7] + ", bg " + sig[8],
+    });
+  }
+  return { samples, spacing, skipped, statefulSkipped };
+})()`;
+
+/**
+ * Judge role coherence. Pure so the thresholds are unit-testable without a
+ * browser.
+ */
+export function judgeDesignPolicy(
+  input: DesignPolicyInput,
+  options: Pick<DesignPolicyOptions, "minReuse" | "minInstances" | "outlierMaxUses"> = {},
+): Omit<DesignPolicyReport, "source"> {
+  const minReuse = options.minReuse ?? DEFAULT_MIN_REUSE;
+  const minInstances = options.minInstances ?? DEFAULT_MIN_INSTANCES;
+  const outlierMax = options.outlierMaxUses ?? DEFAULT_OUTLIER_MAX_USES;
+
+  const byRole = new Map<string, DesignSample[]>();
+  for (const s of input.samples) {
+    const list = byRole.get(s.role) ?? [];
+    list.push(s);
+    byRole.set(s.role, list);
+  }
+
+  const roles: DesignPolicyReport["roles"] = [];
+  const findings: DesignFinding[] = [];
+
+  for (const [role, list] of [...byRole.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    const counts = new Map<string, DesignSample[]>();
+    for (const s of list) {
+      const same = counts.get(s.signature) ?? [];
+      same.push(s);
+      counts.set(s.signature, same);
+    }
+    const signatures = counts.size;
+    const reuse = Math.round((list.length / signatures) * 100) / 100;
+    const singletons = [...counts.values()].filter((v) => v.length === 1).length;
+    roles.push({ role, instances: list.length, signatures, reuse, singletons });
+
+    if (list.length < minInstances) continue;
+    if (reuse >= minReuse) continue;
+
+    const ranked = [...counts.entries()].sort((a, b) => b[1].length - a[1].length);
+    const dominant = ranked[0]!;
+    const minority = ranked.slice(1);
+    const examples = minority.slice(0, 3).map(([, els]) =>
+      `${els[0]!.selector} (${els[0]!.described})`
+    );
+    findings.push({
+      kind: "component-drift",
+      severity: "warn",
+      role,
+      message:
+        `${list.length} "${role}" elements render ${signatures} distinct styles `
+        + `(each style reused only ${reuse}x; a system reuses each style ${minReuse}x or more). `
+        + `Dominant style, used ${dominant[1].length}x: ${dominant[1][0]!.described}. `
+        + `Deviating: ${examples.join("; ")}`
+        + (minority.length > 3 ? ` and ${minority.length - 3} more.` : ".")
+        + ` This reports inconsistency, not which style is correct.`,
+    });
+  }
+
+  // Spacing outliers against the page's OWN dominant vocabulary — the
+  // inferred twin of `check tokens`, usable with no config file.
+  const spacingCounts = new Map<number, DesignSpacingSample[]>();
+  for (const s of input.spacing) {
+    const list = spacingCounts.get(s.value) ?? [];
+    list.push(s);
+    spacingCounts.set(s.value, list);
+  }
+  //
+  // Every clause below exists because a designed page tripped the rule without
+  // it. The first implementation reported `verdict: DRIFT` on both MDN and
+  // web.dev — pages the study established as coherent — on rows like
+  // "21.4px, nearest common 21.3px". A metric that fires on the reference set
+  // is not a metric.
+  const scaleReferences = [...spacingCounts.entries()]
+    .filter(([value, uses]) => isScaleValue(value) && uses.length > outlierMax);
+  const candidates = [...spacingCounts.entries()]
+    .filter(([value, uses]) => isScaleValue(value) && uses.length <= outlierMax);
+  // Only meaningful once the page HAS a vocabulary to deviate from.
+  if (scaleReferences.length >= 3 && candidates.length > 0) {
+    const nearest = (v: number) => scaleReferences
+      .reduce((best, entry) => (Math.abs(entry[0] - v) < Math.abs(best[0] - v) ? entry : best));
+    const worst = candidates
+      .map(([value, uses]) => {
+        const [near, nearUses] = nearest(value);
+        return { value, uses: uses.length, near, nearUses: nearUses.length, sample: uses[0]! };
+      })
+      .filter((r) =>
+        r.value !== r.near
+        && Math.abs(r.value - r.near) <= scaleWindow(r.near)
+        // The reference has to be genuinely established, or "off the page's own
+        // scale" is claiming a scale that does not exist: 2 uses vs 3 uses is
+        // not a majority worth snapping to.
+        && r.nearUses >= 4
+        && r.nearUses >= r.uses * 3
+      )
+      .sort((a, b) => Math.abs(a.value - a.near) - Math.abs(b.value - b.near))
+      .slice(0, 5);
+    if (worst.length > 0) {
+      findings.push({
+        kind: "scale-outlier",
+        severity: "info",
+        message:
+          `${worst.length} spacing value(s) sit just off the page's own scale: `
+          + worst.map((w) =>
+            `${w.value}px (${w.uses}x) next to ${w.near}px (${w.nearUses}x) — ${w.sample.selector} ${w.sample.property}`
+          ).join("; ")
+          + `. Snap them to the established value or add them deliberately.`,
+      });
+    }
+  }
+
+  return {
+    roles,
+    findings,
+    skipped: input.skipped,
+    statefulSkipped: input.statefulSkipped,
+    spacingValues: spacingCounts.size,
+    // `info` rows do not move the verdict, and `redirected` is a navigation
+    // problem rather than a design one (it still exits non-zero, being suspect).
+    verdict: findings.some((f) => f.severity === "warn") ? "drift" : "coherent",
+  };
+}
+
+export async function runDesignPolicyCheck(options: DesignPolicyOptions): Promise<DesignPolicyReport> {
+  const { chromium } = await import("playwright");
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage(withAuthState({ viewport: { width: 1280, height: 900 } }, options.storageState));
+    const isUrl = /^https?:\/\//.test(options.source);
+    const url = isUrl ? options.source : pathToFileURL(resolve(options.source)).href;
+    await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+    await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => undefined) : undefined));
+    await page.waitForTimeout(250);
+    const redirect = isUrl ? describeRedirect(options.source, page.url()) : null;
+    const input = await page.evaluate(COLLECT_DESIGN_SAMPLES) as DesignPolicyInput;
+    const judged = judgeDesignPolicy(input, options);
+    if (redirect) {
+      judged.findings.unshift({ kind: "redirected", severity: "suspect", message: redirect });
+    }
+    const report: DesignPolicyReport = { source: options.source, ...judged };
+    appendRunLedger({
+      tool: "check-design",
+      source: options.source,
+      headline: {
+        verdict: report.verdict,
+        drifting: report.findings.filter((f) => f.kind === "component-drift").length,
+        roles: report.roles.length,
+      },
+    });
+    return report;
+  } finally {
+    await browser.close();
+  }
+}
+
+export function formatDesignReport(report: DesignPolicyReport): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`${BOLD}${CYAN}vlmkit check design${RESET}`);
+  lines.push(`${DIM}source: ${report.source}${RESET}`);
+  lines.push("");
+  const bad = report.findings.filter((f) => f.severity === "suspect").length;
+  lines.push(
+    `verdict: ${report.verdict === "coherent" ? `${GREEN}COHERENT${RESET}` : `${YELLOW}DRIFT${RESET}`}`
+    + ` (${report.findings.length} finding(s)${bad > 0 ? `, ${bad} suspect` : ""})`,
+  );
+  lines.push(`${DIM}  roles judged: ${report.roles.length}, spacing values: ${report.spacingValues},`
+    + ` skipped: ${report.skipped} (no inferable role), ${report.statefulSkipped} (non-resting state)${RESET}`);
+  lines.push("");
+  if (report.roles.length > 0) {
+    lines.push(`${BOLD}Role reuse${RESET} ${DIM}(instances / distinct styles)${RESET}`);
+    for (const r of report.roles.slice(0, 10)) {
+      const flag = r.instances >= DEFAULT_MIN_INSTANCES && r.reuse < DEFAULT_MIN_REUSE ? `${YELLOW}drift${RESET}` : `${GREEN}ok${RESET}`;
+      lines.push(`  ${r.role.padEnd(14)} ${String(r.instances).padStart(3)} inst  ${String(r.signatures).padStart(3)} styles`
+        + `  reuse ${String(r.reuse).padStart(5)}x  ${r.singletons} one-off  ${flag}`);
+    }
+    lines.push("");
+  }
+  if (report.findings.length === 0) {
+    lines.push(`${GREEN}No design drift detected.${RESET}`);
+    return lines.join("\n");
+  }
+  const carried = report.findings.filter((f) => f.severity !== "info");
+  const informational = report.findings.filter((f) => f.severity === "info");
+  const mark = (f: DesignFinding) =>
+    f.severity === "suspect" ? `${RED}x${RESET}` : f.severity === "warn" ? `${YELLOW}!${RESET}` : `${DIM}i${RESET}`;
+  if (carried.length > 0) {
+    lines.push(`${BOLD}Findings${RESET}`);
+    for (const f of carried) {
+      lines.push(`  ${mark(f)} [${f.kind}]${f.role ? ` ${f.role}` : ""}: ${f.message}`);
+    }
+  }
+  if (informational.length > 0) {
+    if (carried.length > 0) lines.push("");
+    lines.push(`${BOLD}Informational${RESET} ${DIM}(true, but does not carry the verdict)${RESET}`);
+    for (const f of informational) {
+      lines.push(`  ${mark(f)} [${f.kind}]${f.role ? ` ${f.role}` : ""}: ${f.message}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function printUsage(exitCode: number): never {
+  console.log(`Usage: vlmkit check design <html-or-url> [options]
+
+Conformance to the design system the page itself implies: are components
+styled consistently, and does spacing stay on the page's own scale? Reports
+INCONSISTENCY, never which value is correct — taste stays with humans.
+
+Options:
+  --min-reuse <n>         Times each style must be reused (default 3)
+  --min-instances <n>     Instances before a role is judged (default 3)
+  --json                  Print JSON report
+  --storage-state <file>  Playwright storage state for pages behind a login
+  --advisory              Print findings but exit 0 (default: suspects exit 1)
+
+Findings are warn-level by design; a drifting design system is information,
+not a broken page. Study behind the thresholds:
+docs/design/design-policy-metrics.md`);
+  process.exit(exitCode);
+}
+
+async function main(argv = process.argv.slice(2)): Promise<void> {
+  if (argv.includes("--help") || argv.includes("-h")) printUsage(0);
+  let json = false;
+  let advisory = false;
+  let minReuse: number | undefined;
+  let minInstances: number | undefined;
+  let storageState: string | undefined;
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--json") json = true;
+    else if (arg === "--advisory") advisory = true;
+    else if (arg === "--fail-on-suspect") { /* accepted no-op: suspects already fail */ }
+    else if (arg === "--min-reuse") minReuse = Number.parseFloat(argv[++i] ?? "3");
+    else if (arg === "--min-instances") minInstances = Number.parseInt(argv[++i] ?? "3", 10);
+    else if (arg === "--storage-state") storageState = argv[++i];
+    else if (!arg.startsWith("-")) positional.push(arg);
+  }
+  const source = positional[0];
+  if (!source) printUsage(1);
+  const report = await runDesignPolicyCheck({
+    source,
+    ...(minReuse !== undefined ? { minReuse } : {}),
+    ...(minInstances !== undefined ? { minInstances } : {}),
+    ...(storageState ? { storageState } : {}),
+  });
+  if (json) console.log(JSON.stringify(report, null, 2));
+  else console.log(formatDesignReport(report));
+  applyGateExit(report.findings.some((f) => f.severity === "suspect"), { advisory });
+}
+
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "design-policy" ||
+  (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
+if (isCliEntry) main().catch(handleCliError);

--- a/packages/vlmkit-markup/src/style/design-policy.ts
+++ b/packages/vlmkit-markup/src/style/design-policy.ts
@@ -30,6 +30,7 @@
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { hasFlag, readFlag, readInt, readNumber, readPositionals } from "@mizchi/vlmkit-core/arg-reader.ts";
 import { applyGateExit } from "@mizchi/vlmkit-core/gate-exit.ts";
 import { withAuthState } from "@mizchi/vlmkit-core/auth-state.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
@@ -96,6 +97,13 @@ export interface DesignPolicyReport {
   skipped: number;
   statefulSkipped: number;
   spacingValues: number;
+  /**
+   * Thresholds this run actually used. In the report because the role table
+   * has to flag the same rows the verdict counted: reading them from the
+   * module defaults made `--min-reuse 2` print `drift` next to a role while
+   * the verdict said COHERENT.
+   */
+  thresholds: { minReuse: number; minInstances: number };
   verdict: "coherent" | "drift";
 }
 
@@ -117,6 +125,9 @@ export interface DesignPolicyOptions {
   outlierMaxUses?: number;
   storageState?: string;
 }
+
+/** Flags that consume the next argv entry, so the source positional is found. */
+const VALUE_FLAGS = ["min-reuse", "min-instances", "storage-state"];
 
 const DEFAULT_MIN_REUSE = 3;
 const DEFAULT_MIN_INSTANCES = 3;
@@ -335,6 +346,7 @@ export function judgeDesignPolicy(
     skipped: input.skipped,
     statefulSkipped: input.statefulSkipped,
     spacingValues: spacingCounts.size,
+    thresholds: { minReuse, minInstances },
     // `info` rows do not move the verdict, and `redirected` is a navigation
     // problem rather than a design one (it still exits non-zero, being suspect).
     verdict: findings.some((f) => f.severity === "warn") ? "drift" : "coherent",
@@ -388,9 +400,13 @@ export function formatDesignReport(report: DesignPolicyReport): string {
     + ` skipped: ${report.skipped} (no inferable role), ${report.statefulSkipped} (non-resting state)${RESET}`);
   lines.push("");
   if (report.roles.length > 0) {
-    lines.push(`${BOLD}Role reuse${RESET} ${DIM}(instances / distinct styles)${RESET}`);
+    lines.push(
+      `${BOLD}Role reuse${RESET} ${DIM}(instances / distinct styles;`
+      + ` drift below ${report.thresholds.minReuse}x from ${report.thresholds.minInstances} instances)${RESET}`,
+    );
+    const { minReuse, minInstances } = report.thresholds;
     for (const r of report.roles.slice(0, 10)) {
-      const flag = r.instances >= DEFAULT_MIN_INSTANCES && r.reuse < DEFAULT_MIN_REUSE ? `${YELLOW}drift${RESET}` : `${GREEN}ok${RESET}`;
+      const flag = r.instances >= minInstances && r.reuse < minReuse ? `${YELLOW}drift${RESET}` : `${GREEN}ok${RESET}`;
       lines.push(`  ${r.role.padEnd(14)} ${String(r.instances).padStart(3)} inst  ${String(r.signatures).padStart(3)} styles`
         + `  reuse ${String(r.reuse).padStart(5)}x  ${r.singletons} one-off  ${flag}`);
     }
@@ -441,24 +457,15 @@ docs/design/design-policy-metrics.md`);
 }
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
-  if (argv.includes("--help") || argv.includes("-h")) printUsage(0);
-  let json = false;
-  let advisory = false;
-  let minReuse: number | undefined;
-  let minInstances: number | undefined;
-  let storageState: string | undefined;
-  const positional: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]!;
-    if (arg === "--json") json = true;
-    else if (arg === "--advisory") advisory = true;
-    else if (arg === "--fail-on-suspect") { /* accepted no-op: suspects already fail */ }
-    else if (arg === "--min-reuse") minReuse = Number.parseFloat(argv[++i] ?? "3");
-    else if (arg === "--min-instances") minInstances = Number.parseInt(argv[++i] ?? "3", 10);
-    else if (arg === "--storage-state") storageState = argv[++i];
-    else if (!arg.startsWith("-")) positional.push(arg);
-  }
-  const source = positional[0];
+  if (hasFlag(argv, "help") || hasFlag(argv, "-h")) printUsage(0);
+  // Validated at read time: `--min-reuse abc` used to become NaN, and since
+  // every `reuse >= NaN` comparison is false, the gate would have reported
+  // every role as drifting instead of saying the flag was wrong.
+  const minReuse = readNumber(argv, "min-reuse", { min: 0 });
+  const minInstances = readInt(argv, "min-instances", { min: 1 });
+  const storageState = readFlag(argv, "storage-state");
+  const json = hasFlag(argv, "json");
+  const source = readPositionals(argv, VALUE_FLAGS)[0];
   if (!source) printUsage(1);
   const report = await runDesignPolicyCheck({
     source,
@@ -468,7 +475,9 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   });
   if (json) console.log(JSON.stringify(report, null, 2));
   else console.log(formatDesignReport(report));
-  applyGateExit(report.findings.some((f) => f.severity === "suspect"), { advisory });
+  applyGateExit(report.findings.some((f) => f.severity === "suspect"), {
+    advisory: hasFlag(argv, "advisory"),
+  });
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "design-policy" ||

--- a/packages/vlmkit-markup/src/style/design-tokens.ts
+++ b/packages/vlmkit-markup/src/style/design-tokens.ts
@@ -20,9 +20,9 @@
  * flags or a JSON config file.
  *
  * Usage:
- *   vrt design-tokens <html-or-url>
- *   vrt design-tokens <url> --radius-scale 0,4,8,12,16,24
- *   vrt design-tokens <url> --config tokens.json
+ *   vlmkit check tokens <html-or-url>
+ *   vlmkit check tokens <url> --radius-scale 0,4,8,12,16,24
+ *   vlmkit check tokens <url> --config tokens.json
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -314,7 +314,7 @@ export async function runDesignTokens(
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt design-tokens${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit check tokens${RESET}`);
   console.log(`  ${DIM}source: ${options.source}  inspected: ${byPath.size} element(s)${RESET}`);
   const byProperty = new Map<string, number>();
   for (const v of violations) byProperty.set(v.property, (byProperty.get(v.property) ?? 0) + 1);
@@ -397,7 +397,7 @@ function renderReport(r: Omit<DesignTokensReport, "reportPath">): string {
   lines.push("1. Replace each violating value with its nearest in-scale equivalent (the \"Nearest in-scale\" column).");
   lines.push("2. If a value needs to be off-scale (intentional outlier), document why in a comment — the violation is a code smell, not a hard ban.");
   lines.push("3. Consolidate `box-shadow` values into a small named tier set (e.g., `--shadow-sm`, `--shadow-md`, `--shadow-lg`) and reference the variables instead of inline values.");
-  lines.push("4. Re-run `vrt design-tokens`. The violation count should drop.");
+  lines.push("4. Re-run `vlmkit check tokens`. The violation count should drop.");
   lines.push("");
   return lines.join("\n");
 }
@@ -412,7 +412,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, configPath, strict, flagConfig } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt design-tokens <html-or-url> [options]");
+    console.log("Usage: vlmkit check tokens <html-or-url> [options]");
     console.log("Options:");
     console.log("  --config <path>           JSON config: { radius, spacing, zIndex, shadowTiers, tolerance }");
     console.log("  --radius-scale a,b,c,...  Allowed border-radius values (default: 0,2,4,6,8,12,16,20,24,32,48,999)");

--- a/packages/vlmkit-markup/src/style/design-tokens.ts
+++ b/packages/vlmkit-markup/src/style/design-tokens.ts
@@ -30,6 +30,7 @@ import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
+import { sourceToUrl } from "@mizchi/vlmkit-core/page-open.ts";
 
 export interface DesignTokenConfig {
   radius?: number[];
@@ -234,7 +235,7 @@ export async function runDesignTokens(
     if (isUrl(options.source)) {
       await page.goto(options.source, { waitUntil: "networkidle", timeout: 30000 });
     } else {
-      await page.setContent(html!, { waitUntil: "networkidle" });
+      await page.goto(sourceToUrl(options.source), { waitUntil: "networkidle", timeout: 30000 });
     }
     samples = await page.evaluate(SAMPLE_SCRIPT) as RawSample[];
     await page.close();

--- a/packages/vlmkit-markup/src/style/theme-parity.ts
+++ b/packages/vlmkit-markup/src/style/theme-parity.ts
@@ -27,7 +27,7 @@ import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { PNG } from "pngjs";
 import { chromium } from "playwright";
-import { openSource } from "@mizchi/vlmkit-core/page-open.ts";
+import { openSource, resolveSource } from "@mizchi/vlmkit-core/page-open.ts";
 import { extractComponentsFromFile, type ComponentBbox } from "../component/component-bbox.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
@@ -122,8 +122,9 @@ export async function runThemeParity(
 ): Promise<ThemeParityReport> {
   const outputDir = resolve(options.outputDir);
   await mkdir(outputDir, { recursive: true });
-  const htmlPath = resolve(options.htmlPath);
-  const html = await readFile(htmlPath, "utf-8");
+  // A URL is a valid source now that loading goes through `openSource`;
+  // `resolve()` would have turned it into `<cwd>/http:/host/page.html`.
+  const htmlPath = resolveSource(options.htmlPath);
   const viewport = options.viewport ?? { width: 1280, height: 900 };
   const unchangedThreshold = options.unchangedColorThreshold ?? 16;
 

--- a/packages/vlmkit-markup/src/style/theme-parity.ts
+++ b/packages/vlmkit-markup/src/style/theme-parity.ts
@@ -20,7 +20,7 @@
  * `prefers-color-scheme` media query.
  *
  * Usage:
- *   vrt theme-parity <html> [--output-dir dir]
+ *   vlmkit check theme <html> [--output-dir dir]
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
@@ -214,7 +214,7 @@ export async function runThemeParity(
     });
     await writeFile(reportPath, md);
 
-    console.log(`  ${BOLD}${CYAN}vrt theme-parity${RESET}`);
+    console.log(`  ${BOLD}${CYAN}vlmkit check theme${RESET}`);
     console.log(`  ${DIM}html: ${htmlPath}${RESET}`);
     const pct = (themePixelDelta * 100).toFixed(1);
     const themeIcon = themePixelDelta < 0.02 ? `${YELLOW}!${RESET}` : `${GREEN}✓${RESET}`;
@@ -291,7 +291,7 @@ function renderReport(r: Omit<ThemeParityReport, "reportPath">): string {
     lines.push("2. Replace the hard-coded color values in the CSS for those elements with " +
       "either a `var(--token)` reference, or matching dark-mode overrides via " +
       "`@media (prefers-color-scheme: dark)`.");
-    lines.push("3. Re-run `vrt theme-parity`. Unthemed count should drop to 0.");
+    lines.push("3. Re-run `vlmkit check theme`. Unthemed count should drop to 0.");
   } else {
     lines.push("Every detected component changed fill between themes. Page is theme-clean.");
   }
@@ -303,7 +303,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, threshold } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt theme-parity <html> [--output-dir dir]");
+    console.log("Usage: vlmkit check theme <html> [--output-dir dir]");
     console.log("Options:");
     console.log("  --output-dir <dir>   Default: ./test-results/theme-parity");
     console.log("  --report <path>      Markdown report path");

--- a/packages/vlmkit-markup/src/style/theme-parity.ts
+++ b/packages/vlmkit-markup/src/style/theme-parity.ts
@@ -27,6 +27,7 @@ import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { PNG } from "pngjs";
 import { chromium } from "playwright";
+import { openSource } from "@mizchi/vlmkit-core/page-open.ts";
 import { extractComponentsFromFile, type ComponentBbox } from "../component/component-bbox.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
@@ -129,8 +130,13 @@ export async function runThemeParity(
   const browser = await chromium.launch();
   try {
     // Light render.
-    const lightPage = await browser.newPage({ viewport, colorScheme: "light" });
-    await lightPage.setContent(html, { waitUntil: "networkidle" });
+    // Navigate, so an external stylesheet actually participates in the theme
+    // comparison — the whole point of the gate.
+    const { page: lightPage } = await openSource(browser, htmlPath, {
+      viewport,
+      colorScheme: "light",
+      settleMs: 0,
+    });
     // Disable transitions/animations for deterministic capture (cf.
     // Subagent H dogfood, same root cause as multi-state state diffs).
     await lightPage.addStyleTag({
@@ -144,8 +150,11 @@ export async function runThemeParity(
     await lightPage.close();
 
     // Dark render.
-    const darkPage = await browser.newPage({ viewport, colorScheme: "dark" });
-    await darkPage.setContent(html, { waitUntil: "networkidle" });
+    const { page: darkPage } = await openSource(browser, htmlPath, {
+      viewport,
+      colorScheme: "dark",
+      settleMs: 0,
+    });
     await darkPage.addStyleTag({
       content: `*, *::before, *::after {
         transition: none !important;

--- a/packages/vlmkit-markup/src/verify/markup-autofix.ts
+++ b/packages/vlmkit-markup/src/verify/markup-autofix.ts
@@ -38,6 +38,7 @@ import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { settlePage } from "@mizchi/vlmkit-core/page-open.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import {
   computeTrend,
@@ -199,6 +200,10 @@ export async function captureComputedStyles(
   try {
     const page = await browser.newPage({ viewport });
     await page.goto(pathToFileURL(resolve(attemptPath)).href, { waitUntil: "load" });
+    // Computed styles are read via `page.evaluate`, which does not auto-wait:
+    // a selector whose element renders after `load` came back `styles: null`,
+    // indistinguishable from a selector that genuinely does not exist.
+    await settlePage(page);
     const result = await page.evaluate(
       ({ sels, props }: { sels: string[]; props: string[] }) =>
         sels.map((selector) => {

--- a/packages/vlmkit-markup/src/verify/markup-verify.test.ts
+++ b/packages/vlmkit-markup/src/verify/markup-verify.test.ts
@@ -117,6 +117,31 @@ test("pixelPresence: full presence when the bbox holds the fill; zero when it do
   assert.equal(pixelPresence(img, { ...line, left: -20, top: -20 }), 0, "out-of-bounds bbox is absent");
 });
 
+// 2026-08-01 hard-target audit: a #f1f1f1 card was "pixel-confirmed
+// present" in a render where that area was plain white, because white is
+// only 14 units from the fill and the tolerance was 25. A presence test
+// that cannot separate the fill from the background is vacuous.
+test("pixelPresence: a low-contrast fill is not 'present' on a bare background", () => {
+  const white = { data: new Uint8Array(20 * 20 * 4).fill(255), width: 20, height: 20 };
+  const card = { left: 2, top: 2, width: 10, height: 10, hex: "#f1f1f1" };
+
+  // Without the background reference, plain white passes for the fill.
+  assert.equal(pixelPresence(white, card), 1, "documents the old, vacuous behavior");
+
+  // With it, the tolerance is clamped below the fill/background distance.
+  assert.equal(pixelPresence(white, card, 25, [255, 255, 255]), 0);
+
+  // And the fill itself is still detected where it genuinely is.
+  const withCard = { data: new Uint8Array(white.data), width: 20, height: 20 };
+  for (let y = 2; y < 12; y++) {
+    for (let x = 2; x < 12; x++) {
+      const i = (y * 20 + x) * 4;
+      withCard.data[i] = 241; withCard.data[i + 1] = 241; withCard.data[i + 2] = 241;
+    }
+  }
+  assert.equal(pixelPresence(withCard, card, 25, [255, 255, 255]), 1);
+});
+
 test("kickback near-miss: an extra whose fill sits 12px away in the target reads as displacement", () => {
   const hairline = component(3, 0, 645, 1280, 1, "#e7e5e4");
   const c = composition({ extra: [hairline] });

--- a/packages/vlmkit-markup/src/verify/markup-verify.ts
+++ b/packages/vlmkit-markup/src/verify/markup-verify.ts
@@ -39,6 +39,7 @@ import {
   type PageMatch,
 } from "../component/page-compose.ts";
 import { kindLabel } from "../component/component-classify.ts";
+import { detectBackground } from "../component/component-bbox.ts";
 import {
   captureRegionElementsFromHtml,
   matchRegionBboxToElement,
@@ -87,20 +88,42 @@ export interface TargetVerdict {
  * ring on one side (S7 endgame: three legs chased two "missing"
  * dividers whose pixels were correct all along). Before a missing or
  * extra blocks the verdict, sample the OTHER side's pixels at the
- * residual's own bbox (fill tolerance 25 — tight enough that white does
- * not pass for a light-gray hairline): if the fill is present there, the element
+ * residual's own bbox. The fill tolerance is clamped against the page
+ * background (see pixelPresence — a bare 25 let white pass for a
+ * light-gray fill): if the fill is present there, the element
  * exists and only the segmentation disagrees — report it, don't block
  * on it. Position still matters: the same line 30px away stays
  * blocking, because the bbox sample misses it.
+ */
+/**
+ * Share of the component's bbox whose pixels match its fill.
+ *
+ * `fillTolerance` absorbs JPEG ringing and antialiasing around a flat
+ * fill, but it must never be loose enough to swallow the page background:
+ * the 2026-08-01 hard-target audit found a `#f1f1f1` card "pixel-confirmed
+ * present" in a render where that area was plain white, because white sits
+ * only 14 units from the fill and the tolerance was 25. A presence test
+ * that cannot tell the fill from the background is vacuous, so pass
+ * `background` and the tolerance is clamped to stay strictly between them.
  */
 export function pixelPresence(
   image: { data: Uint8Array; width: number; height: number },
   component: Pick<PageComponent, "left" | "top" | "width" | "height" | "hex">,
   fillTolerance = 25,
+  background?: [number, number, number],
 ): number {
   const r0 = parseInt(component.hex.slice(1, 3), 16);
   const g0 = parseInt(component.hex.slice(3, 5), 16);
   const b0 = parseInt(component.hex.slice(5, 7), 16);
+  let tolerance = fillTolerance;
+  if (background) {
+    // Halve the fill-to-background distance and step inside it, so a
+    // background pixel can never be counted as the fill present.
+    const bgDist = Math.sqrt(
+      (background[0] - r0) ** 2 + (background[1] - g0) ** 2 + (background[2] - b0) ** 2,
+    );
+    if (bgDist > 0) tolerance = Math.max(1, Math.min(tolerance, Math.floor(bgDist / 2) - 1));
+  }
   let inside = 0;
   let matchingPixels = 0;
   for (let y = component.top; y < component.top + component.height; y++) {
@@ -112,7 +135,7 @@ export function pixelPresence(
       const dist = Math.sqrt(
         (image.data[i]! - r0) ** 2 + (image.data[i + 1]! - g0) ** 2 + (image.data[i + 2]! - b0) ** 2,
       );
-      if (dist <= fillTolerance) matchingPixels++;
+      if (dist <= tolerance) matchingPixels++;
     }
   }
   return inside === 0 ? 0 : matchingPixels / inside;
@@ -447,6 +470,9 @@ export async function runMarkupVerify(options: MarkupVerifyOptions): Promise<Mar
     const composeOptions = degraded ? { minArea: 1400 } : {};
     const presenceRatio = degraded ? 0.45 : 0.6;
     const presenceFillTolerance = degraded ? 35 : 25;
+    // Clamp the presence tolerance against the page background so a bare
+    // background pixel can never be read as "the fill is present here".
+    const presenceBg = detectBackground(target.data, target.width, target.height);
     const current = await renderHtmlToPng(options.attempt, target.width, target.height);
     const composition = composePageDiff(target, current, composeOptions);
     const shot = await fullPageRestShot(options.attempt, target.width, Math.min(target.height, 800));
@@ -475,9 +501,9 @@ export async function runMarkupVerify(options: MarkupVerifyOptions): Promise<Mar
       ownImage: { data: Uint8Array; width: number; height: number },
       otherImage: { data: Uint8Array; width: number; height: number },
     ): boolean => {
-      const self = pixelPresence(ownImage, component, presenceFillTolerance);
+      const self = pixelPresence(ownImage, component, presenceFillTolerance, presenceBg);
       if (self <= 0) return false;
-      return pixelPresence(otherImage, component, presenceFillTolerance) >= presenceRatio * self;
+      return pixelPresence(otherImage, component, presenceFillTolerance, presenceBg) >= presenceRatio * self;
     };
     const missingBlocking = composition.missing.filter((m) => !isSegmentationOnly(m, target, shot));
     const missingConfirmed = composition.missing.filter((m) => isSegmentationOnly(m, target, shot));
@@ -495,7 +521,7 @@ export async function runMarkupVerify(options: MarkupVerifyOptions): Promise<Mar
         side: "target" | "current",
         box: { left: number; top: number; width: number; height: number },
         hex: string,
-      ): number => pixelPresence(side === "target" ? target : shot, { ...box, hex });
+      ): number => pixelPresence(side === "target" ? target : shot, { ...box, hex }, presenceFillTolerance, presenceBg);
       targetKickback.push(...kickbackForComposition(label, {
         ...composition,
         missing: missingBlocking,

--- a/packages/vlmkit-mcp/package.json
+++ b/packages/vlmkit-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/vlmkit-mcp/src/server.ts
+++ b/packages/vlmkit-mcp/src/server.ts
@@ -8,7 +8,7 @@ import { TOOLS } from "./tools.ts";
 
 export function createVlmkitMcpServer(): McpServer {
   const server = new McpServer(
-    { name: "vlmkit", version: "0.8.0" },
+    { name: "vlmkit", version: "0.9.0" },
     {
       instructions:
         "vlmkit exposes deterministic (no-VLM) verification gates for markup: verify_markup (done-condition verdict + kickback), check_interactions (a11y-event state map + optional --reference behavioral contract), scan_handlers (wired event surface + pointer-only-control detection), check_copy (copy fidelity). Use these to gate generated/edited UI: the kickback text is the next-fix list. A residual is real unless the tool itself marks it pixel-confirmed/demoted.",

--- a/packages/vlmkit-mcp/src/tools.ts
+++ b/packages/vlmkit-mcp/src/tools.ts
@@ -224,14 +224,18 @@ const checkEquivalenceTool: McpTool = {
 const checkIntegrityTool: McpTool = {
   name: "check_integrity",
   description:
-    "Reference-free integrity gate for creative/zero-shot markup — no target image or manifest needed. Detects defects that are unambiguous without a reference: JS errors (construction-phase = fatal), empty/degenerate renders, broken images/stylesheets/scripts/fonts, same-layer text collisions, clipped text, collapsed containers, horizontal page overflow, and declared-but-unapplied styling, swept across multiple viewport widths. Deterministic (DOM + pixel math, no VLM). Intentional patterns (hero overlays, ellipsis truncation, positioning anchors) are exempted by tool-side rules and reported in `exempted` — audit the rule, don't re-litigate the finding. The kickback is a paste-ready, selector-attributed fix list.",
+    "Reference-free integrity gate for creative/zero-shot markup — no target image or manifest needed. Detects defects that are unambiguous without a reference: JS errors (construction-phase = fatal), empty/degenerate renders, broken images/stylesheets/scripts/fonts, same-layer text collisions, clipped text, collapsed containers, horizontal page overflow, and declared-but-unapplied styling, swept across multiple viewport widths. Deterministic (DOM + pixel math, no VLM). Intentional patterns (hero overlays, ellipsis truncation, positioning anchors) are exempted by tool-side rules and reported in `exempted` — audit the rule, don't re-litigate the finding. A pattern the tool does not recognise as intentional can be accepted per finding via `allow` (syntax `<kind>[@<selector>][@<viewport>];<reason>`); a reason is mandatory, an unknown kind is an error, accepted findings are still listed in `exempted` with that reason, and a rule matching nothing comes back in `unusedAllowRules`. Kinds meaning the page is broken (js-error, degenerate-render, unstyled-page, redirected) cannot be accepted — fix the page. The kickback is a paste-ready, selector-attributed fix list.",
   inputSchema: {
     source: z.string().describe("Path or URL of the page to check."),
     viewports: z.array(z.number()).optional().describe("Sweep widths (default 1280, 768, 375)."),
     maxFindings: z.number().optional().describe("Per-class report cap (default 12)."),
+    allow: z.array(z.string()).optional().describe(
+      "Exempt intentional patterns: `<kind>[@<selector>][@<viewport>];<reason>`, e.g. \"near-misalignment@.badge;optically centred\". The reason is required.",
+    ),
   },
   run: async (args) => {
     const { runIntegrityCheck } = await import("@mizchi/vlmkit-markup/inspect/integrity-check.ts");
+    const { parseAllowRules } = await import("@mizchi/vlmkit-markup/inspect/integrity-exemption.ts");
     const heights: Record<number, number> = { 1280: 800, 768: 900, 375: 700 };
     const report = await runIntegrityCheck({
       source: args.source as string,
@@ -239,10 +243,14 @@ const checkIntegrityTool: McpTool = {
         ? { viewports: (args.viewports as number[]).map((w) => ({ width: w, height: heights[w] ?? 800 })) }
         : {}),
       ...(args.maxFindings !== undefined ? { maxFindings: args.maxFindings as number } : {}),
+      ...(args.allow ? { allow: parseAllowRules(args.allow as string[]) } : {}),
     });
     const fails = report.findings.filter((f) => f.severity === "fail").length;
     const warns = report.findings.length - fails;
-    const summary = `check_integrity: ${report.verdict === "clean" ? "CLEAN" : "DEFECTS"} (${fails} fail, ${warns} warn, ${report.exempted.length} exempted)`;
+    const stale = report.unusedAllowRules?.length ?? 0;
+    const summary = `check_integrity: ${report.verdict === "clean" ? "CLEAN" : "DEFECTS"}`
+      + ` (${fails} fail, ${warns} warn, ${report.exempted.length} exempted`
+      + `${stale > 0 ? `, ${stale} allow-rule(s) matched nothing` : ""})`;
     return result(summary, report, report.verdict !== "clean");
   },
 };

--- a/packages/vlmkit-plan/package.json
+++ b/packages/vlmkit-plan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/vlmkit-plan",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Planner contract for Playwright test generation: turns a user story, seed test, PRD, and UI observations into a Markdown test plan.",
   "license": "MIT",
   "author": "mizchi",

--- a/scripts/smoke-dist.sh
+++ b/scripts/smoke-dist.sh
@@ -59,11 +59,11 @@ probe_exec() {
 
 echo "==> smoke-dist: $(node "$DIST" --version 2>&1)"
 
-# Top-level subcommand surface (matches the new vrt 0.5.0 group structure).
+# Top-level subcommand surface (matches the new vlmkit 0.5.0 group structure).
 probe_help "diff html"            "Usage:"                 diff html
 probe_help "diff agent"           "migration"              diff agent
 probe_help "diff png"             "PNG"                    diff png
-probe_help "migration compare"    "vrt compare"            migration compare
+probe_help "migration compare"    "vlmkit diff html"            migration compare
 probe_help "snapshot"             "snapshot"               snapshot
 probe_help "build component"      "Usage: vlmkit build component" build component
 probe_help "scan component"       "component-extract"      scan component

--- a/src/a11y-on-page.ts
+++ b/src/a11y-on-page.ts
@@ -1,7 +1,7 @@
 /**
  * Run the existing a11y checks (contrast + touch-target) on a
  * Playwright `Page` the caller already owns, without launching a
- * separate browser. Used by `vrt diff-pr` to fold a11y into its
+ * separate browser. Used by `vlmkit diff-pr` to fold a11y into its
  * per-route CI gate.
  *
  * The sample scripts and post-processors live in the existing

--- a/src/api/api-server.ts
+++ b/src/api/api-server.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * vrt API server
+ * vlmkit API server
  *
  * Built with Hono. For local Node.js execution.
  * Structured to share the same app factory with Cloudflare Workers.

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -1,5 +1,5 @@
 /**
- * vrt API type definitions
+ * vlmkit API type definitions
  *
  * Shared types for CLI, server (Hono), Cloudflare Workers, and Client SDK.
  * This is the source of truth for all interfaces.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,5 @@
 /**
- * vrt TypeScript Client SDK
+ * vlmkit TypeScript Client SDK
  *
  * Type-safe client for all API server endpoints.
  * Works in Node.js / Deno / browsers.

--- a/src/api/openapi.test.ts
+++ b/src/api/openapi.test.ts
@@ -9,7 +9,7 @@ describe("buildOpenApiSpec", () => {
     });
 
     assert.equal(spec.openapi, "3.1.0");
-    assert.equal(spec.info.title, "vrt HTTP API");
+    assert.equal(spec.info.title, "vlmkit HTTP API");
     assert.equal(spec.servers[0]?.url, "http://127.0.0.1:4567");
 
     assert.ok(spec.paths["/api/openapi.json"]);

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -53,7 +53,7 @@ export function buildOpenApiSpec(options: OpenApiSpecOptions = {}): OpenApiSpec 
   return {
     openapi: "3.1.0",
     info: {
-      title: "vrt HTTP API",
+      title: "vlmkit HTTP API",
       version: API_VERSION,
       description: "Visual regression testing, renderer comparison, reasoning, and smoke test endpoints.",
     },
@@ -77,7 +77,7 @@ export function buildOpenApiSpec(options: OpenApiSpecOptions = {}): OpenApiSpec 
                 "application/json": {
                   schema: {
                     type: "object",
-                    description: "The current OpenAPI document for the vrt HTTP API.",
+                    description: "The current OpenAPI document for the vlmkit HTTP API.",
                   },
                 },
               },

--- a/src/baseline-cli.test.ts
+++ b/src/baseline-cli.test.ts
@@ -51,7 +51,7 @@ describe("archiveRouteBaselines", () => {
   });
 });
 
-describe("vrt baseline approve", () => {
+describe("vlmkit baseline approve", () => {
   it("writes a selector approval rule with audit fields", async () => {
     const dir = await mkdtemp(join(tmpdir(), "vlmkit-approve-"));
     try {

--- a/src/baseline-cli.ts
+++ b/src/baseline-cli.ts
@@ -1,49 +1,49 @@
 #!/usr/bin/env node
 /**
- * `vrt baseline` — unified baseline surface that dispatches to the
+ * `vlmkit baseline` — unified baseline surface that dispatches to the
  * appropriate underlying flow.
  *
  * Two flows coexist intentionally:
  *
- *   - `vrt diff-pr` is the CI gate for an external project. Uses
+ *   - `vlmkit diff-pr` is the CI gate for an external project. Uses
  *     direct Playwright per route + per-route thresholds + manifest
  *     suppression. Baselines live at
  *     `<baselineDir>/<route>/<viewport>.png`.
  *
- *   - `vrt workflow` is vrt's own e2e dogfood harness. Uses a
+ *   - `vlmkit workflow` is vlmkit's own e2e dogfood harness. Uses a
  *     Playwright spec (`e2e/vlmkit-capture.spec.ts`) + bulk approval.
  *     Baselines live at `<VRT_ROOT>/baselines/*.png`.
  *
- * `vrt baseline` is the canonical name for the diff-pr flow —
+ * `vlmkit baseline` is the canonical name for the diff-pr flow —
  * the one external projects should pick first. The legacy
- * `vrt workflow {init,capture,verify,approve}` and `vrt diff-pr
+ * `vlmkit workflow {init,capture,verify,approve}` and `vlmkit diff-pr
  * {pin,run,post}` surfaces continue to work; this command is a
  * mnemonic alias.
  *
  * Subcommands:
- *   vrt baseline pin [route...] [--config vrt.config.json]
+ *   vlmkit baseline pin [route...] [--config vrt.config.json]
  *     Capture / refresh baseline PNGs for declared routes. Equivalent
- *     to `vrt diff-pr pin`.
+ *     to `vlmkit diff-pr pin`.
  *
- *   vrt baseline verify [--config vrt.config.json] [--output <dir>]
+ *   vlmkit baseline verify [--config vrt.config.json] [--output <dir>]
  *                       [--against-previous <dir>]
  *     Diff current rendering against pinned baselines + a11y +
- *     media-variants gates. Equivalent to `vrt diff-pr`.
+ *     media-variants gates. Equivalent to `vlmkit diff-pr`.
  *
- *   vrt baseline post --pr <ref> [--summary <path>] [--marker <id>]
+ *   vlmkit baseline post --pr <ref> [--summary <path>] [--marker <id>]
  *     Post a previously-generated summary.md as a PR comment.
- *     Equivalent to `vrt diff-pr post`.
+ *     Equivalent to `vlmkit diff-pr post`.
  *
- *   vrt baseline list [--config vrt.config.json]
+ *   vlmkit baseline list [--config vrt.config.json]
  *     Show all pinned baselines, last-modified timestamp, and which
  *     route they correspond to.
  *
- *   vrt baseline rm <route> [--config vrt.config.json]
+ *   vlmkit baseline rm <route> [--config vrt.config.json]
  *     Remove a single route's baselines.
  *
- * Internal-dogfood note: `vrt workflow` (legacy) still works and is
+ * Internal-dogfood note: `vlmkit workflow` (legacy) still works and is
  * the right call inside this repository for end-to-end testing of
- * vrt itself. It uses a Playwright spec + bulk approval.
+ * vlmkit itself. It uses a Playwright spec + bulk approval.
  */
 
 import { existsSync } from "node:fs";
@@ -84,11 +84,11 @@ async function cmdList(args: string[]): Promise<number> {
   }
   const config = loadDiffPrConfig(configPath);
   const baselineRoot = resolve(configBaseDirFor(config), config.baselineDir);
-  console.log(`${BOLD}${CYAN}vrt baseline list${RESET}  ${DIM}${configPath}${RESET}`);
+  console.log(`${BOLD}${CYAN}vlmkit baseline list${RESET}  ${DIM}${configPath}${RESET}`);
   console.log(`${DIM}  ${baselineRoot}${RESET}`);
   console.log();
   if (!existsSync(baselineRoot)) {
-    console.log(`  ${DIM}(no baselines yet — run \`vrt baseline pin\`)${RESET}`);
+    console.log(`  ${DIM}(no baselines yet — run \`vlmkit baseline pin\`)${RESET}`);
     return 0;
   }
   for (const route of config.routes) {
@@ -157,7 +157,7 @@ async function cmdRm(args: string[]): Promise<number> {
 
 /**
  * Move a route's current baseline PNGs into `_history/<timestamp>/` so a
- * re-pin (`vrt baseline update`) is reversible. Returns the number of files
+ * re-pin (`vlmkit baseline update`) is reversible. Returns the number of files
  * archived. Pure file IO — no Playwright — so it is unit-testable.
  */
 export async function archiveRouteBaselines(
@@ -271,7 +271,7 @@ async function cmdApprove(args: string[]): Promise<number> {
   const reason = getArg(args, "reason");
   if ((!selector && !regionRaw) || !reason) {
     console.error(`${RED}error:${RESET} a --selector or --region, plus --reason, are required`);
-    console.error(`\n  vrt baseline approve (--selector <css> | --region "x=,y=,w=,h=[,viewport=]") --reason <text> [--max-px N] [--max-ratio R] [--expires YYYY-MM-DD] [--acknowledged-by name] [--kind visual] [--manifest approval.json] [--dry-run]`);
+    console.error(`\n  vlmkit baseline approve (--selector <css> | --region "x=,y=,w=,h=[,viewport=]") --reason <text> [--max-px N] [--max-ratio R] [--expires YYYY-MM-DD] [--acknowledged-by name] [--kind visual] [--manifest approval.json] [--dry-run]`);
     return 1;
   }
   const maxPxRaw = getArg(args, "max-px");
@@ -310,7 +310,7 @@ async function cmdApprove(args: string[]): Promise<number> {
   const json = JSON.stringify(merged, null, 2) + "\n";
 
   if (dryRun) {
-    console.log(`${BOLD}${CYAN}vrt baseline approve${RESET} ${DIM}(dry-run — ${manifestPath})${RESET}`);
+    console.log(`${BOLD}${CYAN}vlmkit baseline approve${RESET} ${DIM}(dry-run — ${manifestPath})${RESET}`);
     console.log(json);
     return 0;
   }
@@ -322,17 +322,17 @@ async function cmdApprove(args: string[]): Promise<number> {
 }
 
 function formatUsage(): string {
-  return `vrt baseline <command>
+  return `vlmkit baseline <command>
 
 Subcommands:
   pin     [route...] [--config vrt.config.json]
                               Capture / refresh baseline PNGs for
-                              declared routes. Alias for \`vrt diff-pr pin\`.
+                              declared routes. Alias for \`vlmkit diff-pr pin\`.
   verify  [--config vrt.config.json] [--output <dir>]
                               Diff current rendering against pinned
-                              baselines. Alias for \`vrt diff-pr\`.
+                              baselines. Alias for \`vlmkit diff-pr\`.
   post    --pr <ref>          Post the most recent summary.md to a PR.
-                              Alias for \`vrt diff-pr post\`.
+                              Alias for \`vlmkit diff-pr post\`.
   update  [route...] [--config vrt.config.json]
                               Archive current baselines to _history/<ts>/
                               and re-pin (reversible golden refresh).
@@ -349,9 +349,9 @@ Subcommands:
                               (any diff inside it is accepted; audit fields
                               recorded).
 
-\`vrt workflow {init,capture,verify,approve}\` is the legacy vrt-
+\`vlmkit workflow {init,capture,verify,approve}\` is the legacy vlmkit-
 internal dogfood path (uses a Playwright spec + bulk approval).
-\`vrt baseline\` is the canonical surface for external projects.`;
+\`vlmkit baseline\` is the canonical surface for external projects.`;
 }
 
 async function main(argv = process.argv.slice(2)): Promise<void> {

--- a/src/cli/binary-name.test.ts
+++ b/src/cli/binary-name.test.ts
@@ -1,13 +1,13 @@
 /**
- * No command may tell the reader to run `vlmkit`.
+ * No command may tell the reader to run `vrt`.
  *
- * There is no `vlmkit` binary — `package.json` ships `bin: { vlmkit }` only — so
+ * There is no `vrt` binary — `package.json` ships `bin: { vlmkit }` only — so
  * every `vrt <something>` in help text, a usage line or a fix instruction was an
  * instruction the reader could not paste. `vrt a11y-contrast` was wrong twice
  * over: dead binary AND a deprecated subcommand name.
  *
  * This test also pins the *exceptions*, which is the more useful half. A sweep
- * of the whole tree found ~1670 occurrences of `vlmkit`, and they are not one
+ * of the whole tree found ~1670 occurrences of `vrt`, and they are not one
  * thing:
  *
  *   renamed here          `vrt <cmd>` in help/usage/comments -> `vlmkit <cmd>`
@@ -45,7 +45,7 @@ const COMMANDS = [
 ];
 
 /**
- * `vlmkit` spellings that name something real and must survive. Each is a live
+ * `vrt` spellings that name something real and must survive. Each is a live
  * value, not prose — see the header for why renaming them is a separate,
  * breaking change.
  */
@@ -77,7 +77,7 @@ function offenders(text: string): string[] {
   return [...t.matchAll(/vrt[\s-][\w-]*/g)].map((m) => m[0].trim());
 }
 
-describe("no command tells the reader to run `vlmkit`", () => {
+describe("no command tells the reader to run `vrt`", () => {
   it("package.json ships only the vlmkit binary — the premise of this test", () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8")) as { bin: Record<string, string> };
     assert.deepEqual(Object.keys(pkg.bin), ["vlmkit"]);
@@ -133,5 +133,48 @@ describe("a rename never leaves a definition and its reference disagreeing", () 
       }
     }
     assert.deepEqual(problems, [], problems.join("\n"));
+  });
+});
+
+describe("the rename did not invert text that is about the old name", () => {
+  /**
+   * Fourth instance of the same failure in one day, and the first three were
+   * only caught by reading the diff. A sweep that replaces `vrt` with `vlmkit`
+   * corrupts any sentence whose subject IS the old name, and the corruption is
+   * invisible to tsc and to every other test:
+   *
+   *   "There is no `vrt` binary"        -> "There is no `vlmkit` binary"
+   *   "~1670 occurrences of `vrt`"      -> "~1670 occurrences of `vlmkit`"
+   *   "no word boundary before `vrt`"   -> "… before `vlmkit`"
+   *
+   * Each reads as confident documentation and says the opposite of the truth.
+   * This is a cheap, general detector: the shipped binary exists, so no file may
+   * claim it does not.
+   */
+  it("no file claims the shipped binary does not exist", () => {
+    const files = execFileSync("git", ["ls-files", "*.ts", "*.md"], { cwd: ROOT, encoding: "utf8" })
+      .split("\n").filter(Boolean);
+    const claims: string[] = [];
+    for (const f of files) {
+      const text = readFileSync(resolve(ROOT, f), "utf8");
+      text.split("\n").forEach((line, i) => {
+        if (!/\bno\s+`?vlmkit`?\s+binary\b/i.test(line)) return;
+        // An old -> new illustration is not a claim. Narrowly defined: a line
+        // that shows a quoted before AND a quoted after, separated by an arrow —
+        // the shape the comment above uses. Excluding every line with an arrow
+        // would repeat the mistake this whole gate is about.
+        if (/".*`vrt`.*"\s*(?:->|→)\s*".*`vlmkit`.*"/.test(line)) return;
+        claims.push(`${f}:${i + 1}: ${line.trim()}`);
+      });
+    }
+    assert.deepEqual(claims, [], claims.join("\n"));
+  });
+
+  it("this file still quotes the old name it exists to talk about", () => {
+    // If a future sweep erases `vrt` from here, the header stops explaining why
+    // the allowlist exists and the exceptions look arbitrary.
+    const self = readFileSync(resolve(ROOT, "src", "cli", "binary-name.test.ts"), "utf8");
+    assert.match(self, /There is no `vrt` binary/);
+    assert.match(self, /`vrt a11y-contrast` was wrong twice over/);
   });
 });

--- a/src/cli/binary-name.test.ts
+++ b/src/cli/binary-name.test.ts
@@ -1,13 +1,13 @@
 /**
- * No command may tell the reader to run `vrt`.
+ * No command may tell the reader to run `vlmkit`.
  *
- * There is no `vrt` binary — `package.json` ships `bin: { vlmkit }` only — so
+ * There is no `vlmkit` binary — `package.json` ships `bin: { vlmkit }` only — so
  * every `vrt <something>` in help text, a usage line or a fix instruction was an
  * instruction the reader could not paste. `vrt a11y-contrast` was wrong twice
  * over: dead binary AND a deprecated subcommand name.
  *
  * This test also pins the *exceptions*, which is the more useful half. A sweep
- * of the whole tree found ~1670 occurrences of `vrt`, and they are not one
+ * of the whole tree found ~1670 occurrences of `vlmkit`, and they are not one
  * thing:
  *
  *   renamed here          `vrt <cmd>` in help/usage/comments -> `vlmkit <cmd>`
@@ -45,7 +45,7 @@ const COMMANDS = [
 ];
 
 /**
- * `vrt` spellings that name something real and must survive. Each is a live
+ * `vlmkit` spellings that name something real and must survive. Each is a live
  * value, not prose — see the header for why renaming them is a separate,
  * breaking change.
  */
@@ -77,7 +77,7 @@ function offenders(text: string): string[] {
   return [...t.matchAll(/vrt[\s-][\w-]*/g)].map((m) => m[0].trim());
 }
 
-describe("no command tells the reader to run `vrt`", () => {
+describe("no command tells the reader to run `vlmkit`", () => {
   it("package.json ships only the vlmkit binary — the premise of this test", () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8")) as { bin: Record<string, string> };
     assert.deepEqual(Object.keys(pkg.bin), ["vlmkit"]);
@@ -112,5 +112,26 @@ describe("the allowlist is real, not slack", () => {
     for (const a of ALLOWED) {
       assert.ok(src.includes(a), `${a} is allowlisted but no longer appears in the source — drop it`);
     }
+  });
+});
+
+describe("a rename never leaves a definition and its reference disagreeing", () => {
+  it("every GitHub Actions step id referenced by `steps.<id>` is defined", () => {
+    // Caught during this rename: `- id: vrt` was renamed to `- id: vlmkit`
+    // while the `if: steps.vrt.outcome == 'failure'` that consumes it was NOT,
+    // because `steps.vrt.outcome` has `vrt` followed by a dot and did not match
+    // the sweep's pattern. The template still parsed — the review step just
+    // silently never ran.
+    const files = execFileSync("git", ["ls-files", "*.yml", "*.yaml"], { cwd: ROOT, encoding: "utf8" })
+      .split("\n").filter(Boolean);
+    const problems: string[] = [];
+    for (const f of files) {
+      const text = readFileSync(resolve(ROOT, f), "utf8");
+      const defined = new Set([...text.matchAll(/^\s*-?\s*id:\s*([\w-]+)/gm)].map((m) => m[1]!));
+      for (const m of text.matchAll(/steps\.([\w-]+)\./g)) {
+        if (!defined.has(m[1]!)) problems.push(`${f}: steps.${m[1]} is referenced but no step declares that id`);
+      }
+    }
+    assert.deepEqual(problems, [], problems.join("\n"));
   });
 });

--- a/src/cli/binary-name.test.ts
+++ b/src/cli/binary-name.test.ts
@@ -1,0 +1,116 @@
+/**
+ * No command may tell the reader to run `vrt`.
+ *
+ * There is no `vrt` binary — `package.json` ships `bin: { vlmkit }` only — so
+ * every `vrt <something>` in help text, a usage line or a fix instruction was an
+ * instruction the reader could not paste. `vrt a11y-contrast` was wrong twice
+ * over: dead binary AND a deprecated subcommand name.
+ *
+ * This test also pins the *exceptions*, which is the more useful half. A sweep
+ * of the whole tree found ~1670 occurrences of `vrt`, and they are not one
+ * thing:
+ *
+ *   renamed here          `vrt <cmd>` in help/usage/comments -> `vlmkit <cmd>`
+ *   NOT renamed           `.vrt/`, `.vrt-skills/`, `vrt.config.json`, `VRT_*`
+ *                         — live paths, filenames and env vars; renaming them
+ *                         orphans existing baselines, configs and CI
+ *   NOT renamed           `src/vrt/` — a real source directory
+ *   NOT renamed           `.claude/skills/vrt-*` — real skill directory names
+ *   NOT renamed           `"X-Title": "vrt"`, `projectName: "vrt"`, the plan
+ *                         schema's `vrt?:` field, `title: "vrt HTTP API"` —
+ *                         values on the wire, in snapshot paths, in user files
+ *   NOT renamed           docs/reports/*, CHANGELOG.md, docs/migration-0.5.md
+ *                         — dated records and the old->new mapping itself
+ *
+ * So the allowlist below is not slack in the test; it is the boundary between a
+ * naming fix and a breaking change.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dirname!, "..", "..");
+// The real entry: `cli.ts` prints help but the deprecation shims that route
+// an alias to its leaf live in `vlmkit.ts`, so pointing at cli.ts made the
+// alias case return empty output and "pass" for the wrong reason.
+const ENTRY = resolve(ROOT, "src", "cli", "vlmkit.ts");
+
+/** Every top-level command the CLI advertises as current (not a deprecated alias). */
+const COMMANDS = [
+  "diff", "check", "inspect", "stress", "scan", "build", "contract", "heal", "verify",
+  "snapshot", "migration", "workflow", "bench", "report", "skill", "markup-loop",
+  "api", "mcp", "batch", "gates", "manifest", "watch", "diff-pr", "baseline",
+];
+
+/**
+ * `vrt` spellings that name something real and must survive. Each is a live
+ * value, not prose — see the header for why renaming them is a separate,
+ * breaking change.
+ */
+const ALLOWED = [
+  ".vrt-skills",      // state directory `vlmkit skill` reads
+  ".vrt/",            // state directory (baselines, runs, last-diff-for-agent)
+  "vrt.config.json",  // default config filename `diff-pr` / `baseline` resolve
+  "vrt.config.toml",
+  "VRT_",             // environment variables
+];
+
+const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+function help(args: string[]): string {
+  try {
+    return strip(execFileSync(process.execPath, ["--experimental-strip-types", ENTRY, ...args],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, NO_COLOR: "1" } }));
+  } catch (e) {
+    // Several groups exit non-zero when given no leaf; the text is what matters.
+    const err = e as { stdout?: string; stderr?: string };
+    return strip((err.stdout ?? "") + (err.stderr ?? ""));
+  }
+}
+
+/** Offending `vrt …` mentions, with the allowlisted spellings removed first. */
+function offenders(text: string): string[] {
+  let t = text;
+  for (const a of ALLOWED) t = t.split(a).join("«ok»");
+  return [...t.matchAll(/vrt[\s-][\w-]*/g)].map((m) => m[0].trim());
+}
+
+describe("no command tells the reader to run `vrt`", () => {
+  it("package.json ships only the vlmkit binary — the premise of this test", () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8")) as { bin: Record<string, string> };
+    assert.deepEqual(Object.keys(pkg.bin), ["vlmkit"]);
+  });
+
+  it("root --help is clean", () => {
+    assert.deepEqual(offenders(help(["--help"])), []);
+  });
+
+  for (const cmd of COMMANDS) {
+    it(`\`vlmkit ${cmd} --help\` is clean`, () => {
+      const found = offenders(help([cmd, "--help"]));
+      assert.deepEqual(found, [], `${cmd} --help still says: ${found.join(", ")}`);
+    });
+  }
+
+  it("a deprecated alias still routes, and lands on help naming the CURRENT command", () => {
+    // The alias is kept on purpose (removed in 1.0.0). What was broken is that
+    // the help it delegates to described itself by the dead name.
+    const text = help(["png-diff", "--help"]);
+    assert.match(text, /vlmkit diff png/);
+    assert.deepEqual(offenders(text), []);
+  });
+});
+
+describe("the allowlist is real, not slack", () => {
+  it("each allowlisted spelling is actually present in the source", () => {
+    // If one of these stops existing, the exception should be deleted rather
+    // than left as a hole the next sweep can drive through.
+    const src = execFileSync("git", ["grep", "-rhoE", ALLOWED.map((a) =>
+      a.replace(/[.]/g, "\\.")).join("|"), "--", "*.ts"], { cwd: ROOT, encoding: "utf8" });
+    for (const a of ALLOWED) {
+      assert.ok(src.includes(a), `${a} is allowlisted but no longer appears in the source — drop it`);
+    }
+  });
+});

--- a/src/cli/binary-name.test.ts
+++ b/src/cli/binary-name.test.ts
@@ -178,3 +178,29 @@ describe("the rename did not invert text that is about the old name", () => {
     assert.match(self, /`vrt a11y-contrast` was wrong twice over/);
   });
 });
+
+describe("workflows that run a src/ entrypoint build the packages first", () => {
+  it("no job invokes src/ without pnpm build:packages", () => {
+    // 0.8.1 made the workspace packages publish compiled JS, so their `exports`
+    // map deep imports to `./dist/*` and `node src/cli/vlmkit.ts` cannot resolve
+    // `@mizchi/vlmkit-core/cli-error.ts` until the packages are built. Four
+    // workflows were never updated, and the failure is a bare
+    // ERR_MODULE_NOT_FOUND that says nothing about a missing build step.
+    // Reproduced on a clean `origin/main` checkout, so this is not branch-local.
+    //
+    // `pnpm test` counts as satisfying it — `pretest` runs build:packages.
+    const files = execFileSync("git", ["ls-files", ".github/workflows/*.yml"], { cwd: ROOT, encoding: "utf8" })
+      .split("\n").filter(Boolean);
+    const missing: string[] = [];
+    for (const f of files) {
+      const text = readFileSync(resolve(ROOT, f), "utf8");
+      for (const job of text.split(/^ {2}(?=[\w-]+:$)/m)) {
+        const name = /^([\w-]+):/.exec(job)?.[1] ?? "?";
+        const runsSrc = /node (?:--experimental-strip-types )?src\//.test(job);
+        const builds = /build:packages|pnpm test\b/.test(job);
+        if (runsSrc && !builds) missing.push(`${f}:${name}`);
+      }
+    }
+    assert.deepEqual(missing, [], `these jobs will fail with ERR_MODULE_NOT_FOUND: ${missing.join(", ")}`);
+  });
+});

--- a/src/cli/binary-name.test.ts
+++ b/src/cli/binary-name.test.ts
@@ -197,7 +197,9 @@ describe("workflows that run a src/ entrypoint build the packages first", () => 
       for (const job of text.split(/^ {2}(?=[\w-]+:$)/m)) {
         const name = /^([\w-]+):/.exec(job)?.[1] ?? "?";
         const runsSrc = /node (?:--experimental-strip-types )?src\//.test(job);
-        const builds = /build:packages|pnpm test\b/.test(job);
+        // `build:packages:js` counts: it emits the same dist, skipping only the
+        // MoonBit step, which is loaded at runtime rather than needed to build.
+        const builds = /build:packages(:js)?|pnpm test\b/.test(job);
         if (runsSrc && !builds) missing.push(`${f}:${name}`);
       }
     }

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -88,7 +88,7 @@ describe("vrt CLI tree (cac-based)", () => {
   it("`vrt diff png --help` delegates to the png-diff module's help", () => {
     const r = runVrt(["diff", "png", "--help"]);
     // png-diff exits 0 after printing help
-    assert.match(r.stdout, /vrt png-diff <baseline\.png> <current\.png>/);
+    assert.match(r.stdout, /vlmkit diff png <baseline\.png> <current\.png>/);
   });
 
   it("`vrt diff region --help` delegates to the VLM region-diff helper", () => {
@@ -105,14 +105,16 @@ describe("vrt CLI tree (cac-based)", () => {
   it("`vrt diff component --help` delegates to element-level comparison help", () => {
     const r = runVrt(["diff", "component", "--help"]);
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /vrt diff component/);
+    assert.match(r.stdout, /vlmkit diff component/);
     assert.match(r.stdout, /--selectors/);
   });
 
   it("deprecated `vrt png-diff` warns and delegates", () => {
     const r = runVrt(["png-diff", "--help"]);
     assert.match(r.stderr, /\[vlmkit deprecated\] 'png-diff' → 'vlmkit diff png'/);
-    assert.match(r.stdout, /vrt png-diff <baseline\.png>/);
+    // The alias still routes, and the help it lands on names the CURRENT
+    // command — the old usage line was the thing being fixed.
+    assert.match(r.stdout, /vlmkit diff png <baseline\.png>/);
   });
 
   it("deprecated workflow alias `vrt init` warns (without actually running init)", () => {

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -27,7 +27,7 @@ function runVrt(args: string[]): { stdout: string; stderr: string; status: numbe
   };
 }
 
-describe("vrt CLI tree (cac-based)", () => {
+describe("vlmkit CLI tree (cac-based)", () => {
   it("`vrt --version` matches the package release", () => {
     const r = runVrt(["--version"]);
     assert.equal(r.status, 0);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -83,6 +83,12 @@ async function runDiscover(args: string[]): Promise<void> {
   console.log(`  \x1b[1mViewports (${result.viewports.length}):\x1b[0m`);
   for (const vp of result.viewports) console.log(`    ${String(vp.width).padStart(5)}px  ${vp.label.padEnd(16)} \x1b[2m${vp.reason}\x1b[0m`);
   console.log();
+  const { appendRunLedger } = await import("@mizchi/vlmkit-core/run-ledger.ts");
+  appendRunLedger({
+    tool: "scan-breakpoints",
+    source: file,
+    headline: { breakpoints: result.breakpoints.length, viewports: result.viewports.length },
+  });
 }
 
 async function runApiStatus(args: string[]): Promise<void> {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -143,6 +143,7 @@ const SPECS: Record<string, Spec> = {
   mediaVariants: spec("media-variants", () => import("@mizchi/vlmkit-markup/stress/media-variants.ts")),
   crossBrowser: spec("cross-browser", () => import("@mizchi/vlmkit-markup/stress/cross-browser.ts")),
   designTokens: spec("design-tokens", () => import("@mizchi/vlmkit-markup/style/design-tokens.ts")),
+  designPolicy: spec("design-policy", () => import("@mizchi/vlmkit-markup/style/design-policy.ts")),
   motionDetect: spec("motion-detect", () => import("@mizchi/vlmkit-markup/style/motion-detect.ts")),
   animationEval: spec("animation-eval", () => import("@mizchi/vlmkit-markup/style/animation-eval.ts")),
   scrollScan: spec("scroll-scan", () => import("@mizchi/vlmkit-markup/inspect/scroll-scan.ts")),
@@ -185,7 +186,8 @@ const GROUPS: Record<string, Record<string, { spec?: Spec; run?: (args: string[]
   },
   check: {
     palette: { spec: SPECS.palette, desc: "Dominant colors of a PNG, or palette diff of two PNGs" },
-    tokens: { spec: SPECS.designTokens, desc: "Design-token scale conformance" },
+    tokens: { spec: SPECS.designTokens, desc: "Design-token scale conformance (against a scale YOU declare)" },
+    design: { spec: SPECS.designPolicy, desc: "Coherence of the design system the page itself implies (component/spacing consistency)" },
     theme: { spec: SPECS.themeParity, desc: "Theme parity (hard-coded color scan in dark mode)" },
     motion: { spec: SPECS.motionDetect, desc: "CSS motion detection (animation / transition / reduced-motion)" },
     animation: { spec: SPECS.animationEval, desc: "Frame-sampled animation evaluation (visible effect / settle / reduced-motion behavior)" },

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -134,6 +134,7 @@ const SPECS: Record<string, Spec> = {
   presenceMatrix: spec("presence-matrix", () => import("./commands/presence-matrix-cli.ts")),
   compareRuns: spec("compare-runs-cli", () => import("./commands/compare-runs-cli.ts")),
   batch: spec("batch", () => import("./commands/batch-cli.ts")),
+  gates: spec("gates", () => import("./commands/gates-cli.ts")),
   componentFromImage: spec("component-from-image", () => import("@mizchi/vlmkit-markup/component/component-from-image.ts")),
   contractIntrospect: spec("contract-introspect", () => import("@mizchi/vlmkit-markup/contract/introspect-contract.ts")),
   contractValidate: spec("contract-validate", () => import("@mizchi/vlmkit-markup/contract/validate-contract.ts")),
@@ -423,6 +424,8 @@ REPAIR
 RUN GATES OVER A WHOLE SITE
   batch --gate "<gate>" <glob...>     every matched page in parallel; --shard i/n
                                       for CI runners, --output for per-job logs
+  gates init|list|run                 same, from one reviewed vlmkit.gates.json
+  gates suppressions                  every silenced check with reason/owner/expiry
 
 FOR CODING AGENTS AND PIPELINES
   mcp                                 MCP server exposing the gates (stdio)
@@ -541,6 +544,10 @@ Run \`vlmkit <command> --help\` for options; most gates take --json and
   cli.command("batch [...args]", "Run gates over many pages in parallel (glob, sharding, per-job timing)")
     .allowUnknownOptions()
     .action(async () => delegate(SPECS.batch, passThrough(argv, ["batch"])));
+
+  cli.command("gates [...args]", "One reviewed config for per-page gate sets + auditable suppressions")
+    .allowUnknownOptions()
+    .action(async () => delegate(SPECS.gates, passThrough(argv, ["gates"])));
 
   cli.command("manifest [...args]", "Author / edit approval.json manifests")
     .allowUnknownOptions()

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,5 +1,5 @@
 /**
- * cac-based command tree for `vrt` (0.5.0+).
+ * cac-based command tree for `vlmkit` (0.5.0+).
  *
  * cac doesn't natively support multi-token command names, so we use a
  * two-level routing strategy: cac matches the top-level verb
@@ -9,7 +9,7 @@
  * `process.argv` swap — individual command files don't need to migrate
  * to a function-style API in this PR.
  *
- * Old top-level commands (`vrt compare`, `vrt a11y-touch`, etc.) remain
+ * Old top-level commands (`vlmkit diff html`, `vlmkit check a11y touch`, etc.) remain
  * as deprecation shims at the top level (still single-token, so cac
  * matches them directly).
  */
@@ -32,7 +32,7 @@ const CLI_ENTRY = process.argv[1];
  * closure that returns the dynamic import — keeping the path as a
  * literal at the `import()` call site lets tsdown statically
  * discover the leaf and code-split it into a chunk that ships with
- * `dist/vrt.mjs`.
+ * `dist/vlmkit.mjs`.
  *
  * The `name` is a per-leaf identifier set into `__VRT_DISPATCHER_LEAF__`
  * around the await. Each leaf's CLI-entry guard checks that the env
@@ -440,7 +440,7 @@ Run \`vlmkit <command> --help\` for options; most gates take --json and
       .allowUnknownOptions()
       .action(async () => {
         const groupArgs = passThrough(argv, [groupName]);
-        // `vrt diff --help` (no leaf, just help) → group usage.
+        // `vlmkit diff --help` (no leaf, just help) → group usage.
         // passThrough rewrites --help/-h to HELP_SENTINEL so cac
         // doesn't intercept; we restore the semantics here.
         if (
@@ -465,7 +465,7 @@ Run \`vlmkit <command> --help\` for options; most gates take --json and
   }
 
   // Snapshot / workflow / bench / api / report / skill (single-token).
-  // `vrt snapshot flipbook ...` is special-cased to delegate directly
+  // `vlmkit snapshot flipbook ...` is special-cased to delegate directly
   // to the flipbook CLI (snapshot.ts doesn't have a `flipbook` mode).
   cli.command("snapshot [...args]", "Multi-viewport snapshot baseline + diff")
     .allowUnknownOptions()
@@ -621,7 +621,10 @@ Run \`vlmkit <command> --help\` for options; most gates take --json and
   // Mask --help/-h so cac doesn't intercept; passThrough restores it.
   const maskedArgv = argv.map((a) => (a === "--help" || a === "-h" ? HELP_SENTINEL : a));
 
-  cli.parse(["node", "vrt", ...maskedArgv], { run: false });
+  // argv[1] is a placeholder — cac reads from index 2 and takes its display
+  // name from `cac("vlmkit")` above — but leaving the old binary name here
+  // invites the next reader to think the program is still called vrt.
+  cli.parse(["node", "vlmkit", ...maskedArgv], { run: false });
   if (cli.matchedCommand) {
     await cli.runMatchedCommand();
   } else {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -20,6 +20,14 @@ import { reportDeprecation } from "./deprecation.ts";
 const HELP_SENTINEL = "__VRT_HELP_PASSTHROUGH__";
 
 /**
+ * The script this CLI was started from, captured at import time — `delegate`
+ * overwrites `process.argv` before any leaf runs, so a leaf that needs to spawn
+ * another gate (`vlmkit batch`) can no longer find it. Read at module scope,
+ * which runs before the first delegate call.
+ */
+const CLI_ENTRY = process.argv[1];
+
+/**
  * Each leaf is referenced as `{ name, loader }`. The loader is a
  * closure that returns the dynamic import — keeping the path as a
  * literal at the `import()` call site lets tsdown statically
@@ -50,6 +58,7 @@ async function delegate(s: Spec, args: string[]): Promise<void> {
   ];
   const prev = process.env.__VRT_DISPATCHER_LEAF__;
   process.env.__VRT_DISPATCHER_LEAF__ = s.name;
+  if (CLI_ENTRY) process.env.__VLMKIT_CLI_ENTRY__ = CLI_ENTRY;
   try {
     await s.loader();
   } finally {
@@ -124,6 +133,7 @@ const SPECS: Record<string, Spec> = {
   diffForAgent: spec("diff-for-agent-cli", () => import("./commands/diff-for-agent-cli.ts")),
   presenceMatrix: spec("presence-matrix", () => import("./commands/presence-matrix-cli.ts")),
   compareRuns: spec("compare-runs-cli", () => import("./commands/compare-runs-cli.ts")),
+  batch: spec("batch", () => import("./commands/batch-cli.ts")),
   componentFromImage: spec("component-from-image", () => import("@mizchi/vlmkit-markup/component/component-from-image.ts")),
   contractIntrospect: spec("contract-introspect", () => import("@mizchi/vlmkit-markup/contract/introspect-contract.ts")),
   contractValidate: spec("contract-validate", () => import("@mizchi/vlmkit-markup/contract/validate-contract.ts")),
@@ -396,6 +406,8 @@ COMPARE TWO VERSIONS
 
 AUDIT DESIGN QUALITY
   check tokens|theme|palette          token scale | dark parity | dominant colors
+  check design <page>                 is the page consistent with itself? component
+                                      styles reused, spacing on its own scale
   check a11y contrast|touch|focus     WCAG contrast, touch targets, focus order
   check perf | check drift            Web Vitals | consistency across instances/pages
   stress i18n | stress media          longer strings | media variants
@@ -407,6 +419,10 @@ IMAGE ASSETS (e.g. generated sprites, before they enter a slot)
 REPAIR
   heal selector <page> <selector>     suggest replacements for a dead selector
   heal markup                         [key] LLM auto-fix from a verify-markup kickback
+
+RUN GATES OVER A WHOLE SITE
+  batch --gate "<gate>" <glob...>     every matched page in parallel; --shard i/n
+                                      for CI runners, --output for per-job logs
 
 FOR CODING AGENTS AND PIPELINES
   mcp                                 MCP server exposing the gates (stdio)
@@ -521,6 +537,10 @@ Run \`vlmkit <command> --help\` for options; most gates take --json and
       const { runStdioServer } = await import("@mizchi/vlmkit-mcp/stdio.ts");
       await runStdioServer();
     });
+
+  cli.command("batch [...args]", "Run gates over many pages in parallel (glob, sharding, per-job timing)")
+    .allowUnknownOptions()
+    .action(async () => delegate(SPECS.batch, passThrough(argv, ["batch"])));
 
   cli.command("manifest [...args]", "Author / edit approval.json manifests")
     .allowUnknownOptions()

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -368,7 +368,7 @@ async function runGroupLeaf(
 
 export async function runCli(argv: string[] = process.argv.slice(2)): Promise<void> {
   const cli = cac("vlmkit");
-  cli.version("0.8.0");
+  cli.version("0.9.0");
 
   cli.usage(`<command> [options]
 

--- a/src/cli/commands/batch-cli.test.ts
+++ b/src/cli/commands/batch-cli.test.ts
@@ -8,6 +8,7 @@ import {
   type BatchSummary,
   buildJobs,
   formatBatchSummary,
+  jobLogName,
   parseShard,
   resolvePages,
   runBatch,
@@ -112,8 +113,52 @@ describe("runPool", () => {
     assert.deepEqual(finishOrder, [1, 2, 3, 0]);
   });
 
+  it("refuses an unusable limit instead of silently running nothing", async () => {
+    // A NaN limit made `Array.from({length: NaN})` build zero lanes: the pool
+    // ran nothing, returned holes, and read as success downstream.
+    await assert.rejects(runPool([1, 2], Number.NaN, async (x) => x), /concurrency limit >= 1, got NaN/);
+    await assert.rejects(runPool([1, 2], 0, async (x) => x), /concurrency limit >= 1, got 0/);
+  });
+
   it("handles an empty queue", async () => {
     assert.deepEqual(await runPool([], 4, async () => 1), []);
+  });
+});
+
+describe("jobLogName", () => {
+  it("distinguishes same-named pages in different directories", () => {
+    // `routes/a/index.html` and `routes/b/index.html` used to derive the same
+    // filename from their basename, so two concurrent writes raced and one
+    // page's failing report was lost.
+    const a = jobLogName({ gate: "check integrity", page: "routes/a/index.html" });
+    const b = jobLogName({ gate: "check integrity", page: "routes/b/index.html" });
+    assert.notEqual(a, b);
+    assert.match(a, /routes-a-index\.html/);
+  });
+
+  it("distinguishes same-path different-gate jobs, and same-path URLs", () => {
+    assert.notEqual(
+      jobLogName({ gate: "check integrity", page: "a.html" }),
+      jobLogName({ gate: "check design", page: "a.html" }),
+    );
+    assert.notEqual(
+      jobLogName({ gate: "check integrity", page: "https://x.test/checkout" }),
+      jobLogName({ gate: "check integrity", page: "https://y.test/checkout" }),
+    );
+  });
+
+  it("is stable for the same job and filesystem-safe", () => {
+    const job = { gate: "check copy --manifest c.txt", page: "https://x.test/a?b=1" };
+    assert.equal(jobLogName(job), jobLogName(job));
+    assert.match(jobLogName(job), /^[a-zA-Z0-9._-]+\.txt$/);
+  });
+
+  it("stays unique when two long paths truncate to the same prefix", () => {
+    const long = (tail: string) => `routes/${"deeply/nested/".repeat(8)}${tail}.html`;
+    assert.notEqual(
+      jobLogName({ gate: "check integrity", page: long("one") }),
+      jobLogName({ gate: "check integrity", page: long("two") }),
+    );
   });
 });
 

--- a/src/cli/commands/batch-cli.test.ts
+++ b/src/cli/commands/batch-cli.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  type BatchJobResult,
+  type BatchSummary,
+  buildJobs,
+  formatBatchSummary,
+  parseShard,
+  resolvePages,
+  runBatch,
+  runPool,
+  shardPages,
+} from "./batch-cli.ts";
+
+describe("parseShard", () => {
+  it("parses 1-based index/total", () => {
+    assert.deepEqual(parseShard("2/3"), { index: 2, total: 3 });
+    assert.deepEqual(parseShard(" 1/1 "), { index: 1, total: 1 });
+  });
+
+  it("rejects malformed and out-of-range specs instead of guessing", () => {
+    for (const bad of ["", "2", "2-3", "a/b", "0/3", "4/3", "2/0", "-1/3"]) {
+      assert.throws(() => parseShard(bad), /--shard/, `expected "${bad}" to throw`);
+    }
+  });
+});
+
+describe("shardPages", () => {
+  const pages = Array.from({ length: 10 }, (_, i) => `p${i}.html`);
+
+  it("passes everything through without a shard", () => {
+    assert.deepEqual(shardPages(pages), pages);
+    assert.deepEqual(shardPages(pages, { index: 1, total: 1 }), pages);
+  });
+
+  it("strides so neighbouring pages land in different shards", () => {
+    // Contiguous slicing would hand shard 1 p0..p3; pages in one directory
+    // usually cost the same, so that concentrates the expensive subtree.
+    assert.deepEqual(shardPages(pages, { index: 1, total: 3 }), ["p0.html", "p3.html", "p6.html", "p9.html"]);
+    assert.deepEqual(shardPages(pages, { index: 2, total: 3 }), ["p1.html", "p4.html", "p7.html"]);
+  });
+
+  it("partitions: every page runs exactly once across all shards", () => {
+    const seen = [1, 2, 3, 4].flatMap((index) => shardPages(pages, { index, total: 4 }));
+    assert.deepEqual([...seen].sort(), [...pages].sort());
+    assert.equal(new Set(seen).size, pages.length);
+  });
+});
+
+describe("resolvePages", () => {
+  const dir = mkdtempSync(join(tmpdir(), "batch-glob-"));
+
+  it("expands globs to a sorted, deduplicated list", async () => {
+    for (const name of ["b.html", "a.html", "c.txt"]) writeFileSync(join(dir, name), "<p>x");
+    const pages = await resolvePages(["*.html", "*.html"], dir);
+    assert.deepEqual(pages, ["a.html", "b.html"]);
+  });
+
+  it("passes URLs and literal paths through untouched", async () => {
+    const pages = await resolvePages(["https://example.com/a", "routes/does-not-exist.html"], dir);
+    assert.deepEqual(pages, ["https://example.com/a", "routes/does-not-exist.html"]);
+  });
+});
+
+describe("buildJobs", () => {
+  it("crosses every gate with every page", () => {
+    const jobs = buildJobs(["check integrity", "check design"], ["a.html", "b.html"]);
+    assert.equal(jobs.length, 4);
+    assert.deepEqual(jobs.map((j) => `${j.gate}|${j.page}`), [
+      "check integrity|a.html",
+      "check design|a.html",
+      "check integrity|b.html",
+      "check design|b.html",
+    ]);
+  });
+});
+
+describe("runPool", () => {
+  it("never exceeds the concurrency limit", async () => {
+    let live = 0;
+    let peak = 0;
+    await runPool(Array.from({ length: 12 }, (_, i) => i), 3, async (i) => {
+      live++;
+      peak = Math.max(peak, live);
+      await new Promise((r) => setTimeout(r, 5 + (i % 3)));
+      live--;
+      return i;
+    });
+    assert.equal(peak, 3);
+  });
+
+  it("preserves input order regardless of completion order", async () => {
+    const out = await runPool([30, 5, 20, 1], 4, async (ms) => {
+      await new Promise((r) => setTimeout(r, ms));
+      return ms;
+    });
+    assert.deepEqual(out, [30, 5, 20, 1]);
+  });
+
+  it("keeps every lane fed instead of waiting on a chunk barrier", async () => {
+    // One slow item must not stop the other lanes from draining the queue:
+    // with chunked Promise.all the fast items behind the barrier would idle.
+    const finishOrder: number[] = [];
+    await runPool([100, 1, 1, 1], 2, async (ms, i) => {
+      await new Promise((r) => setTimeout(r, ms));
+      finishOrder.push(i);
+      return i;
+    });
+    assert.deepEqual(finishOrder, [1, 2, 3, 0]);
+  });
+
+  it("handles an empty queue", async () => {
+    assert.deepEqual(await runPool([], 4, async () => 1), []);
+  });
+});
+
+describe("formatBatchSummary", () => {
+  const job = (over: Partial<BatchJobResult> = {}): BatchJobResult => ({
+    gate: "check design",
+    page: "a.html",
+    exitCode: 0,
+    durationMs: 1000,
+    output: "",
+    ...over,
+  });
+  const summary = (jobs: BatchJobResult[]): BatchSummary => ({
+    jobs,
+    passed: jobs.filter((j) => j.exitCode === 0).length,
+    failed: jobs.filter((j) => j.exitCode !== 0).length,
+    wallMs: 2000,
+    serialMs: jobs.reduce((s, j) => s + j.durationMs, 0),
+    concurrency: 2,
+  });
+
+  it("reports the pass case with occupancy, not a speedup claim", () => {
+    // Job time inflates under contention, so total/wall measures how many jobs
+    // were in flight — it is not the gain over running serially.
+    const text = formatBatchSummary(summary([job(), job({ page: "b.html" })]));
+    assert.match(text, /ALL PASS/);
+    assert.match(text, /wall 2\.0s, job time 2\.0s total \(avg 1\.0 jobs in flight\)/);
+    assert.doesNotMatch(text, /speedup/i);
+  });
+
+  it("names every failing job with its exit code", () => {
+    const text = formatBatchSummary(summary([
+      job(),
+      job({ page: "bad.html", exitCode: 1, output: "verdict: DEFECTS" }),
+    ]));
+    assert.match(text, /1 FAILED/);
+    assert.match(text, /bad\.html .*exit 1/);
+    assert.match(text, /vlmkit check design bad\.html/); // re-run hint
+    assert.doesNotMatch(text, /verdict: DEFECTS/); // output withheld unless asked
+  });
+
+  it("prints failing reports inline on request", () => {
+    const text = formatBatchSummary(
+      summary([job({ page: "bad.html", exitCode: 1, output: "verdict: DEFECTS" })]),
+      { showOutput: true },
+    );
+    assert.match(text, /verdict: DEFECTS/);
+  });
+
+  it("surfaces the slowest jobs, which is what sharding has to balance", () => {
+    const jobs = Array.from({ length: 6 }, (_, i) => job({ page: `p${i}.html`, durationMs: (i + 1) * 1000 }));
+    const text = formatBatchSummary(summary(jobs));
+    assert.match(text, /Slowest jobs/);
+    assert.match(text.replace(/\x1B\[\d+m/g, ""), /6\.0s\s+pass\s+check design p5\.html/);
+    assert.ok(text.indexOf("p5.html") < text.indexOf("p2.html"), "slowest first");
+  });
+});
+
+describe("runBatch (spawns real gates)", () => {
+  const CLI = resolve("src/cli/vlmkit.ts");
+  const FIXTURES = "fixtures/auto-markup-proof/creative";
+
+  it("runs a gate over several pages and aggregates the verdicts", async () => {
+    const summary = await runBatch({
+      gates: ["check design"],
+      patterns: [`${FIXTURES}/attempt-s1{8,9}-haiku.html`],
+      concurrency: 2,
+      quiet: true,
+      cliEntry: CLI,
+    });
+    assert.equal(summary.jobs.length, 2, JSON.stringify(summary.jobs.map((j) => j.page)));
+    assert.equal(summary.failed, 0, summary.jobs.map((j) => j.output).join("\n"));
+    assert.equal(summary.concurrency, 2);
+    assert.ok(summary.serialMs > 0);
+    assert.ok(summary.jobs.every((j) => j.output.includes("check design")));
+  });
+
+  it("reports a page whose gate exits non-zero as failed, and keeps going", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "batch-out-"));
+    const summary = await runBatch({
+      gates: ["check design"],
+      patterns: [`${FIXTURES}/attempt-s18-haiku.html`, "no-such-page.html"],
+      concurrency: 2,
+      quiet: true,
+      output: dir,
+      cliEntry: CLI,
+    });
+    assert.equal(summary.jobs.length, 2);
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.passed, 1);
+    const failed = summary.jobs.find((j) => j.exitCode !== 0)!;
+    assert.equal(failed.page, "no-such-page.html");
+    // Logs for both jobs plus the machine-readable summary.
+    const written = readdirSync(dir);
+    assert.equal(written.length, 3);
+    const persisted = JSON.parse(readFileSync(join(dir, "batch-summary.json"), "utf-8"));
+    assert.equal(persisted.failed, 1);
+    assert.equal(persisted.jobs.length, 2);
+    assert.ok(!("output" in persisted.jobs[0]), "per-job logs are files, not JSON blobs");
+  });
+
+  it("refuses to silently pass when nothing matched", async () => {
+    await assert.rejects(
+      runBatch({ gates: ["check design"], patterns: ["fixtures/**/*.no-such-ext"], quiet: true, cliEntry: CLI }),
+      /No pages matched/,
+    );
+  });
+
+  it("runs only its own shard", async () => {
+    const summary = await runBatch({
+      gates: ["check design"],
+      patterns: [`${FIXTURES}/attempt-s1*-haiku.html`],
+      shard: { index: 1, total: 5 },
+      concurrency: 1,
+      quiet: true,
+      cliEntry: CLI,
+    });
+    assert.equal(summary.jobs.length, 1);
+    assert.deepEqual(summary.shard, { index: 1, total: 5 });
+  });
+});

--- a/src/cli/commands/batch-cli.ts
+++ b/src/cli/commands/batch-cli.ts
@@ -18,12 +18,21 @@
  * "did it pass" but "how long, and how do I shard it".
  */
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { glob } from "node:fs/promises";
 import { mkdir, writeFile } from "node:fs/promises";
 import { cpus } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import {
+  hasFlag,
+  readAll,
+  readFlag,
+  readInt,
+  readPositionals,
+  tokenizeCommand,
+} from "@mizchi/vlmkit-core/arg-reader.ts";
 import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
@@ -95,6 +104,9 @@ export async function resolvePages(patterns: string[], cwd = process.cwd()): Pro
   return [...out].sort();
 }
 
+/** Flags that consume the next argv entry, so positionals can be told apart. */
+const VALUE_FLAGS = ["gate", "concurrency", "shard", "output"];
+
 /** Flat job queue: every gate against every page. */
 export function buildJobs(gates: string[], pages: string[]): BatchJob[] {
   return pages.flatMap((page) => gates.map((gate) => ({ gate, page })));
@@ -111,6 +123,12 @@ export async function runPool<T, R>(
   worker: (item: T, index: number) => Promise<R>,
   onSettled?: (result: R, index: number) => void,
 ): Promise<R[]> {
+  // A NaN limit used to make `Array.from({length: NaN})` produce zero lanes, so
+  // the pool ran NOTHING and returned a list of holes — which then read as
+  // success downstream. Fail here instead of somewhere unrelated.
+  if (!Number.isFinite(limit) || limit < 1) {
+    throw new Error(`runPool needs a concurrency limit >= 1, got ${limit}`);
+  }
   const results = new Array<R>(items.length);
   let cursor = 0;
   const lanes = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
@@ -151,7 +169,10 @@ function cliEntryPath(explicit?: string): string {
 }
 
 function runJob(job: BatchJob, cliEntry: string): Promise<BatchJobResult> {
-  const args = [...process.execArgv, cliEntry, ...job.gate.split(/\s+/).filter(Boolean), job.page];
+  // Quote-aware: a gate flag can legitimately carry a value with spaces
+  // (`--manifest "copy/press kit.txt"`, `--mask ".hero, .promo"`), and a plain
+  // whitespace split would hand those to the gate as several arguments.
+  const args = [...process.execArgv, cliEntry, ...tokenizeCommand(job.gate), job.page];
   const started = Date.now();
   return new Promise((resolveJob) => {
     const child = spawn(process.execPath, args, {
@@ -178,6 +199,18 @@ function runJob(job: BatchJob, cliEntry: string): Promise<BatchJobResult> {
 }
 
 const slug = (s: string) => s.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80);
+
+/**
+ * Per-job log filename. Uses the whole source path, not its basename: with
+ * `routes/a/index.html` and `routes/b/index.html` a basename-derived name
+ * collided, so two concurrent writes raced and one page's failing report was
+ * lost. The trailing hash keeps that guarantee when the 80-char cap truncates
+ * two long paths to the same prefix.
+ */
+export function jobLogName(job: BatchJob): string {
+  const hash = createHash("sha1").update(`${job.gate}\u0000${job.page}`).digest("hex").slice(0, 6);
+  return `${slug(job.gate)}--${slug(job.page)}-${hash}.txt`;
+}
 
 /**
  * Run an explicit job list. Split out from `runBatch` so a caller that already
@@ -214,9 +247,7 @@ export async function runJobs(
   };
   if (options.output) {
     await mkdir(options.output, { recursive: true });
-    await Promise.all(results.map((r) =>
-      writeFile(join(options.output!, `${slug(r.gate)}--${slug(basename(r.page))}.txt`), r.output)
-    ));
+    await Promise.all(results.map((r) => writeFile(join(options.output!, jobLogName(r)), r.output)));
     await writeFile(
       join(options.output, "batch-summary.json"),
       JSON.stringify({ ...summary, jobs: summary.jobs.map(({ output: _output, ...rest }) => rest) }, null, 2),
@@ -338,47 +369,29 @@ Examples:
 }
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
-  if (argv.includes("--help") || argv.includes("-h")) printUsage(0);
-  const gates: string[] = [];
-  const patterns: string[] = [];
-  let concurrency: number | undefined;
-  let shard: { index: number; total: number } | undefined;
-  let output: string | undefined;
-  let json = false;
-  let quiet = false;
-  let showOutput = false;
-  let advisory = false;
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]!;
-    if (arg === "--gate") gates.push(argv[++i] ?? "");
-    else if (arg === "--concurrency") concurrency = Number.parseInt(argv[++i] ?? "", 10);
-    else if (arg === "--shard") shard = parseShard(argv[++i] ?? "");
-    else if (arg === "--output") output = argv[++i];
-    else if (arg === "--json") json = true;
-    else if (arg === "--quiet") quiet = true;
-    else if (arg === "--show-output") showOutput = true;
-    else if (arg === "--advisory") advisory = true;
-    else if (!arg.startsWith("-")) patterns.push(arg);
-  }
+  if (hasFlag(argv, "help") || hasFlag(argv, "-h")) printUsage(0);
+  const gates = readAll(argv, "gate");
+  const patterns = readPositionals(argv, VALUE_FLAGS);
+  const concurrency = readInt(argv, "concurrency", { min: 1 });
+  const shardSpec = readFlag(argv, "shard");
+  const output = readFlag(argv, "output");
+  const json = hasFlag(argv, "json");
   if (gates.length === 0 || gates.some((g) => !g.trim())) {
     console.error("At least one --gate is required, e.g. --gate \"check integrity\"\n");
     printUsage(1);
   }
   if (patterns.length === 0) printUsage(1);
-  if (concurrency !== undefined && (!Number.isFinite(concurrency) || concurrency < 1)) {
-    throw new Error(`--concurrency must be >= 1, got "${concurrency}"`);
-  }
   const summary = await runBatch({
     gates,
     patterns,
     ...(concurrency !== undefined ? { concurrency } : {}),
-    ...(shard ? { shard } : {}),
+    ...(shardSpec ? { shard: parseShard(shardSpec) } : {}),
     ...(output ? { output } : {}),
-    quiet,
+    quiet: hasFlag(argv, "quiet"),
   });
   if (json) console.log(JSON.stringify(summary, null, 2));
-  else console.log(formatBatchSummary(summary, { showOutput }));
-  if (summary.failed > 0 && !advisory) process.exitCode = 1;
+  else console.log(formatBatchSummary(summary, { showOutput: hasFlag(argv, "show-output") }));
+  if (summary.failed > 0 && !hasFlag(argv, "advisory")) process.exitCode = 1;
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "batch" ||

--- a/src/cli/commands/batch-cli.ts
+++ b/src/cli/commands/batch-cli.ts
@@ -179,15 +179,17 @@ function runJob(job: BatchJob, cliEntry: string): Promise<BatchJobResult> {
 
 const slug = (s: string) => s.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80);
 
-export async function runBatch(options: BatchOptions): Promise<BatchSummary> {
-  const pages = shardPages(await resolvePages(options.patterns), options.shard);
-  if (pages.length === 0) {
-    throw new Error(
-      `No pages matched: ${options.patterns.join(", ")}`
-      + (options.shard ? ` (after --shard ${options.shard.index}/${options.shard.total})` : ""),
-    );
-  }
-  const jobs = buildJobs(options.gates, pages);
+/**
+ * Run an explicit job list. Split out from `runBatch` so a caller that already
+ * knows its (gate, page) pairs — `vlmkit gates run`, where the pairing comes
+ * from a config file rather than a cross product — reuses the same pool,
+ * timing, log capture and summary instead of reimplementing them.
+ */
+export async function runJobs(
+  jobs: BatchJob[],
+  options: Omit<BatchOptions, "gates" | "patterns"> = {},
+): Promise<BatchSummary> {
+  if (jobs.length === 0) throw new Error("No jobs to run");
   const concurrency = options.concurrency ?? defaultConcurrency();
   const cliEntry = cliEntryPath(options.cliEntry);
   const started = Date.now();
@@ -222,16 +224,27 @@ export async function runBatch(options: BatchOptions): Promise<BatchSummary> {
   }
   appendRunLedger({
     tool: "batch",
-    source: options.patterns.join(" "),
+    source: [...new Set(jobs.map((j) => j.page))].join(" ").slice(0, 200),
     headline: {
-      gates: options.gates.length,
-      pages: pages.length,
+      gates: new Set(jobs.map((j) => j.gate)).size,
+      pages: new Set(jobs.map((j) => j.page)).size,
       failed: summary.failed,
       wallMs: summary.wallMs,
       concurrency,
     },
   });
   return summary;
+}
+
+export async function runBatch(options: BatchOptions): Promise<BatchSummary> {
+  const pages = shardPages(await resolvePages(options.patterns), options.shard);
+  if (pages.length === 0) {
+    throw new Error(
+      `No pages matched: ${options.patterns.join(", ")}`
+      + (options.shard ? ` (after --shard ${options.shard.index}/${options.shard.total})` : ""),
+    );
+  }
+  return runJobs(buildJobs(options.gates, pages), options);
 }
 
 export function formatBatchSummary(summary: BatchSummary, options: { showOutput?: boolean } = {}): string {

--- a/src/cli/commands/batch-cli.ts
+++ b/src/cli/commands/batch-cli.ts
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * `vlmkit batch` — run gates over many pages in parallel.
+ *
+ * The gate CLIs each take one source. A repo with twenty routes therefore
+ * needs twenty invocations, which is why every project that adopted the gates
+ * ended up hand-rolling a shell loop, and why nobody could answer "what does
+ * this cost in CI".
+ *
+ * The runner spawns each (gate, page) pair as a child process and reads the
+ * verdict off the **exit code** — the one thing every gate agrees on since
+ * `gate-exit.ts` unified the contract (suspect/defect ⇒ non-zero, warn ⇒ zero).
+ * That keeps the runner gate-agnostic: it needs no knowledge of any report
+ * shape, so a new gate is batchable the day it lands. Child processes also
+ * mean one page's crashed browser cannot take the run down.
+ *
+ * Timing is reported per job and in aggregate because the CI question is not
+ * "did it pass" but "how long, and how do I shard it".
+ */
+import { spawn } from "node:child_process";
+import { glob } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
+import { cpus } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
+
+export interface BatchJob {
+  /** Gate command as typed, e.g. `check integrity` or `check design --min-reuse 4`. */
+  gate: string;
+  /** One page: a file path or a URL. */
+  page: string;
+}
+
+export interface BatchJobResult extends BatchJob {
+  exitCode: number;
+  durationMs: number;
+  output: string;
+}
+
+export interface BatchSummary {
+  jobs: BatchJobResult[];
+  passed: number;
+  failed: number;
+  /** Wall clock for the whole run. */
+  wallMs: number;
+  /** Sum of per-job durations — what a shell loop would have cost. */
+  serialMs: number;
+  concurrency: number;
+  shard?: { index: number; total: number };
+}
+
+/** `1/3` → `{index: 1, total: 3}`. Throws on anything else, loudly. */
+export function parseShard(spec: string): { index: number; total: number } {
+  const m = /^(\d+)\/(\d+)$/.exec(spec.trim());
+  if (!m) throw new Error(`--shard expects <index>/<total> (1-based), got "${spec}"`);
+  const index = Number.parseInt(m[1]!, 10);
+  const total = Number.parseInt(m[2]!, 10);
+  if (total < 1) throw new Error(`--shard total must be >= 1, got ${total}`);
+  if (index < 1 || index > total) throw new Error(`--shard index must be 1..${total}, got ${index}`);
+  return { index, total };
+}
+
+/**
+ * Stride sharding, not contiguous blocks. Pages in the same directory tend to
+ * cost the same (a routes/admin/** subtree of dense tables is uniformly slow),
+ * so slicing contiguously hands one shard the whole expensive subtree. Stride
+ * spreads neighbours across shards.
+ */
+export function shardPages(pages: string[], shard?: { index: number; total: number }): string[] {
+  if (!shard || shard.total === 1) return pages;
+  return pages.filter((_, i) => i % shard.total === shard.index - 1);
+}
+
+/**
+ * Expand positional arguments into a sorted, deduplicated page list. A URL or
+ * a plain existing path passes through untouched; anything containing a glob
+ * metacharacter is expanded against the cwd.
+ */
+export async function resolvePages(patterns: string[], cwd = process.cwd()): Promise<string[]> {
+  const out = new Set<string>();
+  for (const pattern of patterns) {
+    if (/^https?:\/\//.test(pattern)) {
+      out.add(pattern);
+      continue;
+    }
+    if (!/[*?[\]{}]/.test(pattern)) {
+      out.add(pattern);
+      continue;
+    }
+    for await (const hit of glob(pattern, { cwd })) out.add(hit);
+  }
+  return [...out].sort();
+}
+
+/** Flat job queue: every gate against every page. */
+export function buildJobs(gates: string[], pages: string[]): BatchJob[] {
+  return pages.flatMap((page) => gates.map((gate) => ({ gate, page })));
+}
+
+/**
+ * Bounded-concurrency pool. Deliberately not `Promise.all` in chunks: a chunk
+ * barrier idles the pool for the tail of every chunk, which is exactly the
+ * waste a batch runner exists to remove.
+ */
+export async function runPool<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+  onSettled?: (result: R, index: number) => void,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const lanes = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      const result = await worker(items[index]!, index);
+      results[index] = result;
+      onSettled?.(result, index);
+    }
+  });
+  await Promise.all(lanes);
+  return results;
+}
+
+export interface BatchOptions {
+  gates: string[];
+  patterns: string[];
+  concurrency?: number;
+  shard?: { index: number; total: number };
+  output?: string;
+  quiet?: boolean;
+  /** Injected in tests; defaults to the CLI entry this process was started from. */
+  cliEntry?: string;
+}
+
+/** Default width: leave the machine a core, and don't run 32 browsers at once. */
+export function defaultConcurrency(): number {
+  return Math.max(1, Math.min(4, cpus().length - 1));
+}
+
+function cliEntryPath(explicit?: string): string {
+  const entry = explicit ?? process.env.__VLMKIT_CLI_ENTRY__;
+  if (entry) return entry;
+  // Fall back to the sibling entry module, which is correct for a dev checkout
+  // and for the bundled dist (both keep vlmkit next to the commands dir).
+  return resolve(fileURLToPath(import.meta.url), "../../vlmkit.ts");
+}
+
+function runJob(job: BatchJob, cliEntry: string): Promise<BatchJobResult> {
+  const args = [...process.execArgv, cliEntry, ...job.gate.split(/\s+/).filter(Boolean), job.page];
+  const started = Date.now();
+  return new Promise((resolveJob) => {
+    const child = spawn(process.execPath, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      // The child is one more gate run; it must not inherit the marker that
+      // tells a leaf module "you are the CLI entry".
+      env: { ...process.env, __VRT_DISPATCHER_LEAF__: "" },
+    });
+    let output = "";
+    child.stdout.on("data", (d) => { output += d; });
+    child.stderr.on("data", (d) => { output += d; });
+    child.on("error", (err) => {
+      resolveJob({ ...job, exitCode: 127, durationMs: Date.now() - started, output: `${output}${err.message}\n` });
+    });
+    child.on("close", (code, signal) => {
+      resolveJob({
+        ...job,
+        exitCode: code ?? (signal ? 129 : 1),
+        durationMs: Date.now() - started,
+        output,
+      });
+    });
+  });
+}
+
+const slug = (s: string) => s.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 80);
+
+export async function runBatch(options: BatchOptions): Promise<BatchSummary> {
+  const pages = shardPages(await resolvePages(options.patterns), options.shard);
+  if (pages.length === 0) {
+    throw new Error(
+      `No pages matched: ${options.patterns.join(", ")}`
+      + (options.shard ? ` (after --shard ${options.shard.index}/${options.shard.total})` : ""),
+    );
+  }
+  const jobs = buildJobs(options.gates, pages);
+  const concurrency = options.concurrency ?? defaultConcurrency();
+  const cliEntry = cliEntryPath(options.cliEntry);
+  const started = Date.now();
+  let done = 0;
+  const results = await runPool(jobs, concurrency, (job) => runJob(job, cliEntry), (result) => {
+    done++;
+    if (options.quiet) return;
+    const status = result.exitCode === 0 ? `${GREEN}pass${RESET}` : `${RED}fail${RESET}`;
+    process.stderr.write(
+      `${DIM}[${String(done).padStart(String(jobs.length).length)}/${jobs.length}]${RESET} `
+      + `${status} ${DIM}${(result.durationMs / 1000).toFixed(1)}s${RESET} ${result.gate} ${result.page}\n`,
+    );
+  });
+  const summary: BatchSummary = {
+    jobs: results,
+    passed: results.filter((r) => r.exitCode === 0).length,
+    failed: results.filter((r) => r.exitCode !== 0).length,
+    wallMs: Date.now() - started,
+    serialMs: results.reduce((sum, r) => sum + r.durationMs, 0),
+    concurrency,
+    ...(options.shard ? { shard: options.shard } : {}),
+  };
+  if (options.output) {
+    await mkdir(options.output, { recursive: true });
+    await Promise.all(results.map((r) =>
+      writeFile(join(options.output!, `${slug(r.gate)}--${slug(basename(r.page))}.txt`), r.output)
+    ));
+    await writeFile(
+      join(options.output, "batch-summary.json"),
+      JSON.stringify({ ...summary, jobs: summary.jobs.map(({ output: _output, ...rest }) => rest) }, null, 2),
+    );
+  }
+  appendRunLedger({
+    tool: "batch",
+    source: options.patterns.join(" "),
+    headline: {
+      gates: options.gates.length,
+      pages: pages.length,
+      failed: summary.failed,
+      wallMs: summary.wallMs,
+      concurrency,
+    },
+  });
+  return summary;
+}
+
+export function formatBatchSummary(summary: BatchSummary, options: { showOutput?: boolean } = {}): string {
+  const lines: string[] = [];
+  const pages = new Set(summary.jobs.map((j) => j.page));
+  const gates = [...new Set(summary.jobs.map((j) => j.gate))];
+  lines.push("");
+  lines.push(`${BOLD}${CYAN}vlmkit batch${RESET}`);
+  lines.push(
+    `${DIM}${pages.size} page(s) x ${gates.length} gate(s) = ${summary.jobs.length} job(s),`
+    + ` concurrency ${summary.concurrency}`
+    + (summary.shard ? `, shard ${summary.shard.index}/${summary.shard.total}` : "")
+    + `${RESET}`,
+  );
+  lines.push("");
+  lines.push(
+    summary.failed === 0
+      ? `verdict: ${GREEN}ALL PASS${RESET} (${summary.passed}/${summary.jobs.length})`
+      : `verdict: ${RED}${summary.failed} FAILED${RESET} (${summary.passed} passed)`,
+  );
+  const wall = summary.wallMs / 1000;
+  const busy = summary.serialMs / 1000;
+  const slowest = [...summary.jobs].sort((a, b) => b.durationMs - a.durationMs)[0];
+  // "avg in flight", NOT speedup. Job time inflates under contention (measured:
+  // 9 integrity runs on 4 cores summed to 34.9s at concurrency 1 and 64.9s at
+  // concurrency 8), so busy/wall would have claimed 5.9x where the real gain
+  // over a serial run was 3.2x. Reporting occupancy keeps the number honest.
+  lines.push(
+    `${DIM}  wall ${wall.toFixed(1)}s, job time ${busy.toFixed(1)}s total`
+    + ` (avg ${(busy / Math.max(wall, 0.001)).toFixed(1)} jobs in flight),`
+    + ` slowest job ${((slowest?.durationMs ?? 0) / 1000).toFixed(1)}s${RESET}`,
+  );
+  // A run can never finish faster than its slowest single job: that is the
+  // floor more concurrency cannot buy through, and the number to shard against.
+  lines.push("");
+  const failures = summary.jobs.filter((j) => j.exitCode !== 0);
+  if (failures.length > 0) {
+    lines.push(`${BOLD}Failures${RESET}`);
+    for (const f of failures) {
+      lines.push(`  ${RED}x${RESET} ${f.gate} ${f.page} ${DIM}(exit ${f.exitCode}, ${(f.durationMs / 1000).toFixed(1)}s)${RESET}`);
+    }
+    lines.push("");
+    if (options.showOutput) {
+      for (const f of failures) {
+        lines.push(`${BOLD}${DIM}--- ${f.gate} ${f.page}${RESET}`);
+        lines.push(f.output.trimEnd());
+        lines.push("");
+      }
+    } else {
+      lines.push(`${DIM}Re-run one to see its report, or pass --output <dir> to keep every log:${RESET}`);
+      lines.push(`  vlmkit ${failures[0]!.gate} ${failures[0]!.page}`);
+      lines.push("");
+    }
+  }
+  const slowJobs = [...summary.jobs].sort((a, b) => b.durationMs - a.durationMs).slice(0, 5);
+  if (summary.jobs.length > 5) {
+    lines.push(`${BOLD}Slowest jobs${RESET} ${DIM}(shard against these)${RESET}`);
+    for (const j of slowJobs) {
+      const mark = j.exitCode === 0 ? `${GREEN}pass${RESET}` : `${RED}fail${RESET}`;
+      lines.push(`  ${(j.durationMs / 1000).toFixed(1).padStart(6)}s  ${mark}  ${j.gate} ${j.page}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function printUsage(exitCode: number): never {
+  console.log(`Usage: vlmkit batch --gate "<gate>" [--gate ...] <page-or-glob...> [options]
+
+Run gates over many pages in parallel. Each (gate, page) pair runs as its own
+process; the verdict is that process's exit code, so every gate is batchable
+without the runner knowing anything about its report.
+
+Options:
+  --gate <cmd>          Gate command, repeatable. Quote it with its own flags:
+                        --gate "check integrity" --gate "check design --min-reuse 4"
+  --concurrency <n>     Parallel jobs (default: min(4, cores - 1))
+  --shard <i/n>         Run only shard i of n (1-based, stride-sliced)
+  --output <dir>        Write every job's log plus batch-summary.json
+  --show-output         Print failing jobs' reports inline
+  --json                Print the summary as JSON
+  --quiet               No per-job progress lines
+  --advisory            Print failures but exit 0
+
+Exit code: non-zero if any job failed, unless --advisory.
+
+Examples:
+  vlmkit batch --gate "check integrity" "routes/**/*.html"
+  vlmkit batch --gate "check integrity" --gate "check design" "dist/**/*.html" --concurrency 8
+  vlmkit batch --gate "check integrity" "routes/**/*.html" --shard 2/3 --output ci-logs/`);
+  process.exit(exitCode);
+}
+
+async function main(argv = process.argv.slice(2)): Promise<void> {
+  if (argv.includes("--help") || argv.includes("-h")) printUsage(0);
+  const gates: string[] = [];
+  const patterns: string[] = [];
+  let concurrency: number | undefined;
+  let shard: { index: number; total: number } | undefined;
+  let output: string | undefined;
+  let json = false;
+  let quiet = false;
+  let showOutput = false;
+  let advisory = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--gate") gates.push(argv[++i] ?? "");
+    else if (arg === "--concurrency") concurrency = Number.parseInt(argv[++i] ?? "", 10);
+    else if (arg === "--shard") shard = parseShard(argv[++i] ?? "");
+    else if (arg === "--output") output = argv[++i];
+    else if (arg === "--json") json = true;
+    else if (arg === "--quiet") quiet = true;
+    else if (arg === "--show-output") showOutput = true;
+    else if (arg === "--advisory") advisory = true;
+    else if (!arg.startsWith("-")) patterns.push(arg);
+  }
+  if (gates.length === 0 || gates.some((g) => !g.trim())) {
+    console.error("At least one --gate is required, e.g. --gate \"check integrity\"\n");
+    printUsage(1);
+  }
+  if (patterns.length === 0) printUsage(1);
+  if (concurrency !== undefined && (!Number.isFinite(concurrency) || concurrency < 1)) {
+    throw new Error(`--concurrency must be >= 1, got "${concurrency}"`);
+  }
+  const summary = await runBatch({
+    gates,
+    patterns,
+    ...(concurrency !== undefined ? { concurrency } : {}),
+    ...(shard ? { shard } : {}),
+    ...(output ? { output } : {}),
+    quiet,
+  });
+  if (json) console.log(JSON.stringify(summary, null, 2));
+  else console.log(formatBatchSummary(summary, { showOutput }));
+  if (summary.failed > 0 && !advisory) process.exitCode = 1;
+}
+
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "batch" ||
+  (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
+if (isCliEntry) main().catch(handleCliError);

--- a/src/cli/commands/compare-runs-cli.ts
+++ b/src/cli/commands/compare-runs-cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * `vrt compare-runs <a.json> <b.json>` — pairwise diff of two
+ * `vlmkit diff runs <a.json> <b.json>` — pairwise diff of two
  * migration-compare reports. Validates "the patch did what I expected"
  * across two iterations.
  */
@@ -12,7 +12,7 @@ import { formatCompareRunsMarkdown, type CrReport } from "../../vrt/compare/comp
 function usage(): string {
   return [
     "Usage:",
-    "  vrt compare-runs <a-migration-report.json> <b-migration-report.json> [--out path] [--label-a name] [--label-b name]",
+    "  vlmkit diff runs <a-migration-report.json> <b-migration-report.json> [--out path] [--label-a name] [--label-b name]",
     "",
     "Diffs two migration-compare reports and prints per-viewport delta",
     "(IMPROVED / REGRESSED / UNCHANGED / ADDED / REMOVED) sorted by",

--- a/src/cli/commands/diff-for-agent-cli.ts
+++ b/src/cli/commands/diff-for-agent-cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * `vrt diff-for-agent <migration-report.json>` — emit a one-context-window
+ * `vlmkit diff agent <migration-report.json>` — emit a one-context-window
  * Markdown summary of an existing migration-compare report.
  *
  * Pairs with the dogfood findings in
@@ -24,10 +24,10 @@ const DEFAULT_HISTORY_PATH = ".vrt/last-diff-for-agent.json";
 function usage(): string {
   return [
     "Usage:",
-    "  vrt diff-for-agent <migration-report.json> [--out path] [--max-viewports 1] [--variant working.html] [--show-unverified] [--previous path] [--persist-summary path] [--no-history] [--fail-on-regression]",
+    "  vlmkit diff agent <migration-report.json> [--out path] [--max-viewports 1] [--variant working.html] [--show-unverified] [--previous path] [--persist-summary path] [--no-history] [--fail-on-regression]",
     "",
     "Reads an existing migration-compare report (the report.json written by",
-    "`vrt compare`) and prints a Markdown summary tailored for coding agents.",
+    "`vlmkit diff html`) and prints a Markdown summary tailored for coding agents.",
     "",
     "By default, heuristic fix-candidate rows marked ✗ (value already matches",
     "baseline) are hidden — pass --show-unverified to include them.",

--- a/src/cli/commands/diff-for-agent-cli.ts
+++ b/src/cli/commands/diff-for-agent-cli.ts
@@ -10,7 +10,8 @@
  */
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, relative} from "node:path";
+import { STATE_DIR, resolveStatePath } from "@mizchi/vlmkit-core/legacy-names.ts";
 import {
   buildPreviousRunSummary,
   detectRegression,
@@ -19,7 +20,11 @@ import {
   type PreviousRunSummary,
 } from "../../vrt/compare/diff-for-agent.ts";
 
-const DEFAULT_HISTORY_PATH = ".vrt/last-diff-for-agent.json";
+// See legacy-names: the run-vs-run comparison is worthless if the rename makes
+// it read an absent file and report "no previous run" forever.
+const defaultHistoryPath = (): string =>
+  relative(process.cwd(), resolveStatePath(process.cwd(), "last-diff-for-agent.json"))
+  || `${STATE_DIR}/last-diff-for-agent.json`;
 
 function usage(): string {
   return [
@@ -174,10 +179,10 @@ async function main() {
   //   --no-history: skip both load + write entirely (CI one-shots).
   //   default:      auto-load + auto-persist .vrt/last-diff-for-agent.json,
   //                 overridable via --previous / --persist-summary.
-  const historyPath = parsed.noHistory ? undefined : resolve(parsed.persistSummaryPath ?? DEFAULT_HISTORY_PATH);
+  const historyPath = parsed.noHistory ? undefined : resolve(parsed.persistSummaryPath ?? defaultHistoryPath());
   const previousPath = parsed.noHistory
     ? undefined
-    : resolve(parsed.previousPath ?? parsed.persistSummaryPath ?? DEFAULT_HISTORY_PATH);
+    : resolve(parsed.previousPath ?? parsed.persistSummaryPath ?? defaultHistoryPath());
   const previous = previousPath ? await loadPreviousSummary(previousPath) : undefined;
 
   const md = formatMigrationReportForAgent(report, {

--- a/src/cli/commands/flipbook-cli.ts
+++ b/src/cli/commands/flipbook-cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * `vrt flipbook <pngs...>` — assemble an arbitrary PNG sequence into a
+ * `vlmkit snapshot flipbook <pngs...>` — assemble an arbitrary PNG sequence into a
  * self-contained HTML flipbook.
  *
  * Use cases:
@@ -8,7 +8,7 @@
  *   - Ad-hoc demos: any ordered PNG series
  *
  * Snapshot/stability outputs have their own integrated flipbook commands
- * (`vrt snapshot flipbook`) that auto-discover the right frames.
+ * (`vlmkit snapshot flipbook`) that auto-discover the right frames.
  */
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
@@ -18,11 +18,11 @@ import { DIM, RESET, GREEN, CYAN, BOLD } from "@mizchi/vlmkit-core/terminal-colo
 function usage(): string {
   return [
     "Usage:",
-    "  vrt flipbook <frame1.png> [frame2.png ...] [--out flipbook.html] [--title \"…\"] [--delay 700] [--label A --label B] [--no-loop] [--no-autoplay]",
+    "  vlmkit snapshot flipbook <frame1.png> [frame2.png ...] [--out flipbook.html] [--title \"…\"] [--delay 700] [--label A --label B] [--no-loop] [--no-autoplay]",
     "",
     "Examples:",
-    "  vrt flipbook round-0.png round-1.png round-2.png --out fix-loop.html --title 'Fix-loop convergence'",
-    "  vrt flipbook *.png --delay 1200 --out demo.html",
+    "  vlmkit snapshot flipbook round-0.png round-1.png round-2.png --out fix-loop.html --title 'Fix-loop convergence'",
+    "  vlmkit snapshot flipbook *.png --delay 1200 --out demo.html",
   ].join("\n");
 }
 

--- a/src/cli/commands/gates-cli.test.ts
+++ b/src/cli/commands/gates-cli.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseGateConfig, resolveGatePlan, resolveSuppression } from "@mizchi/vlmkit-core/gate-config.ts";
+import {
+  expandPlanSources,
+  findGateConfig,
+  formatExpiredNotice,
+  formatPlan,
+  formatSuppressions,
+  shardPlan,
+} from "./gates-cli.ts";
+
+const NOW = new Date("2026-08-02T12:00:00Z");
+const plain = (s: string) => s.replace(/\x1B\[\d+m/g, "");
+
+const planFor = (config: unknown, only?: string[]) =>
+  resolveGatePlan(parseGateConfig(JSON.stringify(config)), { now: NOW, ...(only ? { only } : {}) });
+
+describe("findGateConfig", () => {
+  it("finds the conventional filename, and reports absence rather than guessing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gates-find-"));
+    assert.equal(findGateConfig(dir), null);
+    writeFileSync(join(dir, "vlmkit.gates.json"), "{}");
+    assert.equal(findGateConfig(dir), join(dir, "vlmkit.gates.json"));
+  });
+});
+
+describe("expandPlanSources", () => {
+  const dir = mkdtempSync(join(tmpdir(), "gates-glob-"));
+  for (const name of ["a.html", "b.html", "c.html"]) writeFileSync(join(dir, name), "<p>x");
+
+  it("turns one glob entry into one job per file", async () => {
+    const plan = await expandPlanSources(planFor({
+      pages: [{ id: "routes", source: `${dir}/*.html`, gates: ["check integrity"] }],
+    }));
+    assert.equal(plan.jobs.length, 3);
+    assert.deepEqual(plan.jobs.map((j) => j.source.replace(`${dir}/`, "")), ["a.html", "b.html", "c.html"]);
+  });
+
+  it("prefixes expanded ids with the config's own name so --only still addresses the group", async () => {
+    const plan = await expandPlanSources(planFor({
+      pages: [{ id: "routes", source: `${dir}/*.html`, gates: ["check integrity"] }],
+    }));
+    assert.ok(plan.jobs.every((j) => j.pageId.startsWith("routes:")));
+  });
+
+  it("leaves a single literal source's id alone", async () => {
+    const plan = await expandPlanSources(planFor({
+      pages: [{ id: "home", source: `${dir}/a.html`, gates: ["check integrity"] }],
+    }));
+    assert.deepEqual(plan.jobs.map((j) => j.pageId), ["home"]);
+  });
+
+  it("refuses a pattern that matches nothing instead of gating on nothing", async () => {
+    await assert.rejects(
+      expandPlanSources(planFor({ pages: [{ id: "x", source: `${dir}/*.md`, gates: ["check integrity"] }] })),
+      /source matched no files/,
+    );
+  });
+
+  it("keeps URLs as-is", async () => {
+    const plan = await expandPlanSources(planFor({
+      pages: [{ id: "prod", source: "https://example.com/", gates: ["check integrity"] }],
+    }));
+    assert.deepEqual(plan.jobs.map((j) => j.source), ["https://example.com/"]);
+  });
+});
+
+describe("shardPlan", () => {
+  const plan = planFor({
+    defaults: { gates: ["check integrity", "check design"] },
+    pages: [1, 2, 3, 4].map((n) => ({ id: `p${n}`, source: `p${n}.html` })),
+  });
+
+  it("keeps a page's gates together on one runner", () => {
+    // Sharding per job would split one page's integrity and design runs across
+    // machines, so a page's logs would land in two places for no gain.
+    const shard = shardPlan(plan, { index: 1, total: 2 });
+    const pages = [...new Set(shard.jobs.map((j) => j.pageId))];
+    assert.deepEqual(pages, ["p1", "p3"]);
+    assert.equal(shard.jobs.length, 4); // 2 pages x 2 gates
+  });
+
+  it("partitions pages across shards", () => {
+    const seen = [1, 2].flatMap((index) => shardPlan(plan, { index, total: 2 }).jobs.map((j) => j.pageId));
+    assert.equal(new Set(seen).size, 4);
+    assert.equal(seen.length, 8);
+  });
+
+  it("passes through without a shard", () => {
+    assert.equal(shardPlan(plan).jobs.length, 8);
+  });
+});
+
+describe("formatPlan", () => {
+  it("prints the exact command each page will run, with suppression flags visible", () => {
+    const text = plain(formatPlan(planFor({
+      defaults: { gates: ["check integrity"] },
+      pages: [{
+        id: "checkout",
+        source: "checkout.html",
+        extraGates: ["check copy --manifest c.txt"],
+        suppressions: [{ gate: "check copy", flag: "--allow-invisible visually-hidden", reason: "sr-only", expires: "2026-12-01" }],
+      }],
+    }), "vlmkit.gates.json"));
+    assert.match(text, /1 page\(s\), 2 gate run\(s\)/);
+    assert.match(text, /vlmkit check integrity checkout\.html/);
+    assert.match(text, /vlmkit check copy --manifest c\.txt --allow-invisible visually-hidden checkout\.html/);
+    assert.match(text, /\[\+1 suppression\]/);
+  });
+
+  it("flags an expired entry in the plan itself", () => {
+    const text = plain(formatPlan(planFor({
+      pages: [{
+        id: "game",
+        source: "game.html",
+        gates: ["check design"],
+        suppressions: [{ gate: "check design", flag: "--min-reuse 2", reason: "zones differ", expires: "2026-07-01" }],
+      }],
+    }), "cfg.json"));
+    assert.match(text, /1 expired suppression\(s\) NOT applied/);
+    assert.doesNotMatch(text, /--min-reuse 2/); // not applied, so not in the command
+  });
+});
+
+describe("formatSuppressions", () => {
+  const rows = [
+    { gate: "check design", flag: "--min-reuse 2", reason: "zones differ", expires: "2026-07-01" },
+    { gate: "check copy", flag: "--allow-invisible visually-hidden", reason: "sr-only nav", owner: "web-platform", expires: "2026-08-10" },
+    { gate: "check copy", flag: "--allow-invisible camouflage", reason: "brand watermark" },
+  ].map((s, i) => resolveSuppression(s, `page-${i}`, NOW));
+
+  it("is the inventory a grep cannot give you: reason, owner, expiry, per entry", () => {
+    const text = plain(formatSuppressions(rows, 30));
+    assert.match(text, /3 total: 1 active, 1 permanent \(no expiry\), 1 expired/);
+    assert.match(text, /EXPIRED 32d ago/);
+    assert.match(text, /8d left/);
+    assert.match(text, /permanent/);
+    assert.match(text, /zones differ/);
+    assert.match(text, /web-platform/);
+    assert.match(text, /\(no owner\)/);
+    assert.match(text, /expiring within 30d/);
+  });
+
+  it("explains what an expiry actually does", () => {
+    assert.match(plain(formatSuppressions(rows)), /not applied.*runs unmuted/s);
+  });
+
+  it("says so plainly when nothing is silenced", () => {
+    assert.match(plain(formatSuppressions([])), /No suppressions declared/);
+  });
+});
+
+describe("formatExpiredNotice", () => {
+  it("warns before the run that a failure may be stale config, not a regression", () => {
+    const text = plain(formatExpiredNotice([
+      resolveSuppression({ gate: "check design", flag: "--min-reuse 2", reason: "zones differ", expires: "2026-07-01" }, "game", NOW),
+    ]));
+    assert.match(text, /1 suppression\(s\) expired — the gate\(s\) below run unmuted/);
+    assert.match(text, /expired 32d ago: zones differ/);
+    assert.match(text, /may be this, not a new regression/);
+    // The full inventory's counts read wrong for a subset, so this is its own format.
+    assert.doesNotMatch(text, /total:/);
+  });
+
+  it("is empty when nothing expired", () => {
+    assert.equal(formatExpiredNotice([]), "");
+  });
+});
+
+describe("gates run (end to end)", () => {
+  const CLI = join(process.cwd(), "src/cli/vlmkit.ts");
+  const FIXTURE = join(process.cwd(), "fixtures/auto-markup-proof/creative/attempt-s18-haiku.html");
+
+  const runCli = async (args: string[], cwd: string) => {
+    const { spawn } = await import("node:child_process");
+    return new Promise<{ code: number; out: string }>((resolveRun) => {
+      const child = spawn(process.execPath, [...process.execArgv, CLI, ...args], { cwd, stdio: ["ignore", "pipe", "pipe"] });
+      let out = "";
+      child.stdout.on("data", (d) => { out += d; });
+      child.stderr.on("data", (d) => { out += d; });
+      child.on("close", (code) => resolveRun({ code: code ?? 1, out: plain(out) }));
+    });
+  };
+
+  const withConfig = (config: unknown): string => {
+    const dir = mkdtempSync(join(tmpdir(), "gates-e2e-"));
+    writeFileSync(join(dir, "vlmkit.gates.json"), JSON.stringify(config, null, 2));
+    return dir;
+  };
+
+  it("runs the configured gates and passes", async () => {
+    const dir = withConfig({
+      defaults: { gates: ["check design"] },
+      pages: [{ id: "tool-ui", source: FIXTURE }],
+    });
+    const { code, out } = await runCli(["gates", "run", "--concurrency", "1", "--quiet"], dir);
+    assert.equal(code, 0, out);
+    assert.match(out, /ALL PASS \(1\/1\)/);
+  });
+
+  it("fails on stale config even when every gate passes", async () => {
+    // The whole point of an expiry: a suppression nobody renewed is a defect in
+    // the config, and CI is where that gets noticed.
+    const dir = withConfig({
+      defaults: { gates: ["check design"] },
+      pages: [{
+        id: "tool-ui",
+        source: FIXTURE,
+        suppressions: [{ gate: "check design", flag: "--min-reuse 2", reason: "stale on purpose", expires: "2020-01-01" }],
+      }],
+    });
+    const { code, out } = await runCli(["gates", "run", "--concurrency", "1", "--quiet"], dir);
+    assert.match(out, /ALL PASS/);
+    assert.match(out, /suppression\(s\) expired/);
+    assert.equal(code, 1, out);
+  });
+
+  it("--advisory prints the same thing and exits 0", async () => {
+    const dir = withConfig({
+      defaults: { gates: ["check design"] },
+      pages: [{
+        id: "tool-ui",
+        source: FIXTURE,
+        suppressions: [{ gate: "check design", flag: "--min-reuse 2", reason: "stale on purpose", expires: "2020-01-01" }],
+      }],
+    });
+    const { code, out } = await runCli(["gates", "run", "--concurrency", "1", "--quiet", "--advisory"], dir);
+    assert.match(out, /suppression\(s\) expired/);
+    assert.equal(code, 0, out);
+  });
+
+  it("points at `gates init` when there is no config", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gates-empty-"));
+    const { code, out } = await runCli(["gates", "list"], dir);
+    assert.equal(code, 1);
+    assert.match(out, /No gate config found/);
+    assert.match(out, /vlmkit gates init/);
+  });
+
+  it("init scaffolds a config its own parser accepts", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gates-init-"));
+    const init = await runCli(["gates", "init", "--pages", FIXTURE, "--gate", "check design"], dir);
+    assert.equal(init.code, 0, init.out);
+    const list = await runCli(["gates", "list"], dir);
+    assert.equal(list.code, 0, list.out);
+    assert.match(list.out, /1 page\(s\), 1 gate run\(s\)/);
+  });
+});

--- a/src/cli/commands/gates-cli.ts
+++ b/src/cli/commands/gates-cli.ts
@@ -19,6 +19,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { hasFlag, readAll, readFlag, readInt } from "@mizchi/vlmkit-core/arg-reader.ts";
 import {
   GATE_CONFIG_FILENAMES,
   type GateConfig,
@@ -113,8 +114,7 @@ export function formatPlan(plan: GatePlan, configPath: string): string {
   for (const job of plan.jobs) {
     if (job.pageId !== current) {
       current = job.pageId;
-      const source = plan.jobs.find((j) => j.pageId === current)!.source;
-      lines.push(`${BOLD}${current}${RESET}${source === current ? "" : ` ${DIM}${source}${RESET}`}`);
+      lines.push(`${BOLD}${current}${RESET}${job.source === current ? "" : ` ${DIM}${job.source}${RESET}`}`);
     }
     const suffix = job.appliedSuppressions.length > 0
       ? ` ${YELLOW}[+${job.appliedSuppressions.length} suppression]${RESET}`
@@ -189,12 +189,12 @@ export function formatExpiredNotice(expired: ResolvedSuppression[]): string {
 const STARTER_GATE = "check integrity";
 
 async function initConfig(args: string[]): Promise<void> {
-  const path = resolve(getFlag(args, "--path") ?? GATE_CONFIG_FILENAMES[0]!);
-  if (existsSync(path) && !args.includes("--force")) {
+  const path = resolve(readFlag(args, "path") ?? GATE_CONFIG_FILENAMES[0]!);
+  if (existsSync(path) && !hasFlag(args, "force")) {
     throw new Error(`${path} already exists (pass --force to overwrite)`);
   }
-  const patterns = args.filter((a, i) => args[i - 1] === "--pages");
-  const gates = args.filter((a, i) => args[i - 1] === "--gate");
+  const patterns = readAll(args, "pages");
+  const gates = readAll(args, "gate");
   const config: GateConfig = {
     defaults: { gates: gates.length > 0 ? gates : [STARTER_GATE] },
     pages: (patterns.length > 0 ? patterns : ["index.html"]).map((source) => ({ source })),
@@ -207,11 +207,6 @@ async function initConfig(args: string[]): Promise<void> {
   console.log(`  ${config.pages.length} page entr(ies), gates: ${config.defaults!.gates!.join(", ")}`);
   console.log(`\nNext: vlmkit gates list    (see what would run)`);
   console.log(`      vlmkit gates run     (run it)`);
-}
-
-function getFlag(args: string[], name: string): string | undefined {
-  const i = args.indexOf(name);
-  return i >= 0 ? args[i + 1] : undefined;
 }
 
 function printUsage(exitCode: number): never {
@@ -244,14 +239,14 @@ opts out.`);
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
   const sub = argv[0];
-  if (!sub || argv.includes("--help") || argv.includes("-h")) printUsage(sub ? 0 : 1);
+  if (!sub || hasFlag(argv, "help") || hasFlag(argv, "-h")) printUsage(sub ? 0 : 1);
   const args = argv.slice(1);
-  const json = args.includes("--json");
+  const json = hasFlag(args, "json");
 
   if (sub === "init") return initConfig(args);
 
-  const { path, config } = await loadConfig(getFlag(args, "--config"));
-  const only = args.filter((a, i) => args[i - 1] === "--only");
+  const { path, config } = await loadConfig(readFlag(args, "config"));
+  const only = readAll(args, "only");
   const declared = resolveGatePlan(config, only.length > 0 ? { only } : {});
   // `suppressions` is an inventory of the config, so it must not depend on the
   // filesystem: a broken glob should not hide what has been silenced.
@@ -264,16 +259,16 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
   }
 
   if (sub === "suppressions") {
-    const soon = Number.parseInt(getFlag(args, "--soon") ?? "30", 10);
+    const soon = readInt(args, "soon", { min: 0 }) ?? 30;
     const summary = summarizeSuppressions(plan.suppressions, soon);
     if (json) console.log(JSON.stringify({ config: path, ...summary }, null, 2));
     else console.log(formatSuppressions(plan.suppressions, soon));
-    const requireExpiry = args.includes("--require-expiry");
-    const requireOwner = args.includes("--require-owner");
+    const requireExpiry = hasFlag(args, "require-expiry");
+    const requireOwner = hasFlag(args, "require-owner");
     const problems = summary.expired
       + (requireExpiry ? summary.permanent : 0)
       + (requireOwner ? summary.unowned : 0);
-    if (problems > 0 && !args.includes("--advisory")) process.exitCode = 1;
+    if (problems > 0 && !hasFlag(args, "advisory")) process.exitCode = 1;
     return;
   }
 
@@ -282,7 +277,13 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     printUsage(1);
   }
 
-  const shard = args.includes("--shard") ? parseShard(getFlag(args, "--shard") ?? "") : undefined;
+  // Read every flag before doing any work or printing anything: a typo in
+  // --concurrency should not surface after the expiry notice, where it reads
+  // like part of the run rather than a usage error.
+  const shardSpec = readFlag(args, "shard");
+  const shard = shardSpec ? parseShard(shardSpec) : undefined;
+  const concurrency = readInt(args, "concurrency", { min: 1 });
+  const output = readFlag(args, "output");
   const sharded = shardPlan(plan, shard);
   if (sharded.jobs.length === 0) {
     throw new Error(
@@ -297,26 +298,25 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     console.error(formatExpiredNotice(sharded.expired));
     console.error("");
   }
-  const concurrencyFlag = getFlag(args, "--concurrency");
   const summary: BatchSummary = await runJobs(
     sharded.jobs.map((j) => ({ gate: j.gate, page: j.source })),
     {
-      ...(concurrencyFlag ? { concurrency: Number.parseInt(concurrencyFlag, 10) } : {}),
+      ...(concurrency !== undefined ? { concurrency } : {}),
       ...(shard ? { shard } : {}),
-      ...(getFlag(args, "--output") ? { output: getFlag(args, "--output")! } : {}),
-      quiet: args.includes("--quiet") || json,
+      ...(output ? { output } : {}),
+      quiet: hasFlag(args, "quiet") || json,
     },
   );
   const stale = sharded.expired.length;
   if (json) console.log(JSON.stringify({ config: path, expiredSuppressions: stale, ...summary }, null, 2));
   else {
-    console.log(formatBatchSummary(summary, { showOutput: args.includes("--show-output") }));
+    console.log(formatBatchSummary(summary, { showOutput: hasFlag(args, "show-output") }));
     if (stale > 0) {
       console.log("");
       console.log(`${RED}${stale} suppression(s) expired${RESET} — stale config fails the run even when the gates pass.`);
     }
   }
-  if ((summary.failed > 0 || stale > 0) && !args.includes("--advisory")) process.exitCode = 1;
+  if ((summary.failed > 0 || stale > 0) && !hasFlag(args, "advisory")) process.exitCode = 1;
 }
 
 const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "gates" ||

--- a/src/cli/commands/gates-cli.ts
+++ b/src/cli/commands/gates-cli.ts
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/**
+ * `vlmkit gates` — drive the gates from one reviewed config instead of N npm
+ * scripts, and make every suppression enumerable.
+ *
+ * The documented convention was a script per page. Three independent reviewers
+ * raised the same two problems: it stops scaling around twenty pages, and once
+ * a `--allow-invisible` is inlined in a script, auditing what has been silenced
+ * repo-wide means grepping. `gates suppressions` is the answer to the second —
+ * one command that lists every suppression with its reason, owner and expiry,
+ * and exits non-zero when any of them has gone stale.
+ *
+ * Config format and the two decisions that make it reviewable (a reason is
+ * mandatory; an expired suppression stops being applied) live in
+ * `packages/vlmkit-core/src/gate-config.ts`.
+ */
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import {
+  GATE_CONFIG_FILENAMES,
+  type GateConfig,
+  type GatePlan,
+  type ResolvedSuppression,
+  parseGateConfig,
+  resolveGatePlan,
+  summarizeSuppressions,
+} from "@mizchi/vlmkit-core/gate-config.ts";
+import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
+import {
+  type BatchSummary,
+  formatBatchSummary,
+  parseShard,
+  resolvePages,
+  runJobs,
+  shardPages,
+} from "./batch-cli.ts";
+
+export function findGateConfig(cwd = process.cwd()): string | null {
+  for (const name of GATE_CONFIG_FILENAMES) {
+    const candidate = resolve(cwd, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+async function loadConfig(explicit?: string): Promise<{ path: string; config: GateConfig }> {
+  const path = explicit ? resolve(explicit) : findGateConfig();
+  if (!path) {
+    throw new Error(
+      `No gate config found (looked for ${GATE_CONFIG_FILENAMES.join(", ")}).`
+      + ` Create one with: vlmkit gates init --pages "routes/**/*.html"`,
+    );
+  }
+  if (!existsSync(path)) throw new Error(`Gate config not found: ${path}`);
+  return { path, config: parseGateConfig(await readFile(path, "utf-8")) };
+}
+
+/**
+ * Expand glob sources into one entry per file. Without this a config entry of
+ * `routes/**\/*.html` would hand the gate the pattern string itself, and the
+ * config would be as tedious to maintain as the npm scripts it replaces.
+ *
+ * A pattern matching several files keeps its config id as a prefix
+ * (`routes:routes/about.html`), so `--only` and per-page sharding still address
+ * the group by the name the config gave it.
+ */
+export async function expandPlanSources(plan: GatePlan): Promise<GatePlan> {
+  const expansions = new Map<string, string[]>();
+  for (const job of plan.jobs) {
+    if (expansions.has(job.source)) continue;
+    expansions.set(job.source, await resolvePages([job.source]));
+  }
+  const jobs: GatePlan["jobs"] = [];
+  for (const job of plan.jobs) {
+    const files = expansions.get(job.source)!;
+    if (files.length === 0) {
+      throw new Error(
+        `Page "${job.pageId}": source matched no files: ${job.source}`
+        + ` — fix the pattern or remove the entry rather than letting the gate run on nothing.`,
+      );
+    }
+    for (const file of files) {
+      jobs.push({
+        ...job,
+        source: file,
+        pageId: files.length === 1 && file === job.source ? job.pageId : `${job.pageId}:${file}`,
+      });
+    }
+  }
+  return { ...plan, jobs };
+}
+
+/** Shard over PAGES, not jobs, so one page's gates stay on one runner. */
+export function shardPlan(plan: GatePlan, shard?: { index: number; total: number }): GatePlan {
+  if (!shard || shard.total === 1) return plan;
+  const pages = [...new Set(plan.jobs.map((j) => j.pageId))].sort();
+  const mine = new Set(shardPages(pages, shard));
+  return { ...plan, jobs: plan.jobs.filter((j) => mine.has(j.pageId)) };
+}
+
+export function formatPlan(plan: GatePlan, configPath: string): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`${BOLD}${CYAN}vlmkit gates${RESET} ${DIM}${configPath}${RESET}`);
+  lines.push("");
+  const pages = [...new Set(plan.jobs.map((j) => j.pageId))];
+  lines.push(`${pages.length} page(s), ${plan.jobs.length} gate run(s)`);
+  lines.push("");
+  let current = "";
+  for (const job of plan.jobs) {
+    if (job.pageId !== current) {
+      current = job.pageId;
+      const source = plan.jobs.find((j) => j.pageId === current)!.source;
+      lines.push(`${BOLD}${current}${RESET}${source === current ? "" : ` ${DIM}${source}${RESET}`}`);
+    }
+    const suffix = job.appliedSuppressions.length > 0
+      ? ` ${YELLOW}[+${job.appliedSuppressions.length} suppression]${RESET}`
+      : "";
+    lines.push(`  vlmkit ${job.gate} ${job.source}${suffix}`);
+  }
+  if (plan.expired.length > 0) {
+    lines.push("");
+    lines.push(`${RED}${plan.expired.length} expired suppression(s) NOT applied${RESET} ${DIM}(see: vlmkit gates suppressions)${RESET}`);
+  }
+  return lines.join("\n");
+}
+
+export function formatSuppressions(suppressions: ResolvedSuppression[], soonDays = 30): string {
+  const summary = summarizeSuppressions(suppressions, soonDays);
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`${BOLD}${CYAN}vlmkit gates suppressions${RESET}`);
+  lines.push("");
+  if (summary.rows.length === 0) {
+    lines.push(`${GREEN}No suppressions declared.${RESET}`);
+    return lines.join("\n");
+  }
+  lines.push(
+    `${summary.rows.length} total: ${summary.active} active, ${summary.permanent} permanent (no expiry),`
+    + ` ${summary.expired > 0 ? `${RED}${summary.expired} expired${RESET}` : "0 expired"}`
+    + `${summary.expiringSoon > 0 ? `, ${YELLOW}${summary.expiringSoon} expiring within ${soonDays}d${RESET}` : ""}`
+    + `${summary.unowned > 0 ? `, ${YELLOW}${summary.unowned} unowned${RESET}` : ""}`,
+  );
+  lines.push("");
+  for (const s of summary.rows) {
+    const state = s.status === "expired"
+      ? `${RED}EXPIRED ${-s.daysLeft!}d ago${RESET}`
+      : s.status === "permanent"
+        ? `${DIM}permanent${RESET}`
+        : (s.daysLeft ?? Infinity) <= soonDays
+          ? `${YELLOW}${s.daysLeft}d left${RESET}`
+          : `${GREEN}${s.daysLeft}d left${RESET}`;
+    lines.push(`  ${state}  ${BOLD}${s.scope}${RESET} ${DIM}/${RESET} ${s.gate} ${DIM}${s.flag}${RESET}`);
+    lines.push(`      ${s.reason}${s.owner ? ` ${DIM}— ${s.owner}${RESET}` : ` ${YELLOW}(no owner)${RESET}`}`);
+  }
+  if (summary.expired > 0) {
+    lines.push("");
+    lines.push(
+      `${RED}Expired suppressions are not applied${RESET} — the gate they silenced runs unmuted.`,
+    );
+    lines.push(`${DIM}Fix the page, or renew the entry with a new expiry and a re-stated reason.${RESET}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Compact pre-run notice. The full inventory's counts read wrong for a filtered
+ * subset ("1 total: 0 active"), and before a run the only thing that matters is
+ * which gates are about to run unmuted and why.
+ */
+export function formatExpiredNotice(expired: ResolvedSuppression[]): string {
+  if (expired.length === 0) return "";
+  const lines = [
+    `${RED}${expired.length} suppression(s) expired — the gate(s) below run unmuted:${RESET}`,
+  ];
+  for (const s of expired) {
+    lines.push(
+      `  ${RED}x${RESET} ${BOLD}${s.scope}${RESET} ${DIM}/${RESET} ${s.gate} ${DIM}${s.flag}${RESET}`
+      + ` ${DIM}(expired ${-s.daysLeft!}d ago: ${s.reason})${RESET}`,
+    );
+  }
+  lines.push(`${DIM}A failure below may be this, not a new regression. See: vlmkit gates suppressions${RESET}`);
+  return lines.join("\n");
+}
+
+const STARTER_GATE = "check integrity";
+
+async function initConfig(args: string[]): Promise<void> {
+  const path = resolve(getFlag(args, "--path") ?? GATE_CONFIG_FILENAMES[0]!);
+  if (existsSync(path) && !args.includes("--force")) {
+    throw new Error(`${path} already exists (pass --force to overwrite)`);
+  }
+  const patterns = args.filter((a, i) => args[i - 1] === "--pages");
+  const gates = args.filter((a, i) => args[i - 1] === "--gate");
+  const config: GateConfig = {
+    defaults: { gates: gates.length > 0 ? gates : [STARTER_GATE] },
+    pages: (patterns.length > 0 ? patterns : ["index.html"]).map((source) => ({ source })),
+  };
+  // Parse what we are about to write: a scaffold that its own validator
+  // rejects would be a rough first impression.
+  parseGateConfig(JSON.stringify(config));
+  await writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+  console.log(`Wrote ${path}`);
+  console.log(`  ${config.pages.length} page entr(ies), gates: ${config.defaults!.gates!.join(", ")}`);
+  console.log(`\nNext: vlmkit gates list    (see what would run)`);
+  console.log(`      vlmkit gates run     (run it)`);
+}
+
+function getFlag(args: string[], name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+function printUsage(exitCode: number): never {
+  console.log(`Usage: vlmkit gates <init|list|suppressions|run> [options]
+
+One reviewed config (${GATE_CONFIG_FILENAMES[0]}) for which gates run on which
+pages, plus every suppression in one auditable place.
+
+  init            Scaffold a config
+                    --pages <glob>   Page source, repeatable
+                    --gate <cmd>     Default gate, repeatable
+                    --path <file> --force
+  list            Print the resolved page x gate plan without running it
+  suppressions    Inventory: reason, owner, expiry, days left
+                    --soon <days>       Highlight entries expiring within N days (30)
+                    --require-expiry    Fail on permanent (never-reviewed) entries
+                    --require-owner     Fail on entries with no owner
+  run             Run the plan in parallel
+                    --only <text>       Pages whose id/source contains this, repeatable
+                    --concurrency <n> --shard <i/n> --output <dir>
+                    --advisory          Exit 0 even on failures / stale config
+
+Common: --config <file> --json
+
+Exit codes: non-zero when a gate fails, and when a suppression has expired —
+an expired entry is a config defect even if the page now passes. --advisory
+opts out.`);
+  process.exit(exitCode);
+}
+
+async function main(argv = process.argv.slice(2)): Promise<void> {
+  const sub = argv[0];
+  if (!sub || argv.includes("--help") || argv.includes("-h")) printUsage(sub ? 0 : 1);
+  const args = argv.slice(1);
+  const json = args.includes("--json");
+
+  if (sub === "init") return initConfig(args);
+
+  const { path, config } = await loadConfig(getFlag(args, "--config"));
+  const only = args.filter((a, i) => args[i - 1] === "--only");
+  const declared = resolveGatePlan(config, only.length > 0 ? { only } : {});
+  // `suppressions` is an inventory of the config, so it must not depend on the
+  // filesystem: a broken glob should not hide what has been silenced.
+  const plan = sub === "suppressions" ? declared : await expandPlanSources(declared);
+
+  if (sub === "list") {
+    if (json) console.log(JSON.stringify({ config: path, ...plan }, null, 2));
+    else console.log(formatPlan(plan, path));
+    return;
+  }
+
+  if (sub === "suppressions") {
+    const soon = Number.parseInt(getFlag(args, "--soon") ?? "30", 10);
+    const summary = summarizeSuppressions(plan.suppressions, soon);
+    if (json) console.log(JSON.stringify({ config: path, ...summary }, null, 2));
+    else console.log(formatSuppressions(plan.suppressions, soon));
+    const requireExpiry = args.includes("--require-expiry");
+    const requireOwner = args.includes("--require-owner");
+    const problems = summary.expired
+      + (requireExpiry ? summary.permanent : 0)
+      + (requireOwner ? summary.unowned : 0);
+    if (problems > 0 && !args.includes("--advisory")) process.exitCode = 1;
+    return;
+  }
+
+  if (sub !== "run") {
+    console.error(`Unknown gates subcommand: ${sub}\n`);
+    printUsage(1);
+  }
+
+  const shard = args.includes("--shard") ? parseShard(getFlag(args, "--shard") ?? "") : undefined;
+  const sharded = shardPlan(plan, shard);
+  if (sharded.jobs.length === 0) {
+    throw new Error(
+      `No gate runs selected`
+      + (only.length > 0 ? ` by --only ${only.join(", ")}` : "")
+      + (shard ? ` in shard ${shard.index}/${shard.total}` : ""),
+    );
+  }
+  // Print stale config BEFORE the run: a gate failing because its suppression
+  // lapsed should not look like a fresh regression.
+  if (sharded.expired.length > 0) {
+    console.error(formatExpiredNotice(sharded.expired));
+    console.error("");
+  }
+  const concurrencyFlag = getFlag(args, "--concurrency");
+  const summary: BatchSummary = await runJobs(
+    sharded.jobs.map((j) => ({ gate: j.gate, page: j.source })),
+    {
+      ...(concurrencyFlag ? { concurrency: Number.parseInt(concurrencyFlag, 10) } : {}),
+      ...(shard ? { shard } : {}),
+      ...(getFlag(args, "--output") ? { output: getFlag(args, "--output")! } : {}),
+      quiet: args.includes("--quiet") || json,
+    },
+  );
+  const stale = sharded.expired.length;
+  if (json) console.log(JSON.stringify({ config: path, expiredSuppressions: stale, ...summary }, null, 2));
+  else {
+    console.log(formatBatchSummary(summary, { showOutput: args.includes("--show-output") }));
+    if (stale > 0) {
+      console.log("");
+      console.log(`${RED}${stale} suppression(s) expired${RESET} — stale config fails the run even when the gates pass.`);
+    }
+  }
+  if ((summary.failed > 0 || stale > 0) && !args.includes("--advisory")) process.exitCode = 1;
+}
+
+const isCliEntry = process.env.__VRT_DISPATCHER_LEAF__ === "gates" ||
+  (process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false);
+if (isCliEntry) main().catch(handleCliError);

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -328,7 +328,7 @@ export function parseSnapshotCliArgs(
 
   if (positional[0] === "approve") {
     if (positional.length > 1) {
-      throw new Error("`vrt snapshot approve` does not accept positional URLs");
+      throw new Error("`vlmkit snapshot approve` does not accept positional URLs");
     }
     return {
       mode: "approve",
@@ -378,7 +378,7 @@ export function parseSnapshotCliArgs(
   if (positional[0] === "stability-history") {
     const reportPaths = positional.slice(1);
     if (reportPaths.length === 0) {
-      throw new Error("`vrt snapshot stability-history` requires one or more stability-report.json paths");
+      throw new Error("`vlmkit snapshot stability-history` requires one or more stability-report.json paths");
     }
     return {
       mode: "stability-history",
@@ -399,7 +399,7 @@ export function parseSnapshotCliArgs(
 
   if (positional[0] === "flipbook") {
     if (positional.length > 1) {
-      throw new Error("`vrt snapshot flipbook` does not accept positional URLs");
+      throw new Error("`vlmkit snapshot flipbook` does not accept positional URLs");
     }
     return {
       mode: "flipbook",
@@ -421,7 +421,7 @@ export function parseSnapshotCliArgs(
 
   if (positional[0] === "fix-prompt") {
     if (positional.length > 1) {
-      throw new Error("`vrt snapshot fix-prompt` does not accept positional URLs");
+      throw new Error("`vlmkit snapshot fix-prompt` does not accept positional URLs");
     }
     return {
       mode: "fix-prompt",

--- a/src/cli/deprecation.ts
+++ b/src/cli/deprecation.ts
@@ -7,8 +7,13 @@ import { homedir, platform } from "node:os";
  * log file. The log path is consulted before removing shims at 1.0.0.
  *
  * Log path:
- *   Linux/macOS: ${XDG_STATE_HOME ?? ~/.local/state}/vrt/deprecated.log
+ *   Linux/macOS: ${XDG_STATE_HOME ?? ~/.local/state}/vlmkit/deprecated.log
  *   Windows:     ${LOCALAPPDATA}\vlmkit\deprecated.log
+ *
+ * The doc comment already said `vlmkit` for Windows while the code wrote
+ * `vlmkit` on both platforms, so the two disagreed. Both now use `vlmkit`; the
+ * log is append-only local telemetry consulted before removing shims at
+ * 1.0.0, so an old file left at the previous path costs nothing.
  *
  * Failure modes (read-only FS, missing env vars, EACCES) fall through
  * to stderr-only — never crash the CLI.
@@ -40,8 +45,8 @@ function resolveLogPath(): string | null {
   if (platform() === "win32") {
     const localAppData = process.env.LOCALAPPDATA;
     if (!localAppData) return null;
-    return join(localAppData, "vrt", "deprecated.log");
+    return join(localAppData, "vlmkit", "deprecated.log");
   }
   const base = process.env.XDG_STATE_HOME ?? join(homedir(), ".local", "state");
-  return join(base, "vrt", "deprecated.log");
+  return join(base, "vlmkit", "deprecated.log");
 }

--- a/src/cli/deprecation.ts
+++ b/src/cli/deprecation.ts
@@ -8,7 +8,7 @@ import { homedir, platform } from "node:os";
  *
  * Log path:
  *   Linux/macOS: ${XDG_STATE_HOME ?? ~/.local/state}/vrt/deprecated.log
- *   Windows:     ${LOCALAPPDATA}\vrt\deprecated.log
+ *   Windows:     ${LOCALAPPDATA}\vlmkit\deprecated.log
  *
  * Failure modes (read-only FS, missing env vars, EACCES) fall through
  * to stderr-only — never crash the CLI.

--- a/src/cli/vlmkit.ts
+++ b/src/cli/vlmkit.ts
@@ -5,9 +5,9 @@
  * Thin shim around `runCli()` in `./cli.ts`. The cac-based command
  * tree lives there; this file just hands argv off.
  */
+import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { runCli } from "./cli.ts";
 
-runCli().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+// Through `handleCliError` so a usage error — including one raised while a leaf
+// module reads its own argv at import time — prints one line instead of a stack.
+runCli().catch(handleCliError);

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -198,19 +198,19 @@ async function verify() {
   const result = await runVerifyPipeline(paths);
 
   if (!result.passed) {
-    console.log("\nFAILED — Fix the issues and run `vrt workflow capture && vrt workflow verify` again.");
+    console.log("\nFAILED — Fix the issues and run `vlmkit workflow capture && vlmkit workflow verify` again.");
     console.log("Details: " + REPORT_PATH);
     process.exit(1);
   } else if (result.needsReview) {
-    console.log("\nWARNING — Some changes need review. Run `vrt workflow report` for details.");
-    console.log("If changes are intentional, run `vrt workflow approve` to update baselines.");
+    console.log("\nWARNING — Some changes need review. Run `vlmkit workflow report` for details.");
+    console.log("If changes are intentional, run `vlmkit workflow approve` to update baselines.");
     process.exit(0);
   } else if (result.vrtDiffs.length === 0 && result.a11yDiffs.length === 0) {
     console.log("\nPASS — No visual or semantic changes detected.");
     process.exit(0);
   } else {
     console.log("\nPASS — All changes approved.");
-    console.log("Run `vrt workflow approve` to update baselines.");
+    console.log("Run `vlmkit workflow approve` to update baselines.");
     process.exit(0);
   }
 }
@@ -219,7 +219,7 @@ async function approve() {
   console.log("=== VRT Approve: Updating baselines ===\n");
 
   if (!existsSync(SNAPSHOTS_DIR)) {
-    console.error("No snapshots found. Run `vrt workflow capture` first.");
+    console.error("No snapshots found. Run `vlmkit workflow capture` first.");
     process.exit(1);
   }
 
@@ -236,7 +236,7 @@ async function approve() {
 
 async function report() {
   if (!existsSync(REPORT_PATH)) {
-    console.error("No report found. Run `vrt workflow verify` first.");
+    console.error("No report found. Run `vlmkit workflow verify` first.");
     process.exit(1);
   }
 

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -41,6 +41,7 @@ import {
 } from "./workflow/paths.ts";
 import { resolveCaptureRoutes } from "@mizchi/vlmkit-capture/capture-config.ts";
 import type { UnifiedAgentContext } from "@mizchi/vlmkit-core/types.ts";
+import { readEnv } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 const NPX_COMMAND = process.platform === "win32" ? "npx.cmd" : "npx";
 
@@ -99,8 +100,8 @@ function buildCaptureEnv(mode: "baseline" | "capture", options: WorkflowCaptureO
   const routeSet = resolveCaptureRoutes({
     cwd: PROJECT_ROOT,
     configPath: options.configPath,
-    envConfigPath: process.env.VRT_CONFIG_PATH,
-    envBaseUrl: options.baseUrl ?? process.env.VRT_BASE_URL,
+    envConfigPath: readEnv("CONFIG_PATH"),
+    envBaseUrl: options.baseUrl ?? readEnv("BASE_URL"),
   });
 
   if (routeSet.configPath) {

--- a/src/cli/workflow/paths.ts
+++ b/src/cli/workflow/paths.ts
@@ -3,13 +3,13 @@ import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 
 /**
- * Shared paths for `vrt workflow` commands.
+ * Shared paths for `vlmkit workflow` commands.
  *
- * - `HARNESS_ROOT` is the installed vrt package root (used to locate
+ * - `HARNESS_ROOT` is the installed vlmkit package root (used to locate
  *   `dist/e2e/vrt-capture.spec.mjs` or `e2e/vrt-capture.spec.ts`).
  *   Resolved by walking up from the CLI entry until a `package.json` is
  *   found, so it works in both the source layout (`src/cli/vlmkit.ts`) and
- *   the bundled CLI (`dist/vrt.mjs`).
+ *   the bundled CLI (`dist/vlmkit.mjs`).
  * - `PROJECT_ROOT` is the *target* project — where baselines, snapshots,
  *   output, and report files land. Overridable via `VRT_PROJECT_ROOT`;
  *   defaults to the caller's cwd.

--- a/src/cli/workflow/paths.ts
+++ b/src/cli/workflow/paths.ts
@@ -1,6 +1,7 @@
 import { resolve, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
+import { readEnv } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 /**
  * Shared paths for `vlmkit workflow` commands.
@@ -34,7 +35,7 @@ function findHarnessRoot(): string {
 }
 
 export const HARNESS_ROOT = findHarnessRoot();
-export const PROJECT_ROOT = resolve(process.env.VRT_PROJECT_ROOT ?? process.cwd());
+export const PROJECT_ROOT = resolve(readEnv("PROJECT_ROOT") ?? process.cwd());
 
 export const BASELINES_DIR = join(PROJECT_ROOT, "baselines");
 export const SNAPSHOTS_DIR = join(PROJECT_ROOT, "snapshots");

--- a/src/cli/workflow/spec.ts
+++ b/src/cli/workflow/spec.ts
@@ -27,7 +27,7 @@ async function listFiles(dir: string, suffix: string): Promise<string[]> {
 export async function runIntrospect(paths: SpecPaths) {
   const dir = existsSync(paths.snapshotsDir) ? paths.snapshotsDir : paths.baselinesDir;
   if (!existsSync(dir)) {
-    console.error("No snapshots or baselines found. Run `vrt workflow init` or `vrt workflow capture` first.");
+    console.error("No snapshots or baselines found. Run `vlmkit workflow init` or `vlmkit workflow capture` first.");
     process.exit(1);
   }
 
@@ -51,7 +51,7 @@ export async function runIntrospect(paths: SpecPaths) {
 
 export async function runSpecVerify(paths: SpecPaths) {
   if (!existsSync(paths.specPath)) {
-    console.error("No spec.json found. Run `vrt workflow introspect` first.");
+    console.error("No spec.json found. Run `vlmkit workflow introspect` first.");
     process.exit(1);
   }
 
@@ -122,11 +122,11 @@ export async function runExpect(paths: SpecPaths) {
   console.log("=== Generate expectation.json from current state ===\n");
 
   if (!existsSync(paths.baselinesDir)) {
-    console.error("No baselines found. Run `vrt workflow init` first.");
+    console.error("No baselines found. Run `vlmkit workflow init` first.");
     process.exit(1);
   }
   if (!existsSync(paths.snapshotsDir)) {
-    console.error("No snapshots found. Run `vrt workflow capture` first.");
+    console.error("No snapshots found. Run `vlmkit workflow capture` first.");
     process.exit(1);
   }
 
@@ -210,5 +210,5 @@ export async function runExpect(paths: SpecPaths) {
     const icon = !p.hasA11yDiff ? "  " : p.hasRegression ? "!!" : "~~";
     console.log(`  [${icon}] ${p.testId}: ${p.changes.length} change(s)`);
   }
-  console.log(`\nReview and edit as needed, then run: vrt workflow verify`);
+  console.log(`\nReview and edit as needed, then run: vlmkit workflow verify`);
 }

--- a/src/cli/workflow/verify.ts
+++ b/src/cli/workflow/verify.ts
@@ -42,10 +42,10 @@ export async function runVerifyPipeline(paths: VerifyPaths): Promise<VerifyResul
   const { projectRoot, baselinesDir, snapshotsDir, outputDir, reportPath, expectationPath } = paths;
 
   if (!existsSync(baselinesDir)) {
-    throw new Error("No baselines found. Run `vrt init` first.");
+    throw new Error("No baselines found. Run `vlmkit workflow init` first.");
   }
   if (!existsSync(snapshotsDir)) {
-    throw new Error("No snapshots found. Run `vrt capture` first.");
+    throw new Error("No snapshots found. Run `vlmkit workflow capture` first.");
   }
 
   await mkdir(outputDir, { recursive: true });

--- a/src/diff-pr-config.test.ts
+++ b/src/diff-pr-config.test.ts
@@ -15,7 +15,9 @@ describe("parseDiffPrConfig", () => {
     assert.equal(cfg.routes.length, 1);
     assert.equal(cfg.routes[0].name, "home");
     assert.equal(cfg.routes[0].url, "http://localhost:3000/");
-    assert.equal(cfg.baselineDir, ".vrt/baselines");
+    // `.vlmkit/baselines` unless a `.vrt/baselines` already exists in cwd —
+    // see legacy-names.test.ts for the fallback itself.
+    assert.equal(cfg.baselineDir, ".vlmkit/baselines");
   });
 
   it("honors thresholds at top level and per-route overrides", () => {

--- a/src/diff-pr-config.ts
+++ b/src/diff-pr-config.ts
@@ -18,8 +18,9 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, isAbsolute, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { parseToml } from "./toml-min.ts";
+import { CONFIG_CANDIDATES, CONFIG_FILE, STATE_DIR, noteLegacyName, resolveStatePath } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 export interface DiffPrRoute {
   name: string;
@@ -142,7 +143,17 @@ const DEFAULT_THRESHOLDS: Record<string, number> = {
   desktop: 0.005,
   wide: 0.005,
 };
-const DEFAULT_BASELINE_DIR = ".vrt/baselines";
+/**
+ * Default baseline directory, as the relative string the config format stores.
+ *
+ * Computed per call rather than as a module constant: a project whose approved
+ * baselines are still in `.vrt/baselines` must keep resolving there, and a
+ * hard-coded `.vlmkit/baselines` would point it at an empty directory and report
+ * every route as a new baseline.
+ */
+function defaultBaselineDir(): string {
+  return relative(process.cwd(), resolveStatePath(process.cwd(), "baselines")) || `${STATE_DIR}/baselines`;
+}
 
 export function parseDiffPrConfig(raw: string, configPath?: string): DiffPrConfig {
   const parsed = parseConfigSource(raw, configPath);
@@ -154,7 +165,7 @@ export function parseDiffPrConfig(raw: string, configPath?: string): DiffPrConfi
   const viewports = asOptionalStringArray(obj.viewports, "viewports");
   const tokens = asOptionalString(obj.tokens, "tokens");
   const approvalPath = asOptionalString(obj.approvalPath, "approvalPath");
-  const baselineDir = asOptionalString(obj.baselineDir, "baselineDir") ?? DEFAULT_BASELINE_DIR;
+  const baselineDir = asOptionalString(obj.baselineDir, "baselineDir") ?? defaultBaselineDir();
   const thresholds = parseThresholds(obj.thresholds);
 
   // Accept routes at top level or under capture.routes for parity
@@ -406,13 +417,19 @@ export function resolveThreshold(config: DiffPrConfig, route: DiffPrRoute, viewp
 export function findConfigPath(cwd: string, explicit?: string): string | undefined {
   if (explicit) {
     const abs = isAbsolute(explicit) ? explicit : resolve(cwd, explicit);
-    if (!existsSync(abs)) throw new Error(`vrt.config not found: ${abs}`);
+    if (!existsSync(abs)) throw new Error(`config not found: ${abs}`);
     return abs;
   }
-  // Prefer JSON when both exist (back-compat); otherwise pick up TOML.
-  for (const name of ["vrt.config.json", "vrt.config.toml"]) {
+  // New names first, then the pre-rename ones. JSON still wins over TOML when
+  // both are present. A project on `vrt.config.json` keeps working and is told
+  // once; renaming without this fallback would report "no config" to a project
+  // that has one.
+  for (const { name, legacy } of CONFIG_CANDIDATES) {
     const candidate = resolve(cwd, name);
-    if (existsSync(candidate)) return candidate;
+    if (existsSync(candidate)) {
+      if (legacy) noteLegacyName(name, CONFIG_FILE);
+      return candidate;
+    }
   }
   return undefined;
 }

--- a/src/diff-pr-config.ts
+++ b/src/diff-pr-config.ts
@@ -1,5 +1,5 @@
 /**
- * Config loader for `vrt diff-pr` — extends the existing
+ * Config loader for `vlmkit diff-pr` — extends the existing
  * `vrt.config.json` shape (parsed by capture-config.ts for the
  * workflow path) with policy-layer fields:
  *
@@ -102,14 +102,14 @@ export interface DiffPrConfig {
   baselineDir: string;
   a11y?: A11yPolicy;
   /**
-   * When present, `vrt diff-pr` runs the media-variants emulation
+   * When present, `vlmkit diff-pr` runs the media-variants emulation
    * suite (forced-colors / reduced-motion / print / rtl / zoom-200)
    * per route at the default viewport and gates on the per-route
    * verdict counts. Omit to skip media variants entirely.
    */
   mediaVariants?: MediaVariantsPolicy;
   /**
-   * When present, `vrt diff-pr` renders each route in chromium /
+   * When present, `vlmkit diff-pr` renders each route in chromium /
    * firefox / webkit and diffs the screenshots; engines that exceed
    * the threshold count toward the route's pass/fail. Omit to skip.
    */

--- a/src/diff-pr.test.ts
+++ b/src/diff-pr.test.ts
@@ -113,7 +113,7 @@ describe("buildMarkdownSummary", () => {
   });
 });
 
-describe("vrt diff-pr pin <route>...", () => {
+describe("vlmkit diff-pr pin <route>...", () => {
   let cwd: string;
 
   before(async () => {
@@ -181,7 +181,7 @@ describe("vrt diff-pr pin <route>...", () => {
   });
 });
 
-describe("vrt diff-pr a11y gate", () => {
+describe("vlmkit diff-pr a11y gate", () => {
   let cwd: string;
 
   before(async () => {
@@ -277,7 +277,7 @@ describe("vrt diff-pr a11y gate", () => {
   });
 });
 
-describe("vrt diff-pr post", () => {
+describe("vlmkit diff-pr post", () => {
   let cwd: string;
   let summaryPath: string;
 
@@ -285,7 +285,7 @@ describe("vrt diff-pr post", () => {
     cwd = await mkdtemp(join(tmpdir(), "vrt-diff-pr-post-"));
     summaryPath = join(cwd, ".vrt/runs/diff-pr/summary.md");
     await mkdir(join(cwd, ".vrt/runs/diff-pr"), { recursive: true });
-    await writeFile(summaryPath, "# vrt diff-pr summary\n\nStatus: **PASS**\n");
+    await writeFile(summaryPath, "# vlmkit diff-pr summary\n\nStatus: **PASS**\n");
   });
 
   after(async () => {

--- a/src/diff-pr.ts
+++ b/src/diff-pr.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 /**
- * `vrt diff-pr` — CI-mode runner. Walks the declared route set,
+ * `vlmkit diff-pr` — CI-mode runner. Walks the declared route set,
  * compares each route's current rendering against a pinned baseline
  * PNG, applies the per-route diff-ratio policy, and exits non-zero on
  * any uncovered breach.
  *
  * Two subcommands:
- *   vrt diff-pr pin [--config vrt.config.json]
+ *   vlmkit diff-pr pin [--config vrt.config.json]
  *     Capture baselines for every declared route into
  *     <baselineDir>/<route>/<viewport>.png. Run once on main when the
  *     design is intended; downstream PRs gate against these PNGs.
  *
- *   vrt diff-pr [--config vrt.config.json] [--output <dir>]
+ *   vlmkit diff-pr [--config vrt.config.json] [--output <dir>]
  *     For each route, render the current state at every viewport,
  *     pixel-diff against the pinned PNG, apply the per-route policy.
  *     Emit a markdown summary suitable for pasting into a PR comment.
@@ -20,7 +20,7 @@
  * Stays narrow: uses Playwright directly + the existing
  * `compareScreenshots` helper, NOT the full migration-compare
  * pipeline. The richer wireframe-suggestions / palette-diff signals
- * are still available via `vrt compare` / `vrt watch` for the
+ * are still available via `vlmkit diff html` / `vlmkit watch` for the
  * development loop; this is the policy gate.
  */
 
@@ -215,7 +215,7 @@ async function cmdPin(args: string[]): Promise<void> {
     routesToPin = config.routes.filter((r) => requestedRouteNames.includes(r.name));
   }
 
-  console.log(`${BOLD}${CYAN}vrt diff-pr pin${RESET}  ${DIM}${configPath}${RESET}`);
+  console.log(`${BOLD}${CYAN}vlmkit diff-pr pin${RESET}  ${DIM}${configPath}${RESET}`);
   const scopeNote = routesToPin.length === config.routes.length
     ? `pinning ${routesToPin.length} route(s)`
     : `pinning ${routesToPin.length} of ${config.routes.length} route(s) (${routesToPin.map((r) => r.name).join(", ")}); other baselines untouched`;
@@ -236,7 +236,7 @@ async function cmdPin(args: string[]): Promise<void> {
       for (const vp of viewports) {
         try {
           // a11y is intentionally NOT computed during `pin` — the
-          // baseline PNG is what we care about. CI's `vrt diff-pr`
+          // baseline PNG is what we care about. CI's `vlmkit diff-pr`
           // (no pin) runs the a11y checks against the live render.
           await renderViewport(browser, route.url, vp.width, vp.height, join(dir, `${vp.label}.png`), route.waitFor);
           success++;
@@ -250,7 +250,7 @@ async function cmdPin(args: string[]): Promise<void> {
     await browser.close();
   }
   console.log();
-  console.log(`${DIM}Baselines pinned. Run \`vrt diff-pr\` in CI to gate against them.${RESET}`);
+  console.log(`${DIM}Baselines pinned. Run \`vlmkit diff-pr\` in CI to gate against them.${RESET}`);
 }
 
 async function cmdRun(args: string[]): Promise<number> {
@@ -277,7 +277,7 @@ async function cmdRun(args: string[]): Promise<number> {
     }
   }
 
-  console.log(`${BOLD}${CYAN}vrt diff-pr${RESET}  ${DIM}${configPath}${RESET}`);
+  console.log(`${BOLD}${CYAN}vlmkit diff-pr${RESET}  ${DIM}${configPath}${RESET}`);
   console.log(`${DIM}  ${config.routes.length} route(s); thresholds ${JSON.stringify(config.thresholds)}${RESET}`);
   if (manifest) console.log(`${DIM}  approval manifest: ${manifest.rules.length} rule(s)${RESET}`);
   console.log();
@@ -290,7 +290,7 @@ async function cmdRun(args: string[]): Promise<number> {
     for (const route of config.routes) {
       const baselineDir = baselineDirForRoute(config, route);
       if (!existsSync(baselineDir)) {
-        console.log(`  ${route.name.padEnd(20)} ${RED}no baseline${RESET} ${DIM}(${baselineDir} — run \`vrt diff-pr pin\` first)${RESET}`);
+        console.log(`  ${route.name.padEnd(20)} ${RED}no baseline${RESET} ${DIM}(${baselineDir} — run \`vlmkit diff-pr pin\` first)${RESET}`);
         results.push({ route, viewports: [], failed: true, error: `no baseline at ${baselineDir}` });
         continue;
       }
@@ -339,7 +339,7 @@ async function cmdRun(args: string[]): Promise<number> {
         const rawDiff = await compareScreenshots(snap, { outputDir: routeOut });
         // Suppress diffs covered by an approval before gating. Without a DOM
         // here, selector rules can't bind, but region-bbox rules (the zone
-        // matcher) do — that's the CI consumer of `vrt baseline approve
+        // matcher) do — that's the CI consumer of `vlmkit baseline approve
         // --region` (A/B epic 01).
         const diff = rawDiff && manifest
           ? filterApprovedVrtRegions(rawDiff, manifest, [], { viewport: vp.label }).diff
@@ -527,7 +527,7 @@ async function cmdRun(args: string[]): Promise<number> {
 
 export function buildMarkdownSummary(config: DiffPrConfig, results: PerRouteResult[]): string {
   const lines: string[] = [];
-  lines.push("# vrt diff-pr summary");
+  lines.push("# vlmkit diff-pr summary");
   lines.push("");
   const totalRoutes = results.length;
   const failed = results.filter((r) => r.failed).length;
@@ -683,7 +683,7 @@ interface PostPrOptions {
 async function postPrComment(opts: PostPrOptions): Promise<number> {
   if (!existsSync(opts.summaryPath)) {
     console.error(`${RED}error:${RESET} no summary at ${opts.summaryPath}`);
-    console.error(`Run \`vrt diff-pr\` first to produce the summary, or pass --summary <path>.`);
+    console.error(`Run \`vlmkit diff-pr\` first to produce the summary, or pass --summary <path>.`);
     return 1;
   }
   const summary = await readFile(opts.summaryPath, "utf-8");
@@ -740,7 +740,7 @@ async function cmdPost(args: string[]): Promise<number> {
 }
 
 function formatUsage(): string {
-  return `vrt diff-pr <command>
+  return `vlmkit diff-pr <command>
 
 Subcommands:
   pin    [route...] [--config vrt.config.json]

--- a/src/experiments/benchmark/benchmark.ts
+++ b/src/experiments/benchmark/benchmark.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * vrt benchmark
+ * vlmkit benchmark
  *
  * Measure performance of deterministic APIs (no LLM).
  * Record results as baselines for tracking improvements.

--- a/src/experiments/benchmark/benchmark.ts
+++ b/src/experiments/benchmark/benchmark.ts
@@ -82,7 +82,7 @@ async function main() {
   await mkdir(TMP, { recursive: true });
 
   console.log();
-  console.log(`${BOLD}${CYAN}vrt benchmark${RESET}`);
+  console.log(`${BOLD}${CYAN}vlmkit benchmark${RESET}`);
   console.log();
 
   const results: BenchResult[] = [];

--- a/src/experiments/benchmark/vlm-bench.ts
+++ b/src/experiments/benchmark/vlm-bench.ts
@@ -14,10 +14,12 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { listModels, resolveModel, createVlmClient, type VlmModel, type VlmResponse } from "@mizchi/vlmkit-ai/vlm-client.ts";
-import { getArg, hasFlag, getPositionalArgs } from "@mizchi/vlmkit-core/cli-args.ts";
+import { getArg, getFloatArg, getIntArg, hasFlag, getPositionalArgs } from "@mizchi/vlmkit-core/cli-args.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
-const modelArgs = getPositionalArgs();
+// Named explicitly: argv cannot tell `--limit 30` from `--md model-name`,
+// and assuming every flag takes a value dropped a model after `--md`.
+const modelArgs = getPositionalArgs(["image", "max-cost", "limit"]);
 
 const IMAGE_PATH = getArg("image", "");
 const TMP = join(process.cwd(), "test-results", "vlm-bench");
@@ -32,8 +34,8 @@ function formatCost(costPer1k: number): string {
 // ---- List command ----
 
 async function runList() {
-  const maxCost = getArg("max-cost", "") ? parseFloat(getArg("max-cost", "999")) : undefined;
-  const limit = getArg("limit", "") ? parseInt(getArg("limit", "50"), 10) : 50;
+  const maxCost = getArg("max-cost", "") ? getFloatArg("max-cost", 999, { min: 0 }) : undefined;
+  const limit = getIntArg("limit", 50, { min: 1 });
   const models = await listModels({ maxCost, limit, includeGemini: true });
 
   console.log();

--- a/src/experiments/css-challenge/css-challenge-bench-cli.test.ts
+++ b/src/experiments/css-challenge/css-challenge-bench-cli.test.ts
@@ -46,3 +46,25 @@ describe("parseCssChallengeBenchArgs", () => {
     assert.equal(options.enableLlm, true);
   });
 });
+
+describe("parseCssChallengeBenchArgs — numeric validation", () => {
+  it("rejects a non-numeric trials count instead of running NaN trials", () => {
+    // The inline reader this replaced produced NaN, so the bench reported
+    // numbers from a loop that never ran the requested count.
+    assert.throws(() => parseCssChallengeBenchArgs(["--trials", "abc"]), /--trials must be a number/);
+    assert.throws(() => parseCssChallengeBenchArgs(["--trials", "0"]), /--trials must be >= 1/);
+  });
+
+  it("rejects a flag swallowed as a value", () => {
+    assert.throws(
+      () => parseCssChallengeBenchArgs(["--trials", "--no-db"]),
+      /--trials needs a value, got the next flag --no-db/,
+    );
+  });
+
+  it("keeps the documented defaults", () => {
+    const options = parseCssChallengeBenchArgs([]);
+    assert.equal(options.trials, 20);
+    assert.equal(options.startSeed, 1);
+  });
+});

--- a/src/experiments/css-challenge/css-challenge-bench.ts
+++ b/src/experiments/css-challenge/css-challenge-bench.ts
@@ -76,7 +76,8 @@ import {
   type PrescannerTrialResolution,
 } from "@mizchi/vlmkit-capture/prescanner.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "@mizchi/vlmkit-core/terminal-colors.ts";
-import { args } from "@mizchi/vlmkit-core/cli-args.ts";
+import { getRawArgs } from "@mizchi/vlmkit-core/cli-args.ts";
+import { hasFlag, readAll, readFlag, readInt } from "@mizchi/vlmkit-core/arg-reader.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 
 // ---- Config ----
@@ -98,38 +99,30 @@ export interface CssChallengeBenchCliOptions {
   enableLlm: boolean;
 }
 
+/**
+ * A fourth hand-rolled copy of the same reader used to live here, and this one
+ * fed the bench's own `trials` / `start-seed`: `--trials abc` became `NaN`
+ * trials, i.e. a benchmark reporting numbers from a loop that never ran the
+ * requested count. It now goes through `arg-reader`, which rejects that.
+ */
 export function parseCssChallengeBenchArgs(cliArgs: string[]): CssChallengeBenchCliOptions {
-  function getCliArg(name: string, fallback: string): string {
-    const idx = cliArgs.indexOf(`--${name}`);
-    return idx >= 0 && cliArgs[idx + 1] ? cliArgs[idx + 1] : fallback;
-  }
-  function getCliArgValues(name: string): string[] {
-    const values: string[] = [];
-    for (let i = 0; i < cliArgs.length; i++) {
-      if (cliArgs[i] === `--${name}` && cliArgs[i + 1]) values.push(cliArgs[i + 1]);
-    }
-    return values;
-  }
-  function hasCliFlag(name: string): boolean {
-    return cliArgs.includes(`--${name}`);
-  }
-
+  const str = (name: string, fallback: string): string => readFlag(cliArgs, name) || fallback;
   return {
-    trials: parseInt(getCliArg("trials", "20"), 10),
-    startSeed: parseInt(getCliArg("start-seed", "1"), 10),
-    saveDb: !hasCliFlag("no-db"),
-    fixtureArgs: getCliArgValues("fixture"),
-    backend: getCliArg("backend", "chromium") as BenchBackend,
-    approvalPath: getCliArg("approval", ""),
-    strict: hasCliFlag("strict"),
-    suggestApproval: hasCliFlag("suggest-approval"),
-    outputRoot: getCliArg("output-root", CSS_BENCH_OUTPUT_ROOT),
-    mode: getCliArg("mode", "property") as ChallengeMode,
-    enableLlm: !hasCliFlag("no-llm"),
+    trials: readInt(cliArgs, "trials", { min: 1 }) ?? 20,
+    startSeed: readInt(cliArgs, "start-seed", { min: 0 }) ?? 1,
+    saveDb: !hasFlag(cliArgs, "no-db"),
+    fixtureArgs: readAll(cliArgs, "fixture"),
+    backend: str("backend", "chromium") as BenchBackend,
+    approvalPath: str("approval", ""),
+    strict: hasFlag(cliArgs, "strict"),
+    suggestApproval: hasFlag(cliArgs, "suggest-approval"),
+    outputRoot: str("output-root", CSS_BENCH_OUTPUT_ROOT),
+    mode: str("mode", "property") as ChallengeMode,
+    enableLlm: !hasFlag(cliArgs, "no-llm"),
   };
 }
 
-const CLI_OPTIONS = parseCssChallengeBenchArgs(args);
+const CLI_OPTIONS = parseCssChallengeBenchArgs(getRawArgs());
 const TRIALS = CLI_OPTIONS.trials;
 const START_SEED = CLI_OPTIONS.startSeed;
 const SAVE_DB = CLI_OPTIONS.saveDb;

--- a/src/experiments/css-challenge/css-challenge-core.ts
+++ b/src/experiments/css-challenge/css-challenge-core.ts
@@ -45,6 +45,7 @@ import {
 } from "@mizchi/vlmkit-core/computed-style-capture.ts";
 import { formatPlaywrightLaunchError, isPlaywrightSandboxRestrictionError } from "@mizchi/vlmkit-capture/playwright-launch-error.ts";
 import type { A11yNode, VrtSnapshot, VrtDiff, VisualSemanticDiff, A11yDiff } from "@mizchi/vlmkit-core/types.ts";
+import { debugEnabled } from "@mizchi/vlmkit-core/legacy-names.ts";
 
 // ---- Types ----
 
@@ -403,7 +404,7 @@ export async function capturePageState(
       computedStyles.set(selector, props);
     }
   } catch (e) {
-    if (process.env.DEBUG_VRT) console.error("[capturePageState] computed style error:", e);
+    if (debugEnabled()) console.error("[capturePageState] computed style error:", e);
   }
 
   // Capture hover styles by temporarily activating :hover rules

--- a/src/experiments/css-challenge/css-challenge.ts
+++ b/src/experiments/css-challenge/css-challenge.ts
@@ -22,7 +22,7 @@ import { classifyVisualDiff } from "@mizchi/vlmkit-markup/visual-semantic.ts";
 import { diffA11yTrees, verifyA11yTree, parsePlaywrightA11ySnapshot } from "@mizchi/vlmkit-core/a11y-semantic.ts";
 import { createLLMProvider } from "@mizchi/vlmkit-ai/llm-client.ts";
 import type { A11yNode, VrtSnapshot } from "@mizchi/vlmkit-core/types.ts";
-import { getArg, hasFlag } from "@mizchi/vlmkit-core/cli-args.ts";
+import { getArg, getIntArg, hasFlag } from "@mizchi/vlmkit-core/cli-args.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 
@@ -30,8 +30,8 @@ import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
 
 const TMP = join(import.meta.dirname!, "..", "..", "..", "test-results", "css-challenge");
 
-const SEED = parseInt(getArg("seed", String(Date.now())), 10);
-const MAX_ATTEMPTS = parseInt(getArg("max-attempts", "3"), 10);
+const SEED = getIntArg("seed", Date.now());
+const MAX_ATTEMPTS = getIntArg("max-attempts", 3, { min: 1 });
 const FIXTURE = getArg("fixture", "page");
 const HTML_PATH = getCssChallengeFixturePath(FIXTURE);
 const APPROVAL_PATH = getArg("approval", "");

--- a/src/experiments/css-challenge/fix-loop.ts
+++ b/src/experiments/css-challenge/fix-loop.ts
@@ -22,13 +22,13 @@ import { createReasoningPipeline } from "@mizchi/vlmkit-ai/reasoning-pipeline.ts
 import { resolveResolutionForViewport } from "@mizchi/vlmkit-core/image-resize.ts";
 import { getCssChallengeFixturePath } from "./css-challenge-fixtures.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "@mizchi/vlmkit-core/terminal-colors.ts";
-import { getArg } from "@mizchi/vlmkit-core/cli-args.ts";
+import { getArg, getIntArg } from "@mizchi/vlmkit-core/cli-args.ts";
 
 // ---- Config ----
 
 const FIXTURE = getArg("fixture", "page");
-const SEED = parseInt(getArg("seed", String(Date.now())), 10);
-const MAX_ROUNDS = parseInt(getArg("max-rounds", "3"), 10);
+const SEED = getIntArg("seed", Date.now());
+const MAX_ROUNDS = getIntArg("max-rounds", 3, { min: 1 });
 const MODE = getArg("mode", "property") as "property" | "selector";
 const VIEWPORT = { width: 1280, height: 900 };
 const TMP = join(process.cwd(), "test-results", "fix-loop");

--- a/src/experiments/migration/design-md-tokens.ts
+++ b/src/experiments/migration/design-md-tokens.ts
@@ -1,7 +1,7 @@
 /**
  * Lightweight loader for the YAML-ish front matter Google's
  * `design.md` examples use. Goal: surface spacing + color tokens to
- * `vrt`'s fix-candidate and palette-diff layers so an agent can be told
+ * `vlmkit`'s fix-candidate and palette-diff layers so an agent can be told
  * "swap `surface-variant` → `surface-container-high`" instead of
  * staring at two hex strings.
  *

--- a/src/experiments/migration/migration-blind.ts
+++ b/src/experiments/migration/migration-blind.ts
@@ -435,11 +435,11 @@ async function main() {
 function formatUsage(): string {
   return [
     "Usage:",
-    "  vrt migration blind <manifest.json> list",
-    "  vrt migration blind <manifest.json> show <scenario-id>",
-    "  vrt migration blind <manifest.json> prepare <scenario-id> [--output-dir path] [--packet path] [--format markdown|json] [--paint-tree]",
-    "  vrt migration blind <manifest.json> evaluate <scenario-id> --before-report before.json --after-report after.json --rounds n [--output path] [--format markdown|json]",
-    "  vrt migration blind <manifest.json> solo <scenario-id> [--output path] [--report-output-dir path] [--format markdown|json] [--paint-tree] [--check]",
+    "  vlmkit migration blind <manifest.json> list",
+    "  vlmkit migration blind <manifest.json> show <scenario-id>",
+    "  vlmkit migration blind <manifest.json> prepare <scenario-id> [--output-dir path] [--packet path] [--format markdown|json] [--paint-tree]",
+    "  vlmkit migration blind <manifest.json> evaluate <scenario-id> --before-report before.json --after-report after.json --rounds n [--output path] [--format markdown|json]",
+    "  vlmkit migration blind <manifest.json> solo <scenario-id> [--output path] [--report-output-dir path] [--format markdown|json] [--paint-tree] [--check]",
   ].join("\n");
 }
 

--- a/src/experiments/migration/migration-compare.ts
+++ b/src/experiments/migration/migration-compare.ts
@@ -772,7 +772,7 @@ export interface MigrationCompareReport {
   /**
    * Wireframe-mode fix suggestions emitted by
    * `generateWireframeFixCandidates`. Persisted to the JSON report so
-   * `vrt watch` can compute "newly introduced vs resolved" deltas
+   * `vlmkit watch` can compute "newly introduced vs resolved" deltas
    * between rounds without re-deriving them.
    */
   wireframeFixSuggestions?: Array<{
@@ -852,10 +852,10 @@ async function main(cliArgs = process.argv.slice(2)) {
   const hasFileInput = options.baseline && options.variants.length > 0;
   const hasUrlInput = options.baselineUrl && options.variantUrls && options.variantUrls.length > 0;
   if (!hasFileInput && !hasUrlInput) {
-    console.log(`Usage: vrt compare <before.html> <after.html>`);
-    console.log(`       vrt compare --dir <dir> --baseline <file> --variants <file1> <file2> ...`);
-    console.log(`       vrt compare --url <baseline-url> --current-url <current-url>`);
-    console.log(`       vrt compare --url <baseline-url> --variant-urls <url1> <url2> ...`);
+    console.log(`Usage: vlmkit diff html <before.html> <after.html>`);
+    console.log(`       vlmkit diff html --dir <dir> --baseline <file> --variants <file1> <file2> ...`);
+    console.log(`       vlmkit diff html --url <baseline-url> --current-url <current-url>`);
+    console.log(`       vlmkit diff html --url <baseline-url> --variant-urls <url1> <url2> ...`);
     console.log();
     console.log(`Options: [--output-dir path] [--approval approval.json] [--strict]`);
     console.log(`         [--discover-backend auto|regex|crater] [--no-paint-tree] [--no-discover]`);

--- a/src/experiments/migration/migration-subagent.ts
+++ b/src/experiments/migration/migration-subagent.ts
@@ -228,8 +228,8 @@ async function main() {
 function formatMigrationSubagentUsage(): string {
   return [
     "Usage:",
-    "  vrt migration subagent prepare --report path/to/migration-report.json [--variant variant] [--output path] [--format markdown|json]",
-    "  vrt migration subagent evaluate --before-report before.json --after-report after.json [--output path] [--format markdown|json] [--min-success-rate n] [--min-improvement-rate n]",
+    "  vlmkit migration subagent prepare --report path/to/migration-report.json [--variant variant] [--output path] [--format markdown|json]",
+    "  vlmkit migration subagent evaluate --before-report before.json --after-report after.json [--output path] [--format markdown|json] [--min-success-rate n] [--min-improvement-rate n]",
   ].join("\n");
 }
 

--- a/src/experiments/migration/triptych.ts
+++ b/src/experiments/migration/triptych.ts
@@ -1,5 +1,5 @@
 /**
- * Triptych composer: stitches the three PNGs that `vrt compare` already
+ * Triptych composer: stitches the three PNGs that `vlmkit diff html` already
  * emits into a single `baseline | variant | heatmap` image with labeled
  * header bands. Cuts "read each PNG in turn" iteration cost in agent
  * loops (see 2026-05-15 design-md scenario report § F3).

--- a/src/manifest-cli.test.ts
+++ b/src/manifest-cli.test.ts
@@ -137,7 +137,7 @@ describe("vrt manifest CLI", () => {
   it("help: shows usage when no subcommand given", () => {
     const r = cli();
     assert.equal(r.status, 0);
-    assert.match(r.stdout, /vrt manifest <command>/);
+    assert.match(r.stdout, /vlmkit manifest <command>/);
   });
 
   it("unknown subcommand: exits non-zero with usage", () => {

--- a/src/manifest-cli.test.ts
+++ b/src/manifest-cli.test.ts
@@ -23,7 +23,7 @@ function cli(...argv: string[]): { stdout: string; stderr: string; status: numbe
   };
 }
 
-describe("vrt manifest CLI", () => {
+describe("vlmkit manifest CLI", () => {
   before(async () => {
     tmp = await mkdtemp(join(tmpdir(), "vrt-manifest-test-"));
     manifestPath = join(tmp, "approval.json");
@@ -190,7 +190,7 @@ const FAKE_REPORT = {
   ],
 };
 
-describe("vrt manifest add --from-run", () => {
+describe("vlmkit manifest add --from-run", () => {
   let runDir: string;
   let manifestPathFromRun: string;
 

--- a/src/manifest-cli.ts
+++ b/src/manifest-cli.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 /**
- * `vrt manifest` — author and inspect the approval manifest that
- * `vrt compare` already honors. The manifest format (#22's
+ * `vlmkit manifest` — author and inspect the approval manifest that
+ * `vlmkit diff html` already honors. The manifest format (#22's
  * `approval.json`) supports per-selector, per-property, and per-region
  * tolerance overrides plus an `expires` field, but until this CLI
  * existed there was no way to author entries except by hand-editing
  * JSON.
  *
  * Subcommands:
- *   vrt manifest list   [--path approval.json]
- *   vrt manifest add    --reason "..." [other selectors] [--path ...]
- *   vrt manifest rm     <index | selector> [--path ...]
- *   vrt manifest check  [--path ...]    (warns expired rules)
+ *   vlmkit manifest list   [--path approval.json]
+ *   vlmkit manifest add    --reason "..." [other selectors] [--path ...]
+ *   vlmkit manifest rm     <index | selector> [--path ...]
+ *   vlmkit manifest check  [--path ...]    (warns expired rules)
  *
  * The schema honored is the one validated by `validateApprovalManifest`
  * in `src/approval.ts`; this CLI is a thin facade so the consumer
@@ -263,7 +263,7 @@ async function cmdAddFromRun(args: string[], runDir: string, manifestPath: strin
     return;
   }
 
-  const baseReason = getArg(args, "reason") ?? "auto-acknowledged from vrt diff (rule needs a human-readable reason on next edit)";
+  const baseReason = getArg(args, "reason") ?? "auto-acknowledged from vlmkit diff (rule needs a human-readable reason on next edit)";
   const expires = getArg(args, "expires");
   const maxPx = getArg(args, "max-px");
   const tolerancePixels = maxPx ? Number(maxPx) : 2;
@@ -340,7 +340,7 @@ async function cmdRm(args: string[]): Promise<void> {
   }
   if (!target) {
     console.error(`${RED}error:${RESET} pass an index or selector`);
-    console.error(`Usage: vrt manifest rm <index | selector>`);
+    console.error(`Usage: vlmkit manifest rm <index | selector>`);
     process.exit(1);
   }
   const manifest = await loadManifestOrEmpty(path);
@@ -405,7 +405,7 @@ async function cmdCheck(args: string[]): Promise<void> {
 }
 
 function formatUsage(): string {
-  return `vrt manifest <command>
+  return `vlmkit manifest <command>
 
 Subcommands:
   list   [--path approval.json]
@@ -418,7 +418,7 @@ Subcommands:
          [--dry-run]
                               Author an approval rule.
                               --a11y-contrast / --a11y-touch suppress
-                              findings from the vrt diff-pr a11y gate
+                              findings from the vlmkit diff-pr a11y gate
                               instead of pixel/paint diffs. Both
                               require --selector (path substring matcher).
   add    --from-run <dir-or-json> [--auto-tiny | --top N | --all]
@@ -436,10 +436,10 @@ Subcommands:
                               (non-zero exit on expired)
 
 Examples:
-  vrt manifest add --selector .marquee --reason "animated content; intentionally dynamic"
-  vrt manifest add --selector .hero__body --max-px 2 --reason "sub-pixel AA artifact" --expires 2026-09-01
-  vrt manifest list
-  vrt manifest check        # CI hook: fail build if rules expired`;
+  vlmkit manifest add --selector .marquee --reason "animated content; intentionally dynamic"
+  vlmkit manifest add --selector .hero__body --max-px 2 --reason "sub-pixel AA artifact" --expires 2026-09-01
+  vlmkit manifest list
+  vlmkit manifest check        # CI hook: fail build if rules expired`;
 }
 
 async function main(argv = process.argv.slice(2)) {

--- a/src/util/ab-arm-setup.sh
+++ b/src/util/ab-arm-setup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Set up a pinned-revision "arm" for an A/B audit of the gates.
+#
+# Why this exists: the 2026-08-01 FP re-audit's first run was vacuous
+# because the baseline worktree's node_modules was symlinked to the main
+# repo's, and node_modules/@mizchi/vlmkit-* there points at the MAIN
+# repo's packages. Every cross-package deep import resolved to current
+# code, so both arms ran the same build and the audit reported a
+# reassuring "0 new findings" that meant nothing.
+#
+# This script links third-party deps from the shared store but points
+# @mizchi/* at the worktree's OWN packages, then verifies the isolation
+# held before you are allowed to trust anything.
+#
+# Usage: src/util/ab-arm-setup.sh <revision> <target-dir>
+#   e.g. src/util/ab-arm-setup.sh 86d4cdb /tmp/audit/before
+set -euo pipefail
+
+REV="${1:?usage: ab-arm-setup.sh <revision> <target-dir>}"
+DIR="${2:?usage: ab-arm-setup.sh <revision> <target-dir>}"
+REPO="$(git rev-parse --show-toplevel)"
+
+git -C "$REPO" worktree add --detach "$DIR" "$REV" >/dev/null 2>&1 || {
+  echo "worktree add failed (already exists?)" >&2; exit 1;
+}
+
+mkdir -p "$DIR/node_modules/@mizchi"
+for entry in "$REPO"/node_modules/*; do
+  name="$(basename "$entry")"
+  [ "$name" = "@mizchi" ] && continue
+  ln -sfn "$entry" "$DIR/node_modules/$name"
+done
+[ -d "$REPO/node_modules/.bin" ] && ln -sfn "$REPO/node_modules/.bin" "$DIR/node_modules/.bin"
+# The load-bearing part: workspace packages resolve to THIS revision.
+for pkg in "$DIR"/packages/*/; do
+  ln -sfn "../../packages/$(basename "$pkg")" "$DIR/node_modules/@mizchi/$(basename "$pkg")"
+done
+
+# Isolation proof: the arm's own package sources must be what runs. Compare
+# a resolved package file against the worktree copy; if the symlink leaked
+# to the main repo these differ whenever the revision differs.
+resolved="$(readlink -f "$DIR/node_modules/@mizchi/vlmkit-markup")"
+expected="$(readlink -f "$DIR/packages/vlmkit-markup")"
+if [ "$resolved" != "$expected" ]; then
+  echo "ISOLATION FAILED: @mizchi/vlmkit-markup -> $resolved (expected $expected)" >&2
+  exit 1
+fi
+echo "arm ready at $DIR (rev $REV), workspace packages isolated"
+echo "NEXT: prove the arms differ on a case whose answer you know before reading results."

--- a/src/util/design-policy-probe.mjs
+++ b/src/util/design-policy-probe.mjs
@@ -1,0 +1,103 @@
+// Feasibility probe for deterministic "design policy" metrics.
+//
+//   node --experimental-strip-types src/util/design-policy-probe.mjs <page.html|url> ...
+//
+// Findings and the resulting gate proposal:
+// docs/design/design-policy-metrics.md
+//
+// The question is not "is this beautiful" — it is whether a page's de-facto
+// design system is RECOVERABLE from the render. If designed pages show
+// concentrated distributions and sloppy ones show smears, the metrics
+// discriminate and can become gates. If everything is a smear, the idea dies.
+import { chromium } from "playwright";
+
+const PROBE = `(() => {
+  const vis = (el) => {
+    if (typeof el.checkVisibility === "function") {
+      return el.checkVisibility({ visibilityProperty: true, opacityProperty: true, contentVisibilityAuto: true });
+    }
+    const cs = getComputedStyle(el);
+    return cs.display !== "none" && cs.visibility !== "hidden";
+  };
+  const px = (v) => { const n = parseFloat(v); return Number.isFinite(n) ? Math.round(n * 10) / 10 : 0; };
+  const spacing = [], lefts = [], fontSizes = [], radii = [];
+  const byRole = {};
+  let considered = 0;
+  for (const el of document.querySelectorAll("body *")) {
+    if (!vis(el)) continue;
+    const r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) continue;
+    considered++;
+    const cs = getComputedStyle(el);
+    for (const p of ["paddingTop","paddingBottom","paddingLeft","paddingRight","marginTop","marginBottom","rowGap","columnGap"]) {
+      const v = px(cs[p]);
+      if (v > 0) spacing.push(v);
+    }
+    lefts.push(Math.round(r.left));
+    fontSizes.push(px(cs.fontSize));
+    radii.push(px(cs.borderTopLeftRadius));
+    const tag = el.tagName.toLowerCase();
+    const role = el.getAttribute("role")
+      || (tag === "button" || (tag === "input" && /^(button|submit)$/.test(el.type)) ? "button"
+      : /^h[1-6]$/.test(tag) ? tag
+      : null);
+    if (role) {
+      (byRole[role] ??= []).push([
+        px(cs.paddingTop), px(cs.paddingRight), px(cs.paddingBottom), px(cs.paddingLeft),
+        px(cs.borderTopLeftRadius), px(cs.fontSize), Math.round(r.height),
+      ].join("/"));
+    }
+  }
+  return { considered, spacing, lefts, fontSizes, radii, byRole };
+})()`;
+
+const hist = (arr) => {
+  const m = new Map();
+  for (const v of arr) m.set(v, (m.get(v) ?? 0) + 1);
+  return [...m.entries()].sort((a, b) => b[1] - a[1]);
+};
+const coverage = (arr, topN) => {
+  if (arr.length === 0) return 0;
+  const top = hist(arr).slice(0, topN).reduce((s, [, n]) => s + n, 0);
+  return +(top / arr.length).toFixed(3);
+};
+// "Best fit" is a trap: base 2 fits every even value, so it always wins and
+// says nothing. Test a fixed set of real design bases and prefer the LARGEST
+// base that still explains the page — that is the informative claim.
+const gridFit = (arr) => {
+  if (arr.length === 0) return { base: 0, fit: 0 };
+  let best = { base: 0, fit: 0 };
+  for (const base of [4, 8]) {
+    const fit = arr.filter((v) => Math.abs(v / base - Math.round(v / base)) * base <= 0.6).length / arr.length;
+    if (fit >= 0.8 && base > best.base) best = { base, fit: +fit.toFixed(3) };
+    if (best.base === 0 && fit > best.fit) best = { base, fit: +fit.toFixed(3) };
+  }
+  return best;
+};
+
+const targets = process.argv.slice(2);
+const b = await chromium.launch();
+console.log(["page", "els", "spcVals", "spcTop6", "gridBase", "gridFit", "leftTop8", "fontVals", "fontTop5", "radiiVals", "btnSigs", "h2Sigs"].join("\t"));
+for (const t of targets) {
+  const p = await b.newPage({ viewport: { width: 1280, height: 900 } });
+  try {
+    await p.goto(t.startsWith("http") ? t : `file://${t}`, { waitUntil: "load", timeout: 30000 });
+    await p.evaluate(() => document.fonts?.ready).catch(() => {});
+    const d = await p.evaluate(PROBE);
+    const g = gridFit(d.spacing);
+    const sig = (role) => {
+      const list = d.byRole[role] ?? [];
+      return list.length ? `${new Set(list).size}/${list.length}` : "-";
+    };
+    console.log([
+      t.split("/").pop(), d.considered, new Set(d.spacing).size, coverage(d.spacing, 6),
+      g.base, g.fit, coverage(d.lefts, 8),
+      new Set(d.fontSizes).size, coverage(d.fontSizes, 5),
+      new Set(d.radii).size, sig("button"), sig("h2"),
+    ].join("\t"));
+  } catch (e) {
+    console.log(`${t.split("/").pop()}\tERROR ${String(e.message).slice(0, 40)}`);
+  }
+  await p.close();
+}
+await b.close();

--- a/src/util/font-determinism-probe.test.ts
+++ b/src/util/font-determinism-probe.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { IntegrityTextBlock } from "@mizchi/vlmkit-markup/inspect/integrity-check.ts";
+import {
+  compareFingerprints,
+  formatComparison,
+  pairMargins,
+  type ProbeFingerprint,
+} from "./font-determinism-probe.ts";
+
+const block = (over: Partial<IntegrityTextBlock> & { selector: string }): IntegrityTextBlock => ({
+  text: "x",
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 20,
+  overlay: false,
+  zIndex: 0,
+  ariaHidden: false,
+  inkInset: 0,
+  ...over,
+});
+
+describe("pairMargins", () => {
+  it("measures each pair's distance from the ink floor", () => {
+    // Two 20px blocks, no ink slack, offset by 10px: ink bands overlap 10px
+    // against a floor of max(6, 0.5 * 20) = 10 — exactly on the line.
+    const pairs = pairMargins([
+      block({ selector: "#a", y: 0 }),
+      block({ selector: "#b", y: 10 }),
+    ], new Set());
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0]!.oy, 10);
+    assert.equal(pairs[0]!.threshold, 10);
+    assert.equal(pairs[0]!.margin, 0);
+  });
+
+  it("subtracts ink slack from both sides", () => {
+    // 3px of slack per edge shrinks each band by 6px, so a 10px box overlap
+    // becomes a 4px ink overlap — and the floor drops with the ink height.
+    const pairs = pairMargins([
+      block({ selector: "#a", y: 0, inkInset: 3 }),
+      block({ selector: "#b", y: 10, inkInset: 3 }),
+    ], new Set());
+    assert.equal(pairs[0]!.oy, 4);
+    assert.equal(pairs[0]!.threshold, 7); // max(6, 0.5 * (20 - 6))
+    assert.equal(pairs[0]!.margin, -3);
+  });
+
+  it("keeps near-misses, because those are what a metric shift moves", () => {
+    // Bands clear each other by 5px. Excluding it would leave only pairs that
+    // could never flip, which measures nothing.
+    const pairs = pairMargins([
+      block({ selector: "#a", y: 0 }),
+      block({ selector: "#b", y: 25 }),
+    ], new Set());
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0]!.oy, -5);
+  });
+
+  it("drops pairs too far apart to ever flip, and non-overlapping columns", () => {
+    assert.equal(pairMargins([block({ selector: "#a", y: 0 }), block({ selector: "#b", y: 200 })], new Set()).length, 0);
+    assert.equal(pairMargins([block({ selector: "#a", x: 0 }), block({ selector: "#b", x: 500 })], new Set()).length, 0);
+  });
+
+  it("ignores nesting: a block containing another is not a collision", () => {
+    const pairs = pairMargins([
+      block({ selector: "#outer", x: 0, y: 0, width: 200, height: 60 }),
+      block({ selector: "#inner", x: 10, y: 10, width: 50, height: 20 }),
+    ], new Set());
+    assert.deepEqual(pairs, []);
+  });
+
+  it("carries the gate's own report status through, either pair order", () => {
+    const pairs = pairMargins([
+      block({ selector: "#a", y: 0 }),
+      block({ selector: "#b", y: 5 }),
+    ], new Set(["#b x #a"]));
+    assert.equal(pairs[0]!.reported, true);
+  });
+
+  it("sorts tightest-first", () => {
+    const pairs = pairMargins([
+      block({ selector: "#a", y: 0 }),
+      block({ selector: "#b", y: 10 }),
+      block({ selector: "#c", y: 26 }),
+    ], new Set());
+    assert.ok(Math.abs(pairs[0]!.margin) <= Math.abs(pairs[1]!.margin));
+  });
+});
+
+describe("compareFingerprints", () => {
+  const fingerprint = (
+    label: string,
+    pairs: { pair: string; margin: number; reported: boolean }[],
+    inkInset = 2,
+  ): ProbeFingerprint => ({
+    label,
+    platform: "linux-x64",
+    browserVersion: "0",
+    dpr: 1,
+    fontStack: null,
+    hinting: "default",
+    fixtures: [{
+      fixture: "page.html",
+      blocks: [{ selector: "#a", height: 20, inkInset }],
+      pairs: pairs.map((p) => ({ ...p, ox: 50, oy: 10, threshold: 10 - p.margin })),
+      findings: pairs.filter((p) => p.reported).length,
+      reportedPairs: pairs.filter((p) => p.reported).map((p) => p.pair),
+    }],
+  });
+
+  it("calls the floor stable when nothing changed report status", () => {
+    const c = compareFingerprints(
+      fingerprint("linux", [{ pair: "#a x #b", margin: 4, reported: true }]),
+      fingerprint("macos", [{ pair: "#a x #b", margin: 3, reported: true }]),
+    );
+    assert.equal(c.totalThresholdFlips, 0);
+    assert.equal(c.totalGeometryFlips, 0);
+    assert.equal(c.rows[0]!.maxMarginDelta, 1);
+    assert.match(formatComparison(c), /FLOOR STABLE/);
+  });
+
+  it("indicts the floor when the same pair is judged differently", () => {
+    const c = compareFingerprints(
+      fingerprint("linux", [{ pair: "#a x #b", margin: 0.5, reported: true }]),
+      fingerprint("macos", [{ pair: "#a x #b", margin: -0.5, reported: false }]),
+    );
+    assert.equal(c.totalThresholdFlips, 1);
+    assert.equal(c.totalGeometryFlips, 0);
+    assert.match(formatComparison(c), /FLOOR FRAGILE/);
+  });
+
+  it("separates a vanished overlap from a moved threshold", () => {
+    // Measured case: substituting a proportional face for a monospace one made
+    // two absolutely-positioned labels stop overlapping at all. Both verdicts
+    // are right for their own rendering, so this must not read as fragility.
+    const c = compareFingerprints(
+      fingerprint("linux", [{ pair: "#total x #refund", margin: 5.8, reported: true }]),
+      fingerprint("liberation", []),
+    );
+    assert.equal(c.totalThresholdFlips, 0);
+    assert.equal(c.totalGeometryFlips, 1);
+    const text = formatComparison(c);
+    assert.match(text, /FLOOR STABLE/);
+    assert.match(text, /the overlap itself changed/);
+  });
+
+  it("reports the tightest margin anywhere, since that flips first", () => {
+    const c = compareFingerprints(
+      fingerprint("linux", [{ pair: "#a x #b", margin: 9 }, { pair: "#c x #d", margin: -0.3 }].map(
+        (p) => ({ ...p, reported: false }),
+      )),
+      fingerprint("macos", [{ pair: "#a x #b", margin: 9, reported: false }]),
+    );
+    assert.equal(c.tightestMargin?.margin, -0.3);
+    assert.match(formatComparison(c), /tightest margin anywhere: -0\.3px/);
+  });
+
+  it("tracks ink drift per block", () => {
+    const c = compareFingerprints(fingerprint("linux", [], 2.6), fingerprint("macos", [], 1.1));
+    assert.equal(c.rows[0]!.maxInkInsetDelta, 1.5);
+  });
+});

--- a/src/util/font-determinism-probe.ts
+++ b/src/util/font-determinism-probe.ts
@@ -1,0 +1,448 @@
+#!/usr/bin/env node
+/**
+ * Font-determinism probe for the `text-collision` ink floors.
+ *
+ * The collision gate compares glyph **ink bands**, not line boxes:
+ *
+ *   inkInset = clamp((lineHeight - (ascent + descent)) / 2, 0, fontSize / 2)
+ *   report iff  ox >= 6  &&  oy >= 6  &&  oy >= max(2, 0.5 * min-ink-height)
+ *
+ * `ascent + descent` comes from canvas `measureText`, so every threshold above
+ * is a function of the **resolved font's metrics**. That makes one question
+ * unavoidable: does a verdict computed on Linux still hold on macOS, where the
+ * same `font-family: system-ui, sans-serif` resolves to a different face?
+ *
+ * This tool answers it by measurement rather than argument. It does not
+ * re-implement the gate — it drives the production `COLLECT_INTEGRITY_TEXT`
+ * script and `findTextCollisions`, records every candidate pair's distance
+ * from its threshold, and can diff two runs:
+ *
+ *   # on Linux
+ *   node --experimental-strip-types src/util/font-determinism-probe.ts measure \
+ *     "fixtures/collision-fp-corpus/*.html" --label linux-default --out linux.json
+ *   # on macOS, same command, then:
+ *   node --experimental-strip-types src/util/font-determinism-probe.ts compare linux.json macos.json
+ *
+ * `compare` prints the metric deltas and, crucially, any **verdict flip** — a
+ * pair that is reported under one condition and not the other. A flip is the
+ * only outcome that matters; metric drift with margin to spare is noise.
+ */
+import { writeFile } from "node:fs/promises";
+import { glob } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { resolve as resolvePath } from "node:path";
+import {
+  COLLECT_INTEGRITY_TEXT,
+  findTextCollisions,
+  type IntegrityTextBlock,
+} from "@mizchi/vlmkit-markup/inspect/integrity-check.ts";
+
+/** Mirrors the gate's constants; asserted against the gate's own output below. */
+const MIN_OVERLAP_PX = 6;
+const MIN_INK_FRACTION = 0.5;
+/**
+ * How far *below* touching a pair may sit and still be recorded. Pairs whose
+ * ink bands clear each other by a few px are the ones a metric shift can push
+ * into reporting range; pairs 200px apart can never flip and would only bloat
+ * the fingerprint.
+ */
+const NEAR_MISS_PX = 8;
+/** Cap per fixture, tightest margin first — a full O(n^2) dump is unreadable. */
+const MAX_PAIRS_PER_FIXTURE = 40;
+
+export interface PairMargin {
+  pair: string;
+  ox: number;
+  oy: number;
+  /** `max(2, 0.5 * min-ink-height)` — the ink-fraction floor for this pair. */
+  threshold: number;
+  /** oy - threshold. Negative means the pair is below the floor (not reported). */
+  margin: number;
+  reported: boolean;
+}
+
+export interface BlockMetric {
+  selector: string;
+  height: number;
+  inkInset: number;
+}
+
+export interface FixtureFingerprint {
+  fixture: string;
+  blocks: BlockMetric[];
+  pairs: PairMargin[];
+  findings: number;
+  /** Selectors of reported pairs — the verdict, independent of the numbers. */
+  reportedPairs: string[];
+}
+
+export interface ProbeFingerprint {
+  label: string;
+  platform: string;
+  browserVersion: string;
+  dpr: number;
+  fontStack: string | null;
+  hinting: string;
+  fixtures: FixtureFingerprint[];
+}
+
+/**
+ * Recompute each candidate pair's distance from the ink floor. The formula is
+ * duplicated from `findTextCollisions` on purpose: the probe reports margins,
+ * which the gate does not expose. `findings` below comes from the gate itself,
+ * so a divergence between the two shows up as a mismatch rather than silently
+ * measuring the wrong thing.
+ */
+export function pairMargins(blocks: IntegrityTextBlock[], reported: Set<string>): PairMargin[] {
+  const out: PairMargin[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    for (let j = i + 1; j < blocks.length; j++) {
+      const a = blocks[i]!, b = blocks[j]!;
+      const ox = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x);
+      if (ox < MIN_OVERLAP_PX) continue;
+      const aInk = a.inkInset ?? 0;
+      const bInk = b.inkInset ?? 0;
+      const oy = Math.min(a.y + a.height - aInk, b.y + b.height - bInk)
+        - Math.max(a.y + aInk, b.y + bInk);
+      // Keep near-misses, not just overlaps. A pair whose ink bands clear each
+      // other by 3px is precisely what a font-metric shift could push into
+      // reporting range, so excluding it would measure only the pairs that
+      // could never flip. `NEAR_MISS_PX` below the touching point is the
+      // at-risk population.
+      if (oy < -NEAR_MISS_PX) continue;
+      const contains = (o: IntegrityTextBlock, p: IntegrityTextBlock) =>
+        o.x <= p.x && o.y <= p.y && o.x + o.width >= p.x + p.width && o.y + o.height >= p.y + p.height;
+      if (contains(a, b) || contains(b, a)) continue;
+      const minInkHeight = Math.min(
+        Math.max(1, a.height - 2 * aInk),
+        Math.max(1, b.height - 2 * bInk),
+      );
+      const threshold = Math.max(MIN_OVERLAP_PX, Math.max(2, MIN_INK_FRACTION * minInkHeight));
+      const key = `${a.selector} x ${b.selector}`;
+      out.push({
+        pair: key,
+        ox: round(ox),
+        oy: round(oy),
+        threshold: round(threshold),
+        margin: round(oy - threshold),
+        reported: reported.has(key) || reported.has(`${b.selector} x ${a.selector}`),
+      });
+    }
+  }
+  // Tightest first: the pairs closest to their floor are the whole point.
+  const ranked = out.sort((x, y) => Math.abs(x.margin) - Math.abs(y.margin));
+  const kept = ranked.slice(0, MAX_PAIRS_PER_FIXTURE);
+  // A reported pair must never be dropped by the cap: `compare` needs its
+  // presence to tell a threshold flip from a geometry change.
+  const keptKeys = new Set(kept.map((p) => p.pair));
+  return [...kept, ...ranked.slice(MAX_PAIRS_PER_FIXTURE).filter((p) => p.reported && !keptKeys.has(p.pair))];
+}
+
+const round = (n: number) => Math.round(n * 100) / 100;
+
+export interface MeasureOptions {
+  patterns: string[];
+  label: string;
+  /** CSS font-family value forced onto every element, or null to leave the page alone. */
+  fontStack?: string;
+  /** `url()` for an @font-face named ProbeFont, usable inside --font-stack. */
+  fontFace?: string;
+  dpr?: number;
+  hinting?: "default" | "none";
+  viewport?: number;
+}
+
+export async function measure(options: MeasureOptions): Promise<ProbeFingerprint> {
+  const { chromium } = await import("playwright");
+  const hinting = options.hinting ?? "default";
+  const browser = await chromium.launch({
+    args: hinting === "none"
+      ? ["--font-render-hinting=none", "--disable-font-subpixel-positioning", "--disable-lcd-text"]
+      : [],
+  });
+  const dpr = options.dpr ?? 1;
+  const width = options.viewport ?? 1280;
+  const fixtures: FixtureFingerprint[] = [];
+  try {
+    const files: string[] = [];
+    for (const pattern of options.patterns) {
+      if (/[*?[\]{}]/.test(pattern)) {
+        for await (const hit of glob(pattern)) files.push(hit);
+      } else {
+        files.push(pattern);
+      }
+    }
+    files.sort();
+    for (const file of files) {
+      const page = await browser.newPage({
+        viewport: { width, height: 900 },
+        deviceScaleFactor: dpr,
+      });
+      await page.goto(pathToFileURL(resolvePath(file)).href, { waitUntil: "load", timeout: 30000 });
+      if (options.fontStack) {
+        await page.addStyleTag({
+          content: (options.fontFace
+            ? `@font-face { font-family: ProbeFont; src: url("${options.fontFace}"); font-display: block; }\n`
+            : "")
+            // Deliberately blunt: every element, not just body. Cross-OS drift
+            // substitutes one face for another under the SAME declared stack;
+            // this replaces the stack outright, which moves metrics further.
+            + `body, body * { font-family: ${options.fontStack} !important; }`,
+        });
+      }
+      await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => undefined) : undefined));
+      await page.waitForTimeout(150);
+      const blocks = await page.evaluate(COLLECT_INTEGRITY_TEXT) as IntegrityTextBlock[];
+      const gate = findTextCollisions(blocks, width);
+      const reportedPairs = gate.findings
+        .map((f) => f.selector ?? "")
+        .filter(Boolean);
+      fixtures.push({
+        fixture: file,
+        blocks: blocks.map((b) => ({ selector: b.selector, height: b.height, inkInset: round(b.inkInset ?? 0) })),
+        pairs: pairMargins(blocks, new Set(reportedPairs)),
+        findings: gate.findings.length,
+        reportedPairs: [...reportedPairs].sort(),
+      });
+      await page.close();
+    }
+    return {
+      label: options.label,
+      platform: `${process.platform}-${process.arch}`,
+      browserVersion: browser.version(),
+      dpr,
+      fontStack: options.fontStack ?? null,
+      hinting,
+      fixtures,
+    };
+  } finally {
+    await browser.close();
+  }
+}
+
+export interface ComparisonRow {
+  fixture: string;
+  maxInkInsetDelta: number;
+  maxMarginDelta: number;
+  /**
+   * Pairs reported in one run and not the other, *and present as candidates in
+   * both*. This is the only outcome that indicts the floor: the same overlap,
+   * judged differently.
+   */
+  thresholdFlips: string[];
+  /**
+   * Pairs reported in one run whose candidacy disappeared in the other — the
+   * two elements no longer overlap at all. Measured cause: font substitution
+   * changes text *width*, so absolutely-positioned labels that grazed under a
+   * monospace face clear each other under a proportional one. Both verdicts are
+   * correct for their own rendering; this is the page differing, not the gate.
+   */
+  geometryFlips: string[];
+  /** Pairs present in one run only (layout changed enough to add/remove candidates). */
+  onlyInA: number;
+  onlyInB: number;
+}
+
+export interface Comparison {
+  a: string;
+  b: string;
+  rows: ComparisonRow[];
+  /** Same overlap, different verdict. Non-zero means the floor is font-fragile. */
+  totalThresholdFlips: number;
+  /** The overlap itself appeared or disappeared. Expected under substitution. */
+  totalGeometryFlips: number;
+  /** Smallest |margin| seen in either run: how close the corpus came to flipping. */
+  tightestMargin: { fixture: string; pair: string; margin: number; label: string } | null;
+}
+
+export function compareFingerprints(a: ProbeFingerprint, b: ProbeFingerprint): Comparison {
+  const rows: ComparisonRow[] = [];
+  let tightest: Comparison["tightestMargin"] = null;
+  const consider = (fingerprint: ProbeFingerprint, fixture: FixtureFingerprint) => {
+    for (const p of fixture.pairs) {
+      if (!tightest || Math.abs(p.margin) < Math.abs(tightest.margin)) {
+        tightest = { fixture: fixture.fixture, pair: p.pair, margin: p.margin, label: fingerprint.label };
+      }
+    }
+  };
+  for (const fa of a.fixtures) {
+    const fb = b.fixtures.find((f) => f.fixture === fa.fixture);
+    consider(a, fa);
+    if (!fb) continue;
+    consider(b, fb);
+    const inkA = new Map(fa.blocks.map((x) => [x.selector, x.inkInset]));
+    let maxInk = 0;
+    for (const blk of fb.blocks) {
+      const prev = inkA.get(blk.selector);
+      if (prev !== undefined) maxInk = Math.max(maxInk, Math.abs(prev - blk.inkInset));
+    }
+    const marginA = new Map(fa.pairs.map((p) => [p.pair, p.margin]));
+    const marginB = new Map(fb.pairs.map((p) => [p.pair, p.margin]));
+    let maxMargin = 0;
+    for (const [pair, m] of marginB) {
+      const prev = marginA.get(pair);
+      if (prev !== undefined) maxMargin = Math.max(maxMargin, Math.abs(prev - m));
+    }
+    const setA = new Set(fa.reportedPairs);
+    const setB = new Set(fb.reportedPairs);
+    const thresholdFlips: string[] = [];
+    const geometryFlips: string[] = [];
+    const classify = (pair: string, presentThere: Map<string, number>, whereLabel: string) => {
+      const line = `only in ${whereLabel}: ${pair}`;
+      (presentThere.has(pair) ? thresholdFlips : geometryFlips).push(line);
+    };
+    for (const pair of setA) if (!setB.has(pair)) classify(pair, marginB, a.label);
+    for (const pair of setB) if (!setA.has(pair)) classify(pair, marginA, b.label);
+    rows.push({
+      fixture: fa.fixture,
+      maxInkInsetDelta: round(maxInk),
+      maxMarginDelta: round(maxMargin),
+      thresholdFlips,
+      geometryFlips,
+      onlyInA: [...marginA.keys()].filter((p) => !marginB.has(p)).length,
+      onlyInB: [...marginB.keys()].filter((p) => !marginA.has(p)).length,
+    });
+  }
+  return {
+    a: a.label,
+    b: b.label,
+    rows,
+    totalThresholdFlips: rows.reduce((s, r) => s + r.thresholdFlips.length, 0),
+    totalGeometryFlips: rows.reduce((s, r) => s + r.geometryFlips.length, 0),
+    tightestMargin: tightest,
+  };
+}
+
+export function formatComparison(c: Comparison): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`font determinism: ${c.a}  vs  ${c.b}`);
+  lines.push("");
+  lines.push("fixture                                   dInk   dMargin  +/-pairs  thr  geom");
+  for (const r of c.rows) {
+    lines.push(
+      `${r.fixture.slice(-40).padEnd(40)}  ${r.maxInkInsetDelta.toFixed(2).padStart(5)}`
+      + `  ${r.maxMarginDelta.toFixed(2).padStart(8)}`
+      + `  ${`+${r.onlyInB}/-${r.onlyInA}`.padStart(8)}`
+      + `  ${String(r.thresholdFlips.length).padStart(3)}`
+      + `  ${String(r.geometryFlips.length).padStart(4)}`,
+    );
+  }
+  lines.push("");
+  lines.push(c.totalThresholdFlips === 0
+    ? `FLOOR STABLE: no pair present in both runs changed report status.`
+    : `FLOOR FRAGILE: ${c.totalThresholdFlips} pair(s) judged differently at the same overlap.`);
+  for (const r of c.rows) for (const f of r.thresholdFlips) lines.push(`  ! ${r.fixture}: ${f}`);
+  if (c.totalGeometryFlips > 0) {
+    lines.push("");
+    lines.push(
+      `${c.totalGeometryFlips} report(s) differ because the overlap itself changed`
+      + ` (the page renders differently, not the gate judging differently):`,
+    );
+    for (const r of c.rows) for (const f of r.geometryFlips) lines.push(`  - ${r.fixture}: ${f}`);
+  }
+  if (c.tightestMargin) {
+    lines.push("");
+    lines.push(
+      `tightest margin anywhere: ${c.tightestMargin.margin}px (${c.tightestMargin.label},`
+      + ` ${c.tightestMargin.fixture}, ${c.tightestMargin.pair})`,
+    );
+    lines.push(`  a pair this close to its floor is what a metric shift would flip first.`);
+  }
+  return lines.join("\n");
+}
+
+function printUsage(exitCode: number): never {
+  console.log(`Usage:
+  font-determinism-probe measure <glob...> [options]
+  font-determinism-probe compare <a.json> <b.json>
+
+Measure how far each text-collision candidate pair sits from the ink floor,
+so the same corpus can be fingerprinted on another OS and diffed. Reports
+verdict FLIPS, not metric drift — drift with margin to spare is noise.
+
+measure options:
+  --label <name>        Name for this condition (default: platform-default)
+  --out <file.json>     Write the fingerprint (default: stdout)
+  --font-stack <css>    Force this font-family on every element
+  --font-face <url>     @font-face src for a family named ProbeFont
+  --dpr <n>             deviceScaleFactor (default 1)
+  --hinting none        Launch with hinting/subpixel/LCD text disabled
+  --viewport <px>       Viewport width (default 1280)
+
+Examples:
+  measure "fixtures/collision-fp-corpus/*.html" --label linux --out linux.json
+  measure "fixtures/collision-fp-corpus/*.html" --label dejavu \\
+    --font-stack '"DejaVu Serif", serif' --out dejavu.json
+  compare linux.json macos.json`);
+  process.exit(exitCode);
+}
+
+async function main(argv = process.argv.slice(2)): Promise<void> {
+  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) printUsage(argv.length === 0 ? 1 : 0);
+  const mode = argv[0];
+  const rest = argv.slice(1);
+  if (mode === "compare") {
+    const [fileA, fileB] = rest.filter((a) => !a.startsWith("-"));
+    if (!fileA || !fileB) printUsage(1);
+    const { readFile } = await import("node:fs/promises");
+    const a = JSON.parse(await readFile(fileA, "utf-8")) as ProbeFingerprint;
+    const b = JSON.parse(await readFile(fileB, "utf-8")) as ProbeFingerprint;
+    const comparison = compareFingerprints(a, b);
+    console.log(formatComparison(comparison));
+    if (comparison.totalThresholdFlips > 0) process.exitCode = 1;
+    return;
+  }
+  if (mode !== "measure") printUsage(1);
+  const patterns: string[] = [];
+  let label: string | undefined;
+  let out: string | undefined;
+  let fontStack: string | undefined;
+  let fontFace: string | undefined;
+  let dpr: number | undefined;
+  let hinting: "default" | "none" = "default";
+  let viewport: number | undefined;
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i]!;
+    if (arg === "--label") label = rest[++i];
+    else if (arg === "--out") out = rest[++i];
+    else if (arg === "--font-stack") fontStack = rest[++i];
+    else if (arg === "--font-face") fontFace = rest[++i];
+    else if (arg === "--dpr") dpr = Number.parseFloat(rest[++i] ?? "1");
+    else if (arg === "--hinting") hinting = (rest[++i] === "none" ? "none" : "default");
+    else if (arg === "--viewport") viewport = Number.parseInt(rest[++i] ?? "1280", 10);
+    else if (!arg.startsWith("-")) patterns.push(arg);
+  }
+  if (patterns.length === 0) printUsage(1);
+  const fingerprint = await measure({
+    patterns,
+    label: label ?? `${process.platform}-default`,
+    ...(fontStack ? { fontStack } : {}),
+    ...(fontFace ? { fontFace } : {}),
+    ...(dpr !== undefined ? { dpr } : {}),
+    hinting,
+    ...(viewport !== undefined ? { viewport } : {}),
+  });
+  const json = JSON.stringify(fingerprint, null, 2);
+  if (out) {
+    await writeFile(out, json);
+    const pairs = fingerprint.fixtures.reduce((s, f) => s + f.pairs.length, 0);
+    const findings = fingerprint.fixtures.reduce((s, f) => s + f.findings, 0);
+    console.log(
+      `${fingerprint.label}: ${fingerprint.fixtures.length} fixture(s), ${pairs} candidate pair(s),`
+      + ` ${findings} reported -> ${out}`,
+    );
+  } else {
+    console.log(json);
+  }
+}
+
+const isCliEntry = process.argv[1]
+  ? resolvePath(process.argv[1]) === resolvePath(new URL(import.meta.url).pathname)
+  : false;
+if (isCliEntry) {
+  main().catch((e) => {
+    console.error(e instanceof Error ? e.message : e);
+    process.exit(1);
+  });
+}

--- a/src/util/font-determinism-probe.ts
+++ b/src/util/font-determinism-probe.ts
@@ -28,6 +28,8 @@
  * only outcome that matters; metric drift with margin to spare is noise.
  */
 import { writeFile } from "node:fs/promises";
+import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { hasFlag, readFlag, readInt, readNumber, readPositionals } from "@mizchi/vlmkit-core/arg-reader.ts";
 import { glob } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { resolve as resolvePath } from "node:path";
@@ -139,6 +141,9 @@ export function pairMargins(blocks: IntegrityTextBlock[], reported: Set<string>)
 }
 
 const round = (n: number) => Math.round(n * 100) / 100;
+
+/** Flags that consume the next argv entry, so fixture patterns are found. */
+const VALUE_FLAGS = ["label", "out", "font-stack", "font-face", "dpr", "viewport", "hinting"];
 
 export interface MeasureOptions {
   patterns: string[];
@@ -379,11 +384,11 @@ Examples:
 }
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
-  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) printUsage(argv.length === 0 ? 1 : 0);
+  if (argv.length === 0 || hasFlag(argv, "help") || hasFlag(argv, "-h")) printUsage(argv.length === 0 ? 1 : 0);
   const mode = argv[0];
   const rest = argv.slice(1);
   if (mode === "compare") {
-    const [fileA, fileB] = rest.filter((a) => !a.startsWith("-"));
+    const [fileA, fileB] = readPositionals(rest);
     if (!fileA || !fileB) printUsage(1);
     const { readFile } = await import("node:fs/promises");
     const a = JSON.parse(await readFile(fileA, "utf-8")) as ProbeFingerprint;
@@ -394,25 +399,16 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
   if (mode !== "measure") printUsage(1);
-  const patterns: string[] = [];
-  let label: string | undefined;
-  let out: string | undefined;
-  let fontStack: string | undefined;
-  let fontFace: string | undefined;
-  let dpr: number | undefined;
-  let hinting: "default" | "none" = "default";
-  let viewport: number | undefined;
-  for (let i = 0; i < rest.length; i++) {
-    const arg = rest[i]!;
-    if (arg === "--label") label = rest[++i];
-    else if (arg === "--out") out = rest[++i];
-    else if (arg === "--font-stack") fontStack = rest[++i];
-    else if (arg === "--font-face") fontFace = rest[++i];
-    else if (arg === "--dpr") dpr = Number.parseFloat(rest[++i] ?? "1");
-    else if (arg === "--hinting") hinting = (rest[++i] === "none" ? "none" : "default");
-    else if (arg === "--viewport") viewport = Number.parseInt(rest[++i] ?? "1280", 10);
-    else if (!arg.startsWith("-")) patterns.push(arg);
-  }
+  const patterns = readPositionals(rest, VALUE_FLAGS);
+  const label = readFlag(rest, "label");
+  const out = readFlag(rest, "out");
+  const fontStack = readFlag(rest, "font-stack");
+  const fontFace = readFlag(rest, "font-face");
+  // Validated, not coerced: a NaN dpr would silently render at the default and
+  // the fingerprint would claim a condition it never measured.
+  const dpr = readNumber(rest, "dpr", { min: 0.1, max: 4 });
+  const viewport = readInt(rest, "viewport", { min: 200, max: 8000 });
+  const hinting: "default" | "none" = readFlag(rest, "hinting") === "none" ? "none" : "default";
   if (patterns.length === 0) printUsage(1);
   const fingerprint = await measure({
     patterns,
@@ -440,9 +436,4 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 const isCliEntry = process.argv[1]
   ? resolvePath(process.argv[1]) === resolvePath(new URL(import.meta.url).pathname)
   : false;
-if (isCliEntry) {
-  main().catch((e) => {
-    console.error(e instanceof Error ? e.message : e);
-    process.exit(1);
-  });
-}
+if (isCliEntry) main().catch(handleCliError);

--- a/src/util/perf.ts
+++ b/src/util/perf.ts
@@ -15,8 +15,8 @@
  * Lighthouse's ~30s.
  *
  * Usage:
- *   vrt perf <url>
- *   vrt perf <html>           # local HTML supported via setContent
+ *   vlmkit check perf <url>
+ *   vlmkit check perf <html>           # local HTML supported via setContent
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -290,7 +290,7 @@ export async function runPerf(options: PerfOptions): Promise<PerfReport> {
   });
   await writeFile(reportPath, md);
 
-  console.log(`  ${BOLD}${CYAN}vrt perf${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit check perf${RESET}`);
   console.log(`  ${DIM}source: ${options.source}  observed: ${observeMs}ms${RESET}`);
   const icon = (v: "good" | "needs-improvement" | "poor") =>
     v === "good" ? `${GREEN}✓${RESET}` : v === "needs-improvement" ? `${YELLOW}!${RESET}` : `${RED}✗${RESET}`;
@@ -380,7 +380,7 @@ function renderReport(r: Omit<PerfReport, "reportPath">): string {
 
   lines.push("## Note on scope");
   lines.push("");
-  lines.push("`vrt perf` covers visual-stability metrics (CLS, LCP) that overlap " +
+  lines.push("`vlmkit check perf` covers visual-stability metrics (CLS, LCP) that overlap " +
     "with the VRT toolkit's lane. For full Web Vitals analysis (TBT, INP, " +
     "JavaScript bundle size, network waterfall), run a dedicated tool like " +
     "Lighthouse, PageSpeed Insights, or WebPageTest. This tool's value is " +
@@ -395,7 +395,7 @@ async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
   const { positional, outputDir, report, observeMs, strict } = parseArgs(argv);
   if (positional.length === 0) {
-    console.log("Usage: vrt perf <html-or-url> [options]");
+    console.log("Usage: vlmkit check perf <html-or-url> [options]");
     console.log("Options:");
     console.log("  --observe <ms>      Observation window after networkidle (default: 3000)");
     console.log("  --strict            Exit non-zero on any non-good verdict (CI gate mode)");

--- a/src/util/real-site-relay.mjs
+++ b/src/util/real-site-relay.mjs
@@ -1,0 +1,69 @@
+// Local reverse proxy so the gates can measure a REAL site.
+//
+//   RELAY_TARGET=https://example.com RELAY_PORT=8910 node src/util/real-site-relay.mjs
+//   vlmkit check integrity http://127.0.0.1:8910/some/path
+//
+// Chromium in this environment cannot egress (the agent proxy never even
+// sees its connections), but node's fetch can. The gates navigate to
+// 127.0.0.1 while the bytes come from the real origin, so this is a real
+// -site audit rather than a mirror: live HTML, CSS, JS, and a real session.
+//
+// Target sites are ones whose credentials are PUBLISHED for automation
+// practice (Sauce Labs' demo app, the Selenium "the-internet" playground).
+// No third-party accounts, no real user data.
+import { createServer } from "node:http";
+
+const TARGET = process.env.RELAY_TARGET ?? "https://www.saucedemo.com";
+const PORT = Number(process.env.RELAY_PORT ?? 8910);
+const origin = new URL(TARGET).origin;
+
+const HOP = new Set([
+  "connection", "keep-alive", "transfer-encoding", "upgrade",
+  "proxy-authenticate", "proxy-authorization", "te", "trailer",
+  "content-encoding", "content-length",
+]);
+
+createServer(async (req, res) => {
+  const upstream = new URL(req.url, origin);
+  const headers = {};
+  for (const [k, v] of Object.entries(req.headers)) {
+    const lk = k.toLowerCase();
+    if (HOP.has(lk) || lk === "host" || lk === "accept-encoding") continue;
+    headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
+  }
+  let body;
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    body = Buffer.concat(chunks);
+  }
+  try {
+    const up = await fetch(upstream, {
+      method: req.method,
+      headers,
+      body,
+      redirect: "manual", // preserve the site's own redirects (login walls!)
+    });
+    const out = {};
+    for (const [k, v] of up.headers) {
+      const lk = k.toLowerCase();
+      if (HOP.has(lk)) continue;
+      // Rewrite absolute Location / cookie domains onto the local origin so
+      // the browser stays inside the relay.
+      if (lk === "location") { out[k] = v.replace(origin, `http://127.0.0.1:${PORT}`); continue; }
+      if (lk === "set-cookie") {
+        const list = up.headers.getSetCookie ? up.headers.getSetCookie() : [v];
+        out["set-cookie"] = list.map((c) =>
+          c.replace(/;\s*Domain=[^;]*/i, "").replace(/;\s*Secure/gi, ""));
+        continue;
+      }
+      out[k] = v;
+    }
+    const buf = Buffer.from(await up.arrayBuffer());
+    res.writeHead(up.status, out);
+    res.end(buf);
+  } catch (e) {
+    res.writeHead(502, { "content-type": "text/plain" });
+    res.end(`relay error: ${e.message}`);
+  }
+}).listen(PORT, "127.0.0.1", () => console.log(`relay ${PORT} -> ${TARGET}`));

--- a/src/util/skill.ts
+++ b/src/util/skill.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Skill playbooks for the vrt toolkit.
+ * Skill playbooks for the vlmkit toolkit.
  *
  * Adopts the per-domain skill pattern from browser-use/browser-harness:
  * accumulate repeated per-page or per-component configuration as
@@ -25,10 +25,10 @@
  *   }
  *
  * Usage:
- *   vrt skill list                     List skills in .vrt-skills/
- *   vrt skill show <name>              Print the skill file
- *   vrt skill init <name>              Create a starter skill file
- *   vrt skill run <name> --against <html|url>
+ *   vlmkit skill list                     List skills in .vrt-skills/
+ *   vlmkit skill show <name>              Print the skill file
+ *   vlmkit skill init <name>              Create a starter skill file
+ *   vlmkit skill run <name> --against <html|url>
  *                                      Execute every check in the skill
  *                                      against the target.
  */
@@ -174,7 +174,7 @@ export async function runSkill(
   const outputDir = resolve(outputBase, `skill-${skill.name}`);
   await mkdir(outputDir, { recursive: true });
 
-  console.log(`  ${BOLD}${CYAN}vrt skill run ${name}${RESET}`);
+  console.log(`  ${BOLD}${CYAN}vlmkit skill run ${name}${RESET}`);
   console.log(`  ${DIM}target: ${target}${RESET}`);
   console.log(`  ${DIM}${skill.checks.length} check(s):${RESET}`);
 
@@ -235,7 +235,7 @@ async function commandList() {
   const skills = await listSkills();
   if (skills.length === 0) {
     console.log(`${DIM}No skills found in ./${SKILLS_DIR}/.${RESET}`);
-    console.log(`Create one with: vrt skill init <name>`);
+    console.log(`Create one with: vlmkit skill init <name>`);
     return;
   }
   console.log(`Skills in ${SKILLS_DIR}/:`);
@@ -281,7 +281,7 @@ async function main(argv = process.argv.slice(2)) {
   const sub = argv[0];
   const rest = argv.slice(1);
   if (!sub || sub === "--help" || sub === "-h") {
-    console.log("Usage: vrt skill <command>");
+    console.log("Usage: vlmkit skill <command>");
     console.log("");
     console.log("Commands:");
     console.log("  list                            List skills in .vrt-skills/");
@@ -290,7 +290,7 @@ async function main(argv = process.argv.slice(2)) {
     console.log("  run <name> --against <target>   Execute every check in the skill");
     console.log("");
     console.log("Skill files live at .vrt-skills/<name>.json and declare a list of");
-    console.log("checks (vrt commands + their flags) to run against a target.");
+    console.log("checks (vlmkit commands + their flags) to run against a target.");
     process.exit(sub ? 0 : 1);
   }
   if (sub === "list") { await commandList(); return; }

--- a/src/util/skill.ts
+++ b/src/util/skill.ts
@@ -42,7 +42,7 @@ import { DIM, RESET, GREEN, RED, YELLOW, BOLD, CYAN } from "@mizchi/vlmkit-core/
 const SKILLS_DIR = ".vrt-skills";
 
 export interface SkillCheck {
-  /** Which vrt CLI to invoke. */
+  /** Which vlmkit CLI to invoke. */
   tool: string;
   /** Pass-through options. Keys map to CLI flags (`level` → `--level`). */
   [key: string]: unknown;

--- a/src/vrt/compare/diff-for-agent.ts
+++ b/src/vrt/compare/diff-for-agent.ts
@@ -1994,7 +1994,7 @@ export function formatMigrationReportForAgent(
         "has 6 bands, variant has 4), you're missing rows of content — add the " +
         "missing HTML elements before tweaking CSS.");
       lines.push("5. Write the missing HTML elements first (the bbox table tells " +
-        "you their target dimensions), then the CSS rules. Re-run `vrt compare` " +
+        "you their target dimensions), then the CSS rules. Re-run `vlmkit diff html` " +
         "and check that bbox deltas + heatmap regions + text-row Δy all shrink " +
         "toward zero.");
     } else {
@@ -2003,7 +2003,7 @@ export function formatMigrationReportForAgent(
       lines.push("2. Cross-check against the fix-candidate table — it identifies *which* " +
         "selectors differ but may name the wrong property; trust your eyes for the " +
         "actual property.");
-      lines.push("3. Write one CSS patch covering the deltas, re-run `vrt compare`, " +
+      lines.push("3. Write one CSS patch covering the deltas, re-run `vlmkit diff html`, " +
         "and check that the dominant category count drops to zero on every viewport.");
     }
     lines.push("");

--- a/src/vrt/compare/flipbook.ts
+++ b/src/vrt/compare/flipbook.ts
@@ -7,8 +7,8 @@
  * embedded in a PR description via attachment.
  *
  * Used by:
- *   - `vrt snapshot flipbook` (diff three-frame + stability iterations)
- *   - `vrt flipbook <pngs...>`   (free-form sequence, e.g. fix-loop rounds)
+ *   - `vlmkit snapshot flipbook` (diff three-frame + stability iterations)
+ *   - `vlmkit snapshot flipbook <pngs...>`   (free-form sequence, e.g. fix-loop rounds)
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { basename, dirname, resolve } from "node:path";

--- a/src/vrt/snapshot/approval.ts
+++ b/src/vrt/snapshot/approval.ts
@@ -21,7 +21,7 @@ export interface ApprovalRule {
   /**
    * Sub-categorizes the rule. Default ("visual") suppresses pixel /
    * paint diffs as before. "a11y-contrast" / "a11y-touch" suppress
-   * findings from the matching a11y checker (see `vrt diff-pr`'s
+   * findings from the matching a11y checker (see `vlmkit diff-pr`'s
    * a11y gate). The default keeps the schema backward-compatible —
    * existing manifests don't carry `kind`.
    */
@@ -41,7 +41,7 @@ export interface ApprovalRule {
   reason: string;
   issue?: string;
   expires?: string;
-  /** Audit trail: who signed off on this approval (vrt baseline approve). */
+  /** Audit trail: who signed off on this approval (vlmkit baseline approve). */
   acknowledgedBy?: string;
   /** Audit trail: when the rule was authored (ISO date or datetime). */
   createdAt?: string;

--- a/src/vrt/snapshot/snapshot-report.ts
+++ b/src/vrt/snapshot/snapshot-report.ts
@@ -602,8 +602,8 @@ function parseSnapshotReportEvaluateCliArgs(args: string[]): ParsedSnapshotRepor
 export function formatSnapshotReportUsage(exitCode = 1): string {
   const body = [
     "Usage:",
-    "  vrt snapshot report <snapshot-report.json> [--format markdown|json] [--max-false-positive-rate n] [--max-diff-ratio n] [--github-step-summary path]",
-    "  vrt snapshot report evaluate --before-report before.json --after-report after.json [--format markdown|json] [--output path] [--min-success-rate n] [--min-improvement-rate n]",
+    "  vlmkit snapshot report <snapshot-report.json> [--format markdown|json] [--max-false-positive-rate n] [--max-diff-ratio n] [--github-step-summary path]",
+    "  vlmkit snapshot report evaluate --before-report before.json --after-report after.json [--format markdown|json] [--output path] [--min-success-rate n] [--min-improvement-rate n]",
   ].join("\n");
   return exitCode === 0 ? body : `${body}\n`;
 }

--- a/src/vrt/snapshot/snapshot.ts
+++ b/src/vrt/snapshot/snapshot.ts
@@ -3,8 +3,8 @@
  * VRT Snapshot -- capture URLs at multiple viewports, auto-compare with previous
  *
  * Usage:
- *   vrt snapshot http://localhost:4156/todomvc --output snapshots/luna/
- *   vrt snapshot http://localhost:3000/ http://localhost:3000/luna/ --output snapshots/sol/
+ *   vlmkit snapshot http://localhost:4156/todomvc --output snapshots/luna/
+ *   vlmkit snapshot http://localhost:3000/ http://localhost:3000/luna/ --output snapshots/sol/
  */
 import { existsSync } from "node:fs";
 import { access, copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
@@ -55,11 +55,11 @@ interface SnapshotResult {
 function formatSnapshotUsage(): string {
   return [
     "Usage:",
-    "  vrt snapshot <url1> [url2] ... [--output dir] [--label name] [--threshold 0.1] [--fail-on-diff] [--fail-on-new-baseline] [--max-diff-ratio n] [--backend local|cloudflare] [--config vrt.config.json]",
-    "  vrt snapshot approve [--output dir] [--label name] [--config vrt.config.json]",
-    "  vrt snapshot fix-prompt [--output dir] [--label name] [--format markdown|json] [--limit n] [--min-diff 0.01] [--out path] [--config vrt.config.json]",
-    "  vrt snapshot stability <url1> [url2]... [--iterations 3] [--output dir] [--threshold 0.1] [--fp-threshold 0] [--fail-above-rate 0.05] [--config vrt.config.json]",
-    "  vrt snapshot stability-history <stability-report.json>... [--out path]",
+    "  vlmkit snapshot <url1> [url2] ... [--output dir] [--label name] [--threshold 0.1] [--fail-on-diff] [--fail-on-new-baseline] [--max-diff-ratio n] [--backend local|cloudflare] [--config vrt.config.json]",
+    "  vlmkit snapshot approve [--output dir] [--label name] [--config vrt.config.json]",
+    "  vlmkit snapshot fix-prompt [--output dir] [--label name] [--format markdown|json] [--limit n] [--min-diff 0.01] [--out path] [--config vrt.config.json]",
+    "  vlmkit snapshot stability <url1> [url2]... [--iterations 3] [--output dir] [--threshold 0.1] [--fp-threshold 0] [--fail-above-rate 0.05] [--config vrt.config.json]",
+    "  vlmkit snapshot stability-history <stability-report.json>... [--out path]",
   ].join("\n");
 }
 
@@ -106,7 +106,7 @@ async function approve(options: {
     result = await approveSnapshotsFromReport(reportPath, options.labels);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`No snapshot report found at ${reportPath}. Run \`vrt snapshot <url...>\` first.`);
+      throw new Error(`No snapshot report found at ${reportPath}. Run \`vlmkit snapshot <url...>\` first.`);
     }
     throw error;
   }
@@ -142,7 +142,7 @@ async function runFixPrompt(options: {
     raw = await readFile(reportPath, "utf-8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`No snapshot report found at ${reportPath}. Run \`vrt snapshot <url...>\` first.`);
+      throw new Error(`No snapshot report found at ${reportPath}. Run \`vlmkit snapshot <url...>\` first.`);
     }
     throw error;
   }
@@ -391,7 +391,7 @@ async function runDiffFlipbook(options: {
     raw = await readFile(reportPath, "utf-8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`No snapshot report found at ${reportPath}. Run \`vrt snapshot <url...>\` first.`);
+      throw new Error(`No snapshot report found at ${reportPath}. Run \`vlmkit snapshot <url...>\` first.`);
     }
     throw error;
   }

--- a/src/vrt/snapshot/snapshot.ts
+++ b/src/vrt/snapshot/snapshot.ts
@@ -12,6 +12,7 @@ import { dirname, join, resolve } from "node:path";
 import { compareScreenshots, generateDiffReport } from "@mizchi/vlmkit-core/heatmap.ts";
 import { DIM, RESET, GREEN, RED, YELLOW, CYAN, BOLD, hr } from "@mizchi/vlmkit-core/terminal-colors.ts";
 import { applyMask } from "@mizchi/vlmkit-core/mask.ts";
+import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { approveSnapshotsFromReport } from "./approve.ts";
 import { determineSnapshotExitCode, parseSnapshotCliArgs, parseSnapshotConfig, type SnapshotConfig } from "../../cli/commands/snapshot.ts";
 import {
@@ -644,6 +645,24 @@ async function main() {
     failOnDiff: parsed.failOnDiff,
     failOnNewBaseline: parsed.failOnNewBaseline,
     maxDiffRatio: parsed.maxDiffRatio,
+  });
+
+  // Ledger: snapshot is one of the headline tools, so a "verified" claim
+  // that rests on it has to be auditable like every other gate. The
+  // worst per-viewport diff is the headline; `verdict` mirrors the
+  // integrity gate's vocabulary so grepping one field works across tools.
+  const worstDiff = compared.reduce((max, r) => Math.max(max, r.diffRatio ?? 0), 0);
+  appendRunLedger({
+    tool: "snapshot",
+    source: urls.join(" "),
+    headline: {
+      verdict: exitStatus.exitCode === 0 ? "clean" : "defects",
+      captured: results.length,
+      newBaselines: newBaselines.length,
+      compared: compared.length,
+      changed: falsePositives.length,
+      worstDiffRatio: Number(worstDiff.toFixed(6)),
+    },
   });
 
   // Write JSON summary

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * `vrt watch` — dev inner-loop wrapper around `vrt compare`.
+ * `vlmkit watch` — dev inner-loop wrapper around `vlmkit diff html`.
  *
  * Watches the variant file (and the dir of its referenced
  * stylesheets), re-runs the compare on every save, and surfaces a
@@ -275,7 +275,7 @@ async function runOnce(compareArgs: string[], outputDir: string): Promise<RoundS
 export async function runWatch(rawArgs: string[]): Promise<void> {
   const { compareArgs, watchPathOverride } = parseWatchArgs(rawArgs);
   if (compareArgs.length < 2) {
-    console.error("Usage: vrt watch <baseline> <variant> [vrt compare flags...]");
+    console.error("Usage: vlmkit watch <baseline> <variant> [vlmkit diff html flags...]");
     console.error("       (or --url + --current-url for URL mode)");
     process.exit(1);
   }
@@ -292,7 +292,7 @@ export async function runWatch(rawArgs: string[]): Promise<void> {
     ? resolve(watchPathOverride)
     : dirname(resolve(variant));
 
-  console.log(`${BOLD}${CYAN}vrt watch${RESET}`);
+  console.log(`${BOLD}${CYAN}vlmkit watch${RESET}`);
   console.log(`  ${DIM}baseline${RESET} ${baseline}`);
   console.log(`  ${DIM}variant ${RESET} ${variant}`);
   console.log(`  ${DIM}watching${RESET} ${watchPath}`);

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -20,7 +20,8 @@
 
 import { watch as fsWatch } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, relative} from "node:path";
+import { STATE_DIR, resolveStatePath } from "@mizchi/vlmkit-core/legacy-names.ts";
 import { runMigrationCompare, parseMigrationCompareArgs, type MigrationCompareReport } from "./experiments/migration/migration-compare.ts";
 import {
   BOLD,
@@ -34,7 +35,10 @@ import {
 import type { WireframeFixSuggestion } from "./experiments/migration/wireframe-fix-candidates.ts";
 
 const DEBOUNCE_MS = 150;
-const WATCH_OUTPUT_DIR_DEFAULT = ".vrt/runs";
+// See legacy-names: an existing `.vrt/runs` keeps being used so a watch loop
+// mid-session does not start a second run history beside the first.
+const watchOutputDirDefault = (): string =>
+  relative(process.cwd(), resolveStatePath(process.cwd(), "runs")) || `${STATE_DIR}/runs`;
 
 export interface RoundSummary {
   timestamp: string;
@@ -282,7 +286,7 @@ export async function runWatch(rawArgs: string[]): Promise<void> {
   const baseline = compareArgs[0];
   const variant = compareArgs[1];
 
-  const outputDir = resolve(WATCH_OUTPUT_DIR_DEFAULT);
+  const outputDir = resolve(watchOutputDirDefault());
   await mkdir(outputDir, { recursive: true });
 
   // Pick what to watch. By default: the variant file + its parent dir

--- a/wall-server.mjs
+++ b/wall-server.mjs
@@ -1,0 +1,17 @@
+// /app 302s to /login unless a session cookie is present — a plain auth wall.
+import { createServer } from "node:http";
+createServer((req, res) => {
+  const cookie = req.headers.cookie ?? "";
+  if (req.url.startsWith("/app") && !cookie.includes("session=")) {
+    res.writeHead(302, { location: "/login" });
+    res.end();
+    return;
+  }
+  const body = req.url.startsWith("/login")
+    ? `<!doctype html><meta charset="utf-8"><title>Sign in</title><body style="font:16px sans-serif;padding:40px">
+       <h1>Sign in</h1><form><input type="password" name="p"><button>Sign in</button></form></body>`
+    : `<!doctype html><meta charset="utf-8"><title>Dashboard</title><body style="font:16px sans-serif;margin:0">
+       <main><div class="card" style="width:1000px">Revenue</div><div class="card" style="width:1000px">Costs</div></main></body>`;
+  res.writeHead(200, { "content-type": "text/html" });
+  res.end(body);
+}).listen(8901);


### PR DESCRIPTION
Releases 0.9.0 and completes the `vrt` → `vlmkit` rename. 44 commits, 207 files.

## The theme: gates that reported a defect in the page when they had measured the wrong document

Nine gates were confidently wrong, and none of it was visible in a single run — every one needed two runs and a comparison ("do two paths that should agree actually agree?").

**Six were measuring an unstyled document.** They loaded local HTML with `setContent(readFile(...))`, which gives the page an `about:blank` base URL, so every relative stylesheet, image and webfont silently failed to resolve. `check a11y contrast` reported 0 failures where the same CSS inlined reported 1; `check a11y touch` *inverted* — an unstyled control keeps its intrinsic size, so a CSS-shrunk tap target measured as passing. Injecting a `<base href>` was tried and provably does not work (an opaque origin blocks `file://` subresources).

**Five more reported success for a login page.** `check breakpoints`, `check scroll` and `scan scroll` returned `status: ok` for a route that 302s to `/login`, while `check layout` and `verify flow` failed against the sign-in page and blamed the markup.

**Six were reading the pre-render DOM.** `verify flow` reported `count .card expected 2, measured 0` on a page where `check layout` measured 2 at the same instant; `build page` screenshotted a candidate at 5.3% of its settled ink, so every component came back missing; `scan contract` returned zero landmarks for a built SPA opened as a file. Playwright *actions* auto-wait — `page.evaluate`, `page.screenshot` and `getBoundingClientRect` do not, and that is how every gate measures. `waitUntil` turned out not to be the axis at all.

Also fixed: viewport attribution was order-dependent (so `--allow "…@1280"` silently was too), three a11y gates printed 5 of 12 findings with no note, `--json` did not exist on the gates the truncation notice pointed at, and `verify markup` scored low-contrast fills as clean.

## Added

`check design` (design-system coherence, no reference) · `vlmkit batch` (many pages, bounded concurrency, stride sharding) · `vlmkit gates` + `vlmkit.gates.json` (reviewed per-page gate sets, expiring suppressions that require a reason) · `check integrity --allow` (accept an intentional pattern auditably; four kinds meaning "the page is broken" can never be exempted) · `--storage-state` for authenticated pages · `--json` and URL support on the gates that lacked them.

## Breaking

- **A suspect finding fails the command by default.** One exit-code contract across every gate; `--advisory` opts back into print-and-succeed, `--fail-on-suspect` still accepted as a no-op. If you relied on a gate exiting 0 while reporting defects, add `--advisory`.
- **A malformed `verify flow` file is now a usage error.** An unknown assert was reported as an unmet post-condition; an unknown *action* was worse — the step did nothing, had no post-conditions to fail, and the run returned `done: true`. A flow that was silently passing on a typo will now error; it was never verifying anything.

## The rename

There is no `vrt` binary, so every `vrt <something>` in help text or a fix instruction was an instruction you could not paste. The map is the CLI's own 33-entry alias table.

Old names still work for everything that is not text — `.vrt/` (per subpath, because `.vlmkit/` already exists in any repo that ran a gate), `vrt.config.json`, `VRT_*`, `DEBUG_VRT` — each preferring the new name and printing one line. Support ends in 1.0.0, so no existing baseline, config or CI breaks.

Deliberately not renamed, with reasons recorded in `TODO.md`: `data-vrt-action` (a public API users write in their own HTML), `vrt-page.html` / `vrt.spec.ts` (where committed Playwright baselines get their filenames), the APM package name and Actions job name (consumers may pin them), `src/vrt/` (a real directory), and dated records.

## What went wrong while doing this, and what now guards it

A single sweep was attempted and was wrong four times, each time corrupting text whose *subject* is the old name. The fourth landed in the file documenting the rename ("There is no `vrt` binary" → "There is no `vlmkit` binary") and survived tsc and every other test, reading as confident documentation while saying the opposite. Prose cannot be protected by regex, so source and markdown were separate passes and the markdown diff was read.

Renaming `- id: vrt` also broke a workflow template: the `if: steps.vrt.outcome` consuming it did not match the pattern, so the template still parsed and the review step silently stopped running.

Both classes now have gates: `src/cli/binary-name.test.ts` runs `--help` for all 24 commands, asserts every allowlisted exception still exists in the source (the allowlist is the boundary between a naming fix and a breaking change, not slack), checks every `steps.<id>` reference against declared ids, and asserts no file claims the shipped binary does not exist. All ablated.

Tests were deliberately excluded from the sweep so they stayed the check; four then failed on stale usage strings, which is the correct signal.

## Corrections to earlier claims in this branch

- `vrt compare`, `elements`, `smoke`, `serve`, `discover` are **not** removed — they are deprecated aliases that still run (removal in 1.0.0). Only the `vrt` binary is gone. An earlier commit message said otherwise.
- `--json` was verified via `report.failures.length` from the run function, which never touches stdout. Running the built binary during release prep showed it emitted the human block first, so `JSON.parse` threw on line 1. New tests spawn the real CLI.
- One regression test was vacuous on first write: `\bvrt\s` never matched, because the header is `\x1b[36mvrt …` and the escape ends in a word character. It strips ANSI now.

## Verification

`tsc --noEmit` clean · 1856 tests pass · `scripts/smoke-dist.sh` 11/11 against the built bundle · every new command exercised through `dist/vlmkit.mjs` · broken path references in docs dropped 43 → 11 (all 11 predate this branch) · every behavioural claim in `introduce.md` / `introduce.ja.md` run rather than trusted.

`npm publish` has **not** been run — this environment has no npm auth. Versions, CHANGELOG, build and smoke are done.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHk53UdaxvVh9QFBQkdb4q)_