### PR TITLE
Migrate the last 18 positional commands, and fix the injection bug that made the JSON boundary dead in the shipped CLI

### DIFF
--- a/.github/workflows/package-install-smoke.yml
+++ b/.github/workflows/package-install-smoke.yml
@@ -46,3 +46,11 @@ jobs:
       - run: pnpm exec playwright install-deps chromium
       - run: pnpm smoke:pack:workspaces
       - run: pnpm smoke:pack:markup-loop
+      # The bundled CLI's route to MoonBit is a global set by
+      # scripts/vlmkit-bundled.mjs, and nothing above exercises it: the packed
+      # smokes install the *library* packages, which ship the generated bridge on
+      # disk. The root package ships dist/** only. This runs the built CLI with
+      # `moon` removed from PATH, so a JSON-boundary command has to work through
+      # the injected bridge or fail — which is how it shipped broken once.
+      - run: pnpm build
+      - run: pnpm smoke:bundled-json

--- a/docs/design/moonbit-boundary.md
+++ b/docs/design/moonbit-boundary.md
@@ -161,10 +161,37 @@ cannot help, because the global is assigned in a `.mjs` file to a
 `Partial<DirectMarkupCoreModule>`, where absent is legal.
 
 Both instances are one mistake: **a hand-written list of entry points that has to agree
-with an interface, with nothing checking it.** `tests/markup-core-injection.test.mjs`
-compares the two lists as text now. The lesson generalises past this file — it is the
-same shape as the two duplicated positional dispatch tables, and the same shape as the
-`build page` defect, where source and bundle disagreed and only the bundle was wrong.
+with an interface, with nothing checking it.** The lesson generalises past this file — it
+is the same shape as the two duplicated positional dispatch tables, and the same shape as
+the `build page` defect, where source and bundle disagreed and only the bundle was wrong.
+
+### How it is connected now
+
+Three changes, because a test alone would have left the list in place:
+
+1. **No list.** `scripts/vlmkit-bundled.mjs` hands over a **namespace import** of the
+   bridge, so every export crosses by construction. Adding an entry point in
+   `markup-core-api/main.mbt` connects it without anyone remembering to. `pickDirectApi`
+   selects what it understands and ignores the rest.
+2. **No silent degradation.** The runtime records whether the direct API was `injected`
+   or read off disk as `generated`. A missing function from `generated` can be a stale
+   `_build`, so build-and-retry stays right. From `injected` it cannot be stale — there is
+   no toolchain to rebuild with and the root package ships no `_build` for the spawned CLI
+   either — so it **raises**, naming the packaging fault. Both old fallbacks were
+   guaranteed to fail there; trying them quietly is what turned a build fault into a
+   mystery.
+3. **A smoke in the consumer's environment.** `pnpm smoke:bundled-json` runs the built CLI
+   with `moon` removed from PATH and requires a JSON-boundary gate to succeed, so no
+   fallback can pretend to work. It first asserts `moon` is genuinely unreachable, because
+   otherwise the check passes vacuously. In `package-install-smoke`.
+
+Every safety net that existed was in a different room, which is the part worth keeping:
+`pnpm test` runs from source (the runtime finds the bridge through `apiPath` and never
+reads the global); `smoke:pack:workspaces` installs the **library** packages, and
+`@mizchi/vlmkit-markup` *does* ship `_build/.../markup-core-api.js`; and the type checker
+sees a `Partial<DirectMarkupCoreModule>` in a `.mjs` file, where absent is legal. Only the
+root package — `dist/**` and nothing else — depended on the hand-off, and nothing ran the
+root package the way a consumer does.
 
 ## What belongs in MoonBit — and what does not
 

--- a/docs/design/moonbit-boundary.md
+++ b/docs/design/moonbit-boundary.md
@@ -1,7 +1,9 @@
 # The TypeScript ↔ MoonBit boundary
 
-Status: **JSON boundary landed alongside the positional one, and the commands that
-carried real risk are migrated.** All 61 positional arms still exist and still work.
+Status: **JSON boundary landed alongside the positional one, and every command that
+carried swap risk is migrated — 32 of 61.** All 61 positional arms still exist and still
+work; the 29 that remain the only caller of are single-argument or all-distinct-type, so
+a struct would buy them nothing.
 
 ## Which commands were migrated, and why not all of them
 
@@ -19,10 +21,11 @@ The 29 gain nothing from a struct: `is-component-probe-state(value)` takes one
 `src/markup-core-dispatch.test.ts` covers the duplication concern that applies to
 them.
 
-Of the 32, **14 are migrated** — `goal-status` (36 arguments), the 12
-`ui-contract-*-issue-ids` with swappable positions, and `layout-policy-issue-ids`.
-`interaction-issues` is new logic with no positional twin. The remaining 18 are
-listed under "Not done".
+**All 32 are migrated** — `goal-status` (36 arguments), the 12
+`ui-contract-*-issue-ids` with swappable positions, `layout-policy-issue-ids`, and the
+final 18 (landscape, visual/semantic, a11y, grid, shift and quality policies).
+`interaction-issues` is new logic with no positional twin. What each of the last 18
+bought beyond a rename is under "Not done".
 
 **Deleting the positional dispatch entirely is a separate goal** and would require
 all 61, including the 29 with nothing to gain. Worth doing for the 1,487 lines and
@@ -134,13 +137,34 @@ markup-core direct call failed: Double::from_json: expected number (at /width_va
 markup-core direct call failed: unknown markup-core JSON command: nope
 ```
 
-Related: `loadMarkupCoreApi` rebuilt a narrow object holding only
-`run_markup_core`, silently dropping every other export — so the JSON entry
-points were invisible and every JSON call fell through to spawning a node
-process while appearing to work. A boundary built to make MoonBit cheap to call
-had become the expensive path. `markup-core-json.test.ts` asserts
-`getMarkupCoreRuntimeBackend() === "direct-js"`, which is what would have caught
-it.
+### The same bug, twice, in two places
+
+**First:** `loadMarkupCoreApi` rebuilt a narrow object holding only `run_markup_core`,
+silently dropping every other export — so the JSON entry points were invisible and every
+JSON call fell through to spawning a node process while appearing to work. A boundary
+built to make MoonBit cheap to call had become the expensive path.
+`markup-core-json.test.ts` asserts `getMarkupCoreRuntimeBackend() === "direct-js"`,
+which is what would have caught it.
+
+**Then again, in the shipped CLI.** `scripts/vlmkit-bundled.mjs` injects the generated
+bridge through a global so npm consumers need no MoonBit toolchain — and it listed
+`run_markup_core` by hand, from before the JSON boundary existed. Adding the boundary did
+not update it. In `dist/`, `loadMarkupCoreApi` found the global, `run_markup_core_json`
+read as `undefined`, and every JSON command fell through to `ensureMarkupCoreCli()`,
+which shells out to `moon build` — the one thing an npm consumer is guaranteed not to
+have. **Positional commands kept working, so the CLI looked healthy.**
+
+It survived because nothing tests that layout. The suite runs from source, where the
+runtime resolves the bridge through `apiPath` and never reads the global at all; the
+`direct-js` assertion above is true from source for the same reason; and type checking
+cannot help, because the global is assigned in a `.mjs` file to a
+`Partial<DirectMarkupCoreModule>`, where absent is legal.
+
+Both instances are one mistake: **a hand-written list of entry points that has to agree
+with an interface, with nothing checking it.** `tests/markup-core-injection.test.mjs`
+compares the two lists as text now. The lesson generalises past this file — it is the
+same shape as the two duplicated positional dispatch tables, and the same shape as the
+`build page` defect, where source and bundle disagreed and only the bundle was wrong.
 
 ## What belongs in MoonBit — and what does not
 
@@ -239,15 +263,36 @@ Three habits that keep such a handler honest:
   a wiring bug, which is the entire property the differential test rests on. It
   delegates now, like every other handler.
 
-- **18 risky commands remain**: `visual-classify-region` (12 args, 10 swappable),
-  `landscape-cell-score` (10/10), `a11y-contrast-evaluate` (8/6),
-  `landscape-diff-summary`, `region-classify-kind`, `focus-order-classify`,
-  `a11y-touch-in-cluster`, `visual-is-likely-page-surface`,
-  `semantic-drilldown-select-index`, `landscape-cell-hex`, `semantic-drilldown-policy`,
-  `grid-arrays-close`, `shift-classify-suspect`, `quality-error-state-kind`,
-  `quality-coverage-passed`, `merge-component-probe-states`, `landscape-default-grid`,
-  `grid-gcd`. Each is mechanical now that the harness exists: add a struct, an arm,
-  a spec row in `markup-core-migration.test.ts`.
+- **All 32 risky commands are migrated.** The last 18 went over together, because by
+  then the harness made each one a struct, a dispatch arm and a spec row. Three of them
+  were worth more than their argument count suggested:
+
+  - **`landscape-diff-summary` carried a second positional encoding inside a positional
+    argument.** `baseline_stats` was a `String` holding `"r,g,b,l,ink|r,g,b,l,ink|…"`:
+    five positional fields per cell, comma-delimited, inside a pipe-delimited list,
+    inside a tab-delimited argument list, parsed by a hand-written
+    `idx == 0 / 1 / 2 / 3 / 4` chain. No value at any level could contain a comma or a
+    pipe and nothing enforced it. It also returned `"mismatch|<total>|<base>|<curr>"` on
+    a cell-count error — an error in the same shape as a result, with a comment saying it
+    did that "rather than raising, so the FFI surface stays string-only". It raises now.
+    On the TypeScript side `parseSummary` was 36 lines and six throw sites; none of it
+    survives.
+
+  - **`semantic-drilldown-select-index` took three index-correlated parallel arrays** —
+    `flows`, `priority_scores`, `orders` — with nothing tying them together. Filter one
+    and not the others and you get a well-typed call that scores the wrong candidate. One
+    `Array[DrilldownCandidate]` makes that unrepresentable, the same reason
+    `interaction-issues` went over as an array of records.
+
+  - **`landscape-cell-score` and `a11y-contrast-evaluate` were the swap-risk worst
+    cases** (10 of 10 and 6 of 8 positions mutually swappable) and both were *pairs of
+    samples*: two 5-field cells, two RGB triples. Nesting removes the class outright
+    rather than renaming it.
+
+  Four commands also stopped returning composites as strings. `"cols|rows"`,
+  `"ratio|required|level"`, `"flow|priority|reason_id"` and the diff summary each had a
+  TypeScript reader that split, coerced and hand-validated against a literal union.
+  `derive(ToJson)` over a record deletes both halves of that.
 
 - **The 29 zero-risk commands are deliberately not migrated.** See above.
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "sync:skills": "node scripts/sync-skill-package.mjs",
     "smoke:dist": "pnpm build && bash scripts/smoke-dist.sh",
     "smoke:dist:strict": "pnpm build && bash scripts/smoke-dist.sh --strict",
+    "smoke:bundled-json": "node scripts/smoke-bundled-json.mjs",
     "smoke:pack:markup-loop": "node scripts/smoke-packed-markup-loop.mjs",
     "smoke:pack:workspaces": "node scripts/smoke-packed-workspaces.mjs",
     "test": "node --test 'src/**/*.test.ts' 'packages/*/src/**/*.test.ts' 'worker/**/*.test.ts' 'examples/**/*.test.mjs' 'tests/**/*.test.mjs'",

--- a/packages/vlmkit-markup/markup-core/json_dispatch.mbt
+++ b/packages/vlmkit-markup/markup-core/json_dispatch.mbt
@@ -167,6 +167,78 @@ pub fn run_json(command : String, payload : String) -> String raise {
       let input : PatternEvidenceIssuesInput = @json.from_json(json)
       pattern_evidence_issue_ids(input).to_json().stringify()
     }
+    "contrast-evaluate" => {
+      let input : ContrastEvaluateInput = @json.from_json(json)
+      contrast_evaluate(input).to_json().stringify()
+    }
+    "touch-in-cluster" => {
+      let input : TouchClusterInput = @json.from_json(json)
+      touch_in_cluster(input).to_json().stringify()
+    }
+    "focus-order-classify" => {
+      let input : FocusOrderInput = @json.from_json(json)
+      focus_order_classification(input).to_json().stringify()
+    }
+    "grid-arrays-close" => {
+      let input : GridArraysCloseInput = @json.from_json(json)
+      grid_arrays_close_json(input).to_json().stringify()
+    }
+    "grid-gcd" => {
+      let input : GridGcdInput = @json.from_json(json)
+      grid_gcd_json(input).to_json().stringify()
+    }
+    "shift-classify-suspect" => {
+      let input : ShiftSuspectInput = @json.from_json(json)
+      shift_suspect(input).to_json().stringify()
+    }
+    "quality-error-state-kind" => {
+      let input : ErrorStateInput = @json.from_json(json)
+      error_state_kind(input).to_json().stringify()
+    }
+    "quality-coverage-passed" => {
+      let input : CoverageInput = @json.from_json(json)
+      coverage_passed(input).to_json().stringify()
+    }
+    "landscape-cell-score" => {
+      let input : LandscapeCellScoreInput = @json.from_json(json)
+      landscape_cell_score_json(input).to_json().stringify()
+    }
+    "landscape-cell-hex" => {
+      let input : LandscapeCellHexInput = @json.from_json(json)
+      landscape_cell_hex_json(input).to_json().stringify()
+    }
+    "landscape-default-grid" => {
+      let input : LandscapeGridInput = @json.from_json(json)
+      landscape_default_grid_json(input).to_json().stringify()
+    }
+    "landscape-diff-summary" => {
+      let input : LandscapeDiffInput = @json.from_json(json)
+      landscape_diff(input).to_json().stringify()
+    }
+    "visual-classify-region" => {
+      let input : ClassifyRegionInput = @json.from_json(json)
+      classify_region(input).to_json().stringify()
+    }
+    "visual-is-likely-page-surface" => {
+      let input : Rgb = @json.from_json(json)
+      is_likely_page_surface(input).to_json().stringify()
+    }
+    "region-classify-kind" => {
+      let input : RegionKindInput = @json.from_json(json)
+      region_kind(input).to_json().stringify()
+    }
+    "semantic-drilldown-select-index" => {
+      let input : DrilldownSelectInput = @json.from_json(json)
+      drilldown_select_index(input).to_json().stringify()
+    }
+    "semantic-drilldown-policy" => {
+      let input : DrilldownPolicyInput = @json.from_json(json)
+      drilldown_policy(input).to_json().stringify()
+    }
+    "merge-component-probe-states" => {
+      let input : MergeProbeStatesInput = @json.from_json(json)
+      merge_probe_states(input).to_json().stringify()
+    }
     _ => raise Failure("unknown markup-core JSON command: \{command}")
   }
 }
@@ -191,5 +263,23 @@ pub fn json_commands() -> Array[String] {
     "composition-motion-issue-ids",
     "decoration-palette-issue-ids",
     "pattern-evidence-issue-ids",
+    "contrast-evaluate",
+    "touch-in-cluster",
+    "focus-order-classify",
+    "grid-arrays-close",
+    "grid-gcd",
+    "shift-classify-suspect",
+    "quality-error-state-kind",
+    "quality-coverage-passed",
+    "landscape-cell-score",
+    "landscape-cell-hex",
+    "landscape-default-grid",
+    "landscape-diff-summary",
+    "visual-classify-region",
+    "visual-is-likely-page-surface",
+    "region-classify-kind",
+    "semantic-drilldown-select-index",
+    "semantic-drilldown-policy",
+    "merge-component-probe-states",
   ]
 }

--- a/packages/vlmkit-markup/markup-core/landscape_json.mbt
+++ b/packages/vlmkit-markup/markup-core/landscape_json.mbt
@@ -1,0 +1,158 @@
+///| Landscape (coarse grid) diff over the JSON boundary.
+///
+/// `landscape-diff-summary` is the most valuable command in this batch, and not because
+/// of its argument count. It carried a **second positional encoding inside a positional
+/// argument**: `baseline_stats` and `current_stats` were `String`s holding
+/// `"r,g,b,l,ink|r,g,b,l,ink|…"`, parsed by `parse_cell_stats` with an
+/// `idx == 0 / 1 / 2 / 3 / 4` chain. Five fields per cell, positional, comma-delimited,
+/// inside a pipe-delimited list, inside a tab-delimited argument list. Nothing checked
+/// any level of it, and no cell value could contain a comma or a pipe.
+///
+/// Two more things the string-only boundary forced, both visible in the original:
+///
+///  - **A sentinel return.** On a cell-count mismatch it returned
+///    `"mismatch|<total>|<base>|<curr>"`, with a comment saying it does that "rather
+///    than raising, so the FFI surface stays string-only". A caller had to sniff the
+///    first field of a success-shaped result to find out it was an error. Here it
+///    raises, and the raise names the counts.
+///  - **A pipe-joined result** — `mean|similarity|changed|total|idx:score|idx:score…` —
+///    with the top-cell list encoded as `idx:score` pairs that TypeScript split twice.
+///    `derive(ToJson)` over a record with an `Array[LandscapeTopCell]` replaces all of
+///    that parsing on both sides.
+///
+/// `landscape_cell_score` is the other worst case: 10 `Double`s, all mutually
+/// swappable, being two 5-field samples. Nesting removes the entire class.
+
+///|
+/// One grid cell's colour and ink statistics.
+pub struct LandscapeCell {
+  r : Double
+  g : Double
+  b : Double
+  l : Double
+  ink : Double
+} derive(FromJson, ToJson)
+
+///|
+pub struct LandscapeCellScoreInput {
+  baseline : LandscapeCell
+  current : LandscapeCell
+} derive(FromJson, ToJson)
+
+///|
+pub fn landscape_cell_score_json(input : LandscapeCellScoreInput) -> Double {
+  landscape_cell_score(
+    input.baseline.r,
+    input.baseline.g,
+    input.baseline.b,
+    input.baseline.l,
+    input.baseline.ink,
+    input.current.r,
+    input.current.g,
+    input.current.b,
+    input.current.l,
+    input.current.ink,
+  )
+}
+
+///|
+pub struct LandscapeCellHexInput {
+  r : Double
+  g : Double
+  b : Double
+} derive(FromJson, ToJson)
+
+///|
+pub fn landscape_cell_hex_json(input : LandscapeCellHexInput) -> String {
+  landscape_cell_hex(input.r, input.g, input.b)
+}
+
+///|
+pub struct LandscapeGridInput {
+  width : Int
+  height : Int
+} derive(FromJson, ToJson)
+
+///|
+/// `cols|rows` was two integers in a string. It is two integers.
+pub struct LandscapeGrid {
+  cols : Int
+  rows : Int
+} derive(ToJson)
+
+///|
+pub fn landscape_default_grid_json(input : LandscapeGridInput) -> LandscapeGrid {
+  {
+    cols: landscape_default_grid_cols(input.width, input.height),
+    rows: landscape_default_grid_rows(input.width, input.height),
+  }
+}
+
+///|
+pub struct LandscapeDiffInput {
+  cols : Int
+  rows : Int
+  changed_threshold : Double
+  top_n : Int
+  baseline : Array[LandscapeCell]
+  current : Array[LandscapeCell]
+} derive(FromJson, ToJson)
+
+///|
+pub struct LandscapeTopCell {
+  index : Int
+  score : Double
+} derive(ToJson)
+
+///|
+pub struct LandscapeDiffOutput {
+  mean : Double
+  similarity : Double
+  changed : Int
+  total : Int
+  top : Array[LandscapeTopCell]
+} derive(ToJson)
+
+///|
+/// The rules, computed against the typed input.
+///
+/// This is the one handler in the batch that does NOT delegate to its positional twin,
+/// and the reason is specific rather than a lapse: the twin's first act is to *parse the
+/// sub-encoding this input replaces*, so delegating would mean re-serializing the cells
+/// into `"r,g,b,l,ink|…"` to have them parsed straight back. The arithmetic below is the
+/// same and still calls `landscape_cell_score` and `collect_top_indices` — only the
+/// decoding differs, which is exactly what the differential test compares.
+pub fn landscape_diff(input : LandscapeDiffInput) -> LandscapeDiffOutput raise {
+  let total = input.rows * input.cols
+  if total <= 0 {
+    return { mean: 1.0, similarity: 0.0, changed: 0, total: 0, top: [] }
+  }
+  // Raised, not returned as a "mismatch" sentinel. A caller that has to inspect a
+  // success-shaped result to learn it failed will eventually forget to.
+  if input.baseline.length() != total || input.current.length() != total {
+    raise Failure(
+      "landscape cell count mismatch: expected \{total} (\{input.cols}x\{input.rows}), " +
+      "baseline has \{input.baseline.length()}, current has \{input.current.length()}",
+    )
+  }
+  let scores : Array[Double] = []
+  let mut sum : Double = 0.0
+  let mut changed : Int = 0
+  for idx in 0..<total {
+    let b = input.baseline[idx]
+    let c = input.current[idx]
+    let score = landscape_cell_score(b.r, b.g, b.b, b.l, b.ink, c.r, c.g, c.b, c.l, c.ink)
+    scores.push(score)
+    sum = sum + score
+    if score >= input.changed_threshold {
+      changed = changed + 1
+    }
+  }
+  let mean = sum / total.to_double()
+  let similarity = if 1.0 - mean > 0.0 { 1.0 - mean } else { 0.0 }
+  let top : Array[LandscapeTopCell] = []
+  for idx in collect_top_indices(scores, input.top_n) {
+    top.push({ index: idx, score: scores[idx] })
+  }
+  { mean, similarity, changed, total, top }
+}

--- a/packages/vlmkit-markup/markup-core/measure_json.mbt
+++ b/packages/vlmkit-markup/markup-core/measure_json.mbt
@@ -1,0 +1,183 @@
+///| Measurement policies over the JSON boundary: contrast, touch, focus order,
+/// grid ratios, shift and quality thresholds.
+///
+/// Eight of the remaining risky positional commands. They share a shape the
+/// positional form was actively bad at: **coordinate pairs and colour triples**, where
+/// every position has the same type and swapping two of them still parses.
+/// `a11y-contrast-evaluate` took eight arguments of which six were `Int` —
+/// `fr, fg, fb, br, bg, bb` — so foreground and background could be exchanged in
+/// either direction, and the contrast ratio is symmetric enough that many cases would
+/// return the same answer while the ones that matter would not.
+///
+/// Nesting is what fixes it, not renaming: `{foreground: {r,g,b}, background: {r,g,b}}`
+/// makes the swap a type error at the call site rather than a silent one inside.
+///
+/// The rules are not rewritten. Each handler decodes a struct and calls the existing
+/// function, so `markup-core-migration.test.ts` compares two decoders over shared rule
+/// code and a disagreement is a wiring bug.
+
+///|
+/// An 8-bit colour. Shared by every handler here that takes one, so a swap between
+/// two colours needs the caller to name the wrong field rather than count wrong.
+pub struct Rgb {
+  r : Int
+  g : Int
+  b : Int
+} derive(FromJson, ToJson)
+
+///|
+/// A point in CSS pixels. Same argument as `Rgb`: `ax, ay, bx, by` as four positional
+/// `Double`s has 12 distinct wrong orderings that all parse.
+pub struct Point {
+  x : Double
+  y : Double
+} derive(FromJson, ToJson)
+
+///|
+pub struct ContrastEvaluateInput {
+  foreground : Rgb
+  background : Rgb
+  font_size : Double
+  font_weight : Int
+} derive(FromJson, ToJson)
+
+///|
+/// The verdict, as a record rather than `"4.53|4.5|AA"`.
+///
+/// The joined form meant TypeScript split on `|`, coerced two fields to `Number`, and
+/// hand-validated the third against a literal union — every one of which is a place to
+/// be wrong about a value MoonBit already knew the type of.
+pub struct ContrastEvaluateOutput {
+  ratio : Double
+  required_aa : Double
+  level : String
+} derive(ToJson)
+
+///|
+pub fn contrast_evaluate(input : ContrastEvaluateInput) -> ContrastEvaluateOutput raise {
+  let joined = a11y_contrast_evaluate(
+    input.foreground.r,
+    input.foreground.g,
+    input.foreground.b,
+    input.background.r,
+    input.background.g,
+    input.background.b,
+    input.font_size,
+    input.font_weight,
+  )
+  let parts = split_issue_ids(joined)
+  if parts.length() != 3 {
+    raise Failure("a11y_contrast_evaluate returned \{parts.length()} fields: \{joined}")
+  }
+  { ratio: parse_double_field(parts[0]), required_aa: parse_double_field(parts[1]), level: parts[2] }
+}
+
+///|
+pub struct TouchClusterInput {
+  a : Point
+  b : Point
+} derive(FromJson, ToJson)
+
+///|
+pub fn touch_in_cluster(input : TouchClusterInput) -> String {
+  a11y_touch_in_cluster(input.a.x, input.a.y, input.b.x, input.b.y)
+}
+
+///|
+pub struct FocusOrderInput {
+  same_path : Bool
+  previous : Point
+  current : Point
+} derive(FromJson, ToJson)
+
+///|
+pub fn focus_order_classification(input : FocusOrderInput) -> String {
+  focus_order_classify(
+    input.same_path,
+    input.previous.x,
+    input.previous.y,
+    input.current.x,
+    input.current.y,
+  )
+}
+
+///|
+/// `grid_arrays_close` took two **CSV strings**. Numbers are numbers here.
+///
+/// The CSV form had no way to carry a value containing a comma, needed a parser on this
+/// side, and made "these two lists have different lengths" — which the rule treats as
+/// not-close — indistinguishable from a malformed string.
+pub struct GridArraysCloseInput {
+  a : Array[Double]
+  b : Array[Double]
+  tolerance : Double
+} derive(FromJson, ToJson)
+
+///|
+pub fn grid_arrays_close_json(input : GridArraysCloseInput) -> Bool {
+  if input.a.length() != input.b.length() {
+    return false
+  }
+  for i in 0..<input.a.length() {
+    let diff = input.a[i] - input.b[i]
+    let abs_diff = if diff < 0.0 { -diff } else { diff }
+    if abs_diff > input.tolerance {
+      return false
+    }
+  }
+  true
+}
+
+///|
+pub struct GridGcdInput {
+  a : Int
+  b : Int
+} derive(FromJson, ToJson)
+
+///|
+pub fn grid_gcd_json(input : GridGcdInput) -> Int {
+  grid_gcd(input.a, input.b)
+}
+
+///|
+pub struct ShiftSuspectInput {
+  abs_height_delta : Double
+  abs_top_delta : Double
+} derive(FromJson, ToJson)
+
+///|
+pub fn shift_suspect(input : ShiftSuspectInput) -> String {
+  shift_classify_suspect(input.abs_height_delta, input.abs_top_delta)
+}
+
+///|
+pub struct ErrorStateInput {
+  red_ratio : Double
+  yellow_ratio : Double
+} derive(FromJson, ToJson)
+
+///|
+pub fn error_state_kind(input : ErrorStateInput) -> String {
+  quality_error_state_kind(input.red_ratio, input.yellow_ratio)
+}
+
+///|
+pub struct CoverageInput {
+  covered : Int
+  total : Int
+} derive(FromJson, ToJson)
+
+///|
+pub fn coverage_passed(input : CoverageInput) -> Bool {
+  quality_coverage_passed(input.covered, input.total)
+}
+
+///|
+/// Parse a `Double` the rule functions formatted into a string on their way out.
+///
+/// Only reachable for values MoonBit itself just printed, so a failure here means the
+/// formatter and this disagree — a boundary bug, which is why it raises rather than
+/// defaulting to zero.
+fn parse_double_field(value : String) -> Double raise {
+  @string.from_str(value)
+}

--- a/packages/vlmkit-markup/markup-core/visual_json.mbt
+++ b/packages/vlmkit-markup/markup-core/visual_json.mbt
@@ -1,0 +1,150 @@
+///| Visual / semantic classification over the JSON boundary.
+///
+/// `visual-classify-region` is the argument-count worst case in this batch (12, of which
+/// 10 are mutually swappable): a region descriptor followed by two RGB triples, with a
+/// `has_color_sample` boolean in the middle whose job was to say whether the six numbers
+/// after it meant anything. `Rgb?` says that, and the two triples become named.
+///
+/// `semantic-drilldown-select-index` is the interesting one. It took **three parallel
+/// arrays** — `flows : Array[String]`, `priority_scores : Array[Double]`,
+/// `orders : Array[Int]` — correlated by index, with nothing tying them together. A
+/// caller that filtered one and not the others, or built them in different orders,
+/// produces a well-typed call that silently scores the wrong candidate. One array of
+/// records makes that unrepresentable, which is the same reason `interaction-issues`
+/// went over as `Array[InteractionElementInput]`.
+
+///|
+pub struct ClassifyRegionInput {
+  region_type : String
+  width : Int
+  height : Int
+  diff_pixel_count : Int
+  total_pixels : Int
+  /// Absent when no colour was sampled. The positional form spent a boolean plus six
+  /// numbers saying this.
+  baseline_color : Rgb?
+  current_color : Rgb?
+} derive(FromJson, ToJson)
+
+///|
+pub fn classify_region(input : ClassifyRegionInput) -> String {
+  // The rule takes one `has_color_sample` covering both triples, so reconstruct it as
+  // "both present" — which is what every existing caller sent, since a sample is a
+  // baseline/current pair or nothing.
+  let has_sample = input.baseline_color is Some(_) && input.current_color is Some(_)
+  let baseline = input.baseline_color.unwrap_or({ r: 0, g: 0, b: 0 })
+  let current = input.current_color.unwrap_or({ r: 0, g: 0, b: 0 })
+  visual_classify_region(
+    input.region_type,
+    input.width,
+    input.height,
+    input.diff_pixel_count,
+    input.total_pixels,
+    has_sample,
+    baseline.r,
+    baseline.g,
+    baseline.b,
+    current.r,
+    current.g,
+    current.b,
+  )
+}
+
+///|
+pub fn is_likely_page_surface(input : Rgb) -> String {
+  visual_is_likely_page_surface(input.r, input.g, input.b)
+}
+
+///|
+pub struct RegionKindInput {
+  area : Int
+  aspect : Double
+  luma_std : Double
+  color_count : Int
+  stripe_rows : Int
+} derive(FromJson, ToJson)
+
+///|
+pub fn region_kind(input : RegionKindInput) -> String {
+  region_classify_kind(
+    input.area,
+    input.aspect,
+    input.luma_std,
+    input.color_count,
+    input.stripe_rows,
+  )
+}
+
+///|
+/// One drilldown candidate. Replaces three index-correlated parallel arrays.
+pub struct DrilldownCandidate {
+  flow : String
+  priority_score : Double
+  order : Int
+} derive(FromJson, ToJson)
+
+///|
+pub struct DrilldownSelectInput {
+  candidates : Array[DrilldownCandidate]
+} derive(FromJson, ToJson)
+
+///|
+pub fn drilldown_select_index(input : DrilldownSelectInput) -> Int {
+  let flows : Array[String] = []
+  let scores : Array[Double] = []
+  let orders : Array[Int] = []
+  for candidate in input.candidates {
+    flows.push(candidate.flow)
+    scores.push(candidate.priority_score)
+    orders.push(candidate.order)
+  }
+  semantic_drilldown_select_index(flows, scores, orders)
+}
+
+///|
+pub struct DrilldownPolicyInput {
+  layout_score : Double
+  decoration_score : Double
+  heatmap_kind_count : Int
+} derive(FromJson, ToJson)
+
+///|
+/// `flow|priority|reason_id` was three values in a string that TypeScript split, coerced
+/// and hand-validated against two literal unions, raising three different "unexpected
+/// markup-core …" errors when it did not like what it found. The types are known here.
+pub struct DrilldownPolicy {
+  flow : String
+  priority_score : Double
+  reason_id : String
+} derive(ToJson)
+
+///|
+pub fn drilldown_policy(input : DrilldownPolicyInput) -> DrilldownPolicy {
+  let flow = semantic_drilldown_flow(input.layout_score)
+  {
+    flow,
+    priority_score: semantic_drilldown_priority(
+      flow,
+      input.layout_score,
+      input.decoration_score,
+    ),
+    reason_id: semantic_drilldown_reason_id(flow, input.heatmap_kind_count),
+  }
+}
+
+///|
+/// Two pipe-joined lists in, one out. `Array[String]` in all three places.
+pub struct MergeProbeStatesInput {
+  explicit : Array[String]
+  injected : Array[String]
+} derive(FromJson, ToJson)
+
+///|
+pub fn merge_probe_states(input : MergeProbeStatesInput) -> Array[String] {
+  split_issue_ids(
+    merge_component_probe_states(
+      join_issue_ids(input.explicit),
+      join_issue_ids(input.injected),
+    ),
+  )
+}

--- a/packages/vlmkit-markup/src/markup-core-a11y-contrast.ts
+++ b/packages/vlmkit-markup/src/markup-core-a11y-contrast.ts
@@ -1,7 +1,7 @@
 /**
  * Thin TS wrapper over the MoonBit `a11y-contrast-*` policy commands.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, intOr } from "./markup-core-runtime.ts";
 
 export type WcagContrastLevel = "AAA" | "AA" | "AA-large" | "fail";
 
@@ -17,34 +17,27 @@ export function evaluateA11yContrast(input: {
   fontSize: number;
   fontWeight: number;
 }): A11yContrastEvaluation {
-  const out = runMarkupCore([
-    "a11y-contrast-evaluate",
-    intArg(input.foreground.r),
-    intArg(input.foreground.g),
-    intArg(input.foreground.b),
-    intArg(input.background.r),
-    intArg(input.background.g),
-    intArg(input.background.b),
-    doubleArg(input.fontSize),
-    intArg(input.fontWeight),
-  ]);
-  const [ratioStr, requiredStr, level] = out.split("|");
-  const ratio = Number(ratioStr);
-  const requiredAA = Number(requiredStr);
-  if (!Number.isFinite(ratio) || !Number.isFinite(requiredAA) || !isWcagLevel(level)) {
-    throw new Error(`markup-core a11y-contrast-evaluate unexpected: ${out}`);
+  // Two named colours, not six positional Ints. `fr fg fb br bg bb` could be
+  // exchanged in either direction and still parse, and contrast is symmetric enough
+  // that many swapped cases return the same answer while the ones that matter do not.
+  const out = callMarkupCoreJson<{ ratio: number; required_aa: number; level: string }>(
+    "contrast-evaluate",
+    {
+      foreground: { r: intOr(input.foreground.r), g: intOr(input.foreground.g), b: intOr(input.foreground.b) },
+      background: { r: intOr(input.background.r), g: intOr(input.background.g), b: intOr(input.background.b) },
+      font_size: finiteOr(input.fontSize),
+      font_weight: intOr(input.fontWeight),
+    },
+  );
+  // `level` is still checked: MoonBit types it `String`, so the literal union is a
+  // TypeScript-side claim either way. The two numbers are no longer parsed from text.
+  if (!isWcagLevel(out.level)) {
+    throw new Error(`markup-core contrast-evaluate unexpected level: ${JSON.stringify(out)}`);
   }
-  return { ratio, requiredAA, level };
+  return { ratio: out.ratio, requiredAA: out.required_aa, level: out.level };
 }
 
 function isWcagLevel(value: string): value is WcagContrastLevel {
   return value === "AAA" || value === "AA" || value === "AA-large" || value === "fail";
 }
 
-function intArg(value: number): string {
-  return String(Number.isFinite(value) ? Math.trunc(value) : 0);
-}
-
-function doubleArg(value: number): string {
-  return String(Number.isFinite(value) ? value : 0);
-}

--- a/packages/vlmkit-markup/src/markup-core-a11y-focus-order.ts
+++ b/packages/vlmkit-markup/src/markup-core-a11y-focus-order.ts
@@ -1,7 +1,7 @@
 /**
  * Thin TS wrapper over the MoonBit `focus-order-*` policy commands.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, flag } from "./markup-core-runtime.ts";
 
 export type FocusOrderTransition =
   | "trap"
@@ -15,14 +15,11 @@ export function classifyFocusOrderStep(input: {
   prev: { x: number; y: number };
   cur: { x: number; y: number };
 }): FocusOrderTransition {
-  const out = runMarkupCore([
-    "focus-order-classify",
-    input.samePath ? "true" : "false",
-    doubleArg(input.prev.x),
-    doubleArg(input.prev.y),
-    doubleArg(input.cur.x),
-    doubleArg(input.cur.y),
-  ]);
+  const out = callMarkupCoreJson<string>("focus-order-classify", {
+    same_path: flag(input.samePath),
+    previous: { x: finiteOr(input.prev.x), y: finiteOr(input.prev.y) },
+    current: { x: finiteOr(input.cur.x), y: finiteOr(input.cur.y) },
+  });
   if (isFocusOrderTransition(out)) return out;
   throw new Error(`markup-core focus-order-classify unexpected: ${out}`);
 }
@@ -37,6 +34,3 @@ function isFocusOrderTransition(value: string): value is FocusOrderTransition {
   );
 }
 
-function doubleArg(value: number): string {
-  return String(Number.isFinite(value) ? value : 0);
-}

--- a/packages/vlmkit-markup/src/markup-core-a11y-touch.ts
+++ b/packages/vlmkit-markup/src/markup-core-a11y-touch.ts
@@ -1,7 +1,7 @@
 /**
  * Thin TS wrapper over the MoonBit `a11y-touch-*` policy commands.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, runMarkupCore } from "./markup-core-runtime.ts";
 
 export type WcagTouchLevel = "AAA" | "AA";
 
@@ -22,16 +22,15 @@ export function touchTargetBelowRequired(minSide: number, level: WcagTouchLevel)
 }
 
 export function touchTargetInCluster(a: { x: number; y: number }, b: { x: number; y: number }): boolean {
-  const out = runMarkupCore([
-    "a11y-touch-in-cluster",
-    doubleArg(a.x),
-    doubleArg(a.y),
-    doubleArg(b.x),
-    doubleArg(b.y),
-  ]);
+  // Two named points. `ax ay bx by` as four positional Doubles has 12 wrong
+  // orderings that all parse and most of which still return a plausible answer.
+  const out = callMarkupCoreJson<string>("touch-in-cluster", {
+    a: { x: finiteOr(a.x), y: finiteOr(a.y) },
+    b: { x: finiteOr(b.x), y: finiteOr(b.y) },
+  });
   if (out === "true") return true;
   if (out === "false") return false;
-  throw new Error(`markup-core a11y-touch-in-cluster unexpected: ${out}`);
+  throw new Error(`markup-core touch-in-cluster unexpected: ${out}`);
 }
 
 function doubleArg(value: number): string {

--- a/packages/vlmkit-markup/src/markup-core-grid.ts
+++ b/packages/vlmkit-markup/src/markup-core-grid.ts
@@ -2,15 +2,11 @@
  * Thin TS wrapper over the MoonBit `grid-*` commands.
  * Used by `landscape-diff`'s neighbour `grid-ratio.ts`.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, intOr, runMarkupCore } from "./markup-core-runtime.ts";
 
 export function computeGridGcd(a: number, b: number): number {
-  const out = runMarkupCore(["grid-gcd", intArg(a), intArg(b)]);
-  const parsed = Number(out);
-  if (!Number.isInteger(parsed)) {
-    throw new Error(`markup-core grid-gcd returned non-integer: ${out}`);
-  }
-  return parsed;
+  // MoonBit returns an `Int`, so there is nothing to parse or re-check.
+  return callMarkupCoreJson<number>("grid-gcd", { a: intOr(a), b: intOr(b) });
 }
 
 export function computeGridAllEqual(widths: number[], tolerance: number): boolean {
@@ -23,13 +19,14 @@ export function computeGridAllEqual(widths: number[], tolerance: number): boolea
 }
 
 export function computeGridArraysClose(a: number[], b: number[], tolerance: number): boolean {
-  const out = runMarkupCore([
-    "grid-arrays-close",
-    encodeWidths(a),
-    encodeWidths(b),
-    doubleArg(tolerance),
-  ]);
-  return parseBool("grid-arrays-close", out);
+  // Numbers, not CSV. The comma-joined form could not carry a value containing a
+  // comma, needed a parser on the MoonBit side, and made "different lengths" —
+  // which the rule treats as not-close — look like a malformed string.
+  return callMarkupCoreJson<boolean>("grid-arrays-close", {
+    a: a.map((value) => finiteOr(value)),
+    b: b.map((value) => finiteOr(value)),
+    tolerance: finiteOr(tolerance),
+  });
 }
 
 export function computeGridRatiosToDecimal(widths: number[]): string {

--- a/packages/vlmkit-markup/src/markup-core-landscape.ts
+++ b/packages/vlmkit-markup/src/markup-core-landscape.ts
@@ -5,7 +5,7 @@
  * MoonBit ABI); MoonBit owns the cell-score formula, default grid
  * geometry, threshold counting, and top-N ranking.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, intOr, runMarkupCore } from "./markup-core-runtime.ts";
 
 export interface LandscapeGrid {
   cols: number;
@@ -42,28 +42,41 @@ export interface LandscapeDiffSummary {
   topIndices: LandscapeDiffSummaryEntry[];
 }
 
-const STAT_SEPARATOR = "|";
-const FIELD_SEPARATOR = ",";
+/**
+ * One cell, as a record.
+ *
+ * This replaced `"r,g,b,luma,ink"` joined by "," inside a list joined by "|" inside a
+ * tab-delimited argument — five positional fields, two nested delimiters, and a
+ * hand-written `idx == 0 / 1 / 2 / 3 / 4` parser on the MoonBit side. No cell value
+ * could contain a comma or a pipe, and nothing enforced that at any level.
+ */
+function cellPayload(cell: LandscapeCellStat): { r: number; g: number; b: number; l: number; ink: number } {
+  return {
+    r: finiteOr(cell.r),
+    g: finiteOr(cell.g),
+    b: finiteOr(cell.b),
+    // `luma` here, `l` across the boundary — the MoonBit rule's field name. Spelled out
+    // once, in the one place that knows both.
+    l: finiteOr(cell.luma),
+    ink: finiteOr(cell.ink),
+  };
+}
 
 export function computeLandscapeDefaultGrid(width: number, height: number): LandscapeGrid {
-  const out = runMarkupCore([
-    "landscape-default-grid",
-    intArg(width),
-    intArg(height),
-  ]);
-  const [cols, rows] = out.split("|");
-  const c = Number(cols);
-  const r = Number(rows);
-  if (!Number.isInteger(c) || !Number.isInteger(r)) {
-    throw new Error(`markup-core landscape-default-grid returned unparseable output: ${out}`);
-  }
-  return { cols: c, rows: r };
+  // `"cols|rows"` was two integers in a string. MoonBit types them, so the split and
+  // the two `Number.isInteger` re-checks are gone.
+  return callMarkupCoreJson<LandscapeGrid>("landscape-default-grid", {
+    width: intOr(width),
+    height: intOr(height),
+  });
 }
 
 export function computeLandscapeClampByte(value: number): number {
+  // Still positional, deliberately: one argument of one type, so there is no wiring
+  // bug available to make and a struct would buy nothing.
   const out = runMarkupCore([
     "landscape-clamp-byte",
-    doubleArg(value),
+    String(finiteOr(value)),
   ]);
   const parsed = Number(out);
   if (!Number.isInteger(parsed)) {
@@ -73,33 +86,20 @@ export function computeLandscapeClampByte(value: number): number {
 }
 
 export function computeLandscapeCellScore(baseline: LandscapeCellStat, current: LandscapeCellStat): number {
-  const out = runMarkupCore([
-    "landscape-cell-score",
-    doubleArg(baseline.r),
-    doubleArg(baseline.g),
-    doubleArg(baseline.b),
-    doubleArg(baseline.luma),
-    doubleArg(baseline.ink),
-    doubleArg(current.r),
-    doubleArg(current.g),
-    doubleArg(current.b),
-    doubleArg(current.luma),
-    doubleArg(current.ink),
-  ]);
-  const parsed = Number(out);
-  if (!Number.isFinite(parsed)) {
-    throw new Error(`markup-core landscape-cell-score returned non-finite: ${out}`);
-  }
-  return parsed;
+  // Ten mutually swappable Doubles were two five-field samples. Nesting removes the
+  // entire class of mistake — this was the worst case in the batch by that measure.
+  return callMarkupCoreJson<number>("landscape-cell-score", {
+    baseline: cellPayload(baseline),
+    current: cellPayload(current),
+  });
 }
 
 export function computeLandscapeCellHex(r: number, g: number, b: number): string {
-  return runMarkupCore([
-    "landscape-cell-hex",
-    doubleArg(r),
-    doubleArg(g),
-    doubleArg(b),
-  ]);
+  return callMarkupCoreJson<string>("landscape-cell-hex", {
+    r: finiteOr(r),
+    g: finiteOr(g),
+    b: finiteOr(b),
+  });
 }
 
 export function computeLandscapeDiffSummary(input: LandscapeDiffSummaryInput): LandscapeDiffSummary {
@@ -112,81 +112,31 @@ export function computeLandscapeDiffSummary(input: LandscapeDiffSummaryInput): L
       `markup-core landscape-diff-summary expected ${total} cells, got baseline=${input.baseline.length}, current=${input.current.length}`,
     );
   }
-  const out = runMarkupCore(
-    [
-      "landscape-diff-summary",
-      intArg(input.cols),
-      intArg(input.rows),
-      doubleArg(input.changedThreshold),
-      intArg(input.topN),
-      encodeStats(input.baseline),
-      encodeStats(input.current),
-    ],
-    { cache: false },
-  );
-  return parseSummary(out, total);
+  const summary = callMarkupCoreJson<{
+    mean: number;
+    similarity: number;
+    changed: number;
+    total: number;
+    top: { index: number; score: number }[];
+  }>("landscape-diff-summary", {
+    cols: intOr(input.cols),
+    rows: intOr(input.rows),
+    changed_threshold: finiteOr(input.changedThreshold),
+    top_n: intOr(input.topN),
+    baseline: input.baseline.map(cellPayload),
+    current: input.current.map(cellPayload),
+  });
+  // `parseSummary` was 36 lines and six distinct throw sites — a `|` split, four
+  // `Number()` coercions, a total-count cross-check, then a second split on ":" per top
+  // entry with two more validity checks. MoonBit typed all of it; none of it survives.
+  // A cell-count mismatch now raises from the handler and names the counts, instead of
+  // arriving as a `"mismatch|…"` string in the same shape as a successful result.
+  return {
+    score: summary.mean,
+    similarity: summary.similarity,
+    changedCells: summary.changed,
+    totalCells: summary.total,
+    topIndices: summary.top,
+  };
 }
 
-function parseSummary(raw: string, expectedTotal: number): LandscapeDiffSummary {
-  const parts = raw.split("|");
-  if (parts[0] === "mismatch") {
-    throw new Error(`markup-core landscape-diff-summary length mismatch: ${raw}`);
-  }
-  if (parts.length < 4) {
-    throw new Error(`markup-core landscape-diff-summary malformed output: ${raw}`);
-  }
-  const [scoreStr, similarityStr, changedStr, totalStr, ...rest] = parts;
-  const score = Number(scoreStr);
-  const similarity = Number(similarityStr);
-  const changedCells = Number(changedStr);
-  const totalCells = Number(totalStr);
-  if (![score, similarity, changedCells, totalCells].every(Number.isFinite)) {
-    throw new Error(`markup-core landscape-diff-summary non-finite scalars: ${raw}`);
-  }
-  if (totalCells !== expectedTotal) {
-    throw new Error(
-      `markup-core landscape-diff-summary total mismatch: expected=${expectedTotal}, got=${totalCells}`,
-    );
-  }
-  const topIndices: LandscapeDiffSummaryEntry[] = [];
-  for (const entry of rest) {
-    if (!entry) continue;
-    const sep = entry.indexOf(":");
-    if (sep < 0) {
-      throw new Error(`markup-core landscape-diff-summary malformed top entry: ${entry}`);
-    }
-    const idx = Number(entry.slice(0, sep));
-    const s = Number(entry.slice(sep + 1));
-    if (!Number.isInteger(idx) || !Number.isFinite(s)) {
-      throw new Error(`markup-core landscape-diff-summary unparseable top entry: ${entry}`);
-    }
-    topIndices.push({ index: idx, score: s });
-  }
-  return { score, similarity, changedCells, totalCells, topIndices };
-}
-
-function encodeStats(stats: LandscapeCellStat[]): string {
-  const out: string[] = [];
-  for (const cell of stats) {
-    out.push(
-      [
-        doubleArg(cell.r),
-        doubleArg(cell.g),
-        doubleArg(cell.b),
-        doubleArg(cell.luma),
-        doubleArg(cell.ink),
-      ].join(FIELD_SEPARATOR),
-    );
-  }
-  return out.join(STAT_SEPARATOR);
-}
-
-function doubleArg(value: number): string {
-  return String(Number.isFinite(value) ? value : 0);
-}
-
-function intArg(value: number | undefined): string {
-  return typeof value === "number" && Number.isFinite(value)
-    ? String(Math.trunc(value))
-    : "0";
-}

--- a/packages/vlmkit-markup/src/markup-core-migration.test.ts
+++ b/packages/vlmkit-markup/src/markup-core-migration.test.ts
@@ -333,17 +333,6 @@ function casesFor(command: CommandSpec): { label: string; values: (string | numb
 }
 
 describe("migrated commands match their positional arms", { timeout: 240_000 }, () => {
-  it("covers every command the JSON boundary claims, except the two with no positional twin", async () => {
-    // `interaction-issues` is new logic with no positional arm, and `goal-status`
-    // has its own dedicated differential test. Everything else must be here, or a
-    // migration could land with no comparison at all.
-    const { markupCoreJsonCommands } = await import("./markup-core-runtime.ts");
-    const covered = new Set(COMMANDS.map((c) => c.json));
-    const exempt = new Set(["interaction-issues", "goal-status"]);
-    const uncovered = markupCoreJsonCommands().filter((name) => !covered.has(name) && !exempt.has(name));
-    assert.deepEqual(uncovered, [], `migrated with no differential coverage: ${uncovered.join(", ")}`);
-  });
-
   for (const command of COMMANDS) {
     it(`${command.json} (${casesFor(command).length} cases)`, () => {
       const disagreements: string[] = [];
@@ -384,6 +373,454 @@ describe("migrated commands match their positional arms", { timeout: 240_000 }, 
  * These go through the public wrappers rather than `callMarkupCoreJson`, because the
  * normalisation lives in the wrappers and testing below it would test nothing.
  */
+/**
+ * The eighteen commands whose JSON form is NESTED, and therefore does not fit the flat
+ * `ArgSpec` table above.
+ *
+ * `{foreground: {r,g,b}, background: {r,g,b}}` is the entire point of migrating
+ * `a11y-contrast-evaluate` — six same-typed `Int`s in a row become two named colours —
+ * so a harness that could only describe flat payloads would have had to skip exactly the
+ * commands that most needed checking. Rather than bend `ArgSpec` into a path language,
+ * each command here owns its two encoders and reuses the same case generation. The
+ * `layout-policy` special case above set that precedent.
+ *
+ * `normalize` exists because several of these changed their OUTPUT shape too: the
+ * positional arms returned `"4.53|4.5|AA"`, `"cols|rows"`, `"flow|priority|reason"`, and
+ * the JSON handlers return records. Comparing them means saying, once and explicitly, how
+ * the record maps back to the joined string. That mapping is the migration's claim; if it
+ * is wrong, the test says so.
+ */
+interface NestedCommandSpec {
+  positional: string;
+  json: string;
+  /** Flat, for case generation only — the encoders below place the values. */
+  args: ArgSpec[];
+  toArgv(values: CaseValues): string[];
+  toPayload(values: CaseValues): unknown;
+  /** JSON result → the string the positional arm returns. Identity when unchanged. */
+  normalize(result: unknown): string;
+}
+
+type CaseValues = (string | number | boolean | readonly string[] | undefined)[];
+
+const num = (v: unknown): string => String(Number.isFinite(v as number) ? v : 0);
+const int = (v: unknown): string => String(Number.isFinite(v as number) ? Math.trunc(v as number) : 0);
+const asIs = (result: unknown): string => String(result);
+
+/** Colour channels sweep across the clamp boundaries the rules actually test. */
+const CHANNELS = [0, 128, 255] as const;
+const ch = (field: string): ArgSpec => ({ kind: "int", field, values: CHANNELS });
+
+const NESTED_COMMANDS: NestedCommandSpec[] = [
+  {
+    positional: "a11y-contrast-evaluate",
+    json: "contrast-evaluate",
+    args: [
+      ch("fr"), ch("fg"), ch("fb"), ch("br"), ch("bg"), ch("bb"),
+      { kind: "number", field: "font_size", values: [0, 13, 14, 18, 24] },
+      { kind: "int", field: "font_weight", values: [400, 700] },
+    ],
+    toArgv: (v) => ["a11y-contrast-evaluate", int(v[0]), int(v[1]), int(v[2]), int(v[3]), int(v[4]), int(v[5]), num(v[6]), int(v[7])],
+    toPayload: (v) => ({
+      foreground: { r: v[0], g: v[1], b: v[2] },
+      background: { r: v[3], g: v[4], b: v[5] },
+      font_size: v[6],
+      font_weight: v[7],
+    }),
+    normalize: (r) => {
+      const o = r as { ratio: number; required_aa: number; level: string };
+      // The positional arm formats to 2dp / 1dp before joining; compare on the
+      // formatted form rather than asserting the float round-trips exactly.
+      return `${o.ratio.toFixed(2)}|${o.required_aa.toFixed(1)}|${o.level}`;
+    },
+  },
+  {
+    positional: "a11y-touch-in-cluster",
+    json: "touch-in-cluster",
+    // Not `n(...)`: every NUMBERS value sits inside the cluster radius, so all 17
+    // cases returned "true" and the vacuity assertion caught it. These straddle it.
+    args: [
+      { kind: "number", field: "ax", values: [0, 5, 200] },
+      { kind: "number", field: "ay", values: [0, 5, 200] },
+      { kind: "number", field: "bx", values: [0, 5, 200] },
+      { kind: "number", field: "by", values: [0, 5, 200] },
+    ],
+    toArgv: (v) => ["a11y-touch-in-cluster", num(v[0]), num(v[1]), num(v[2]), num(v[3])],
+    toPayload: (v) => ({ a: { x: v[0], y: v[1] }, b: { x: v[2], y: v[3] } }),
+    normalize: asIs,
+  },
+  {
+    positional: "focus-order-classify",
+    json: "focus-order-classify",
+    args: [b("same_path"), n("prev_x"), n("prev_y"), n("cur_x"), n("cur_y")],
+    toArgv: (v) => ["focus-order-classify", String(v[0]), num(v[1]), num(v[2]), num(v[3]), num(v[4])],
+    toPayload: (v) => ({ same_path: v[0], previous: { x: v[1], y: v[2] }, current: { x: v[3], y: v[4] } }),
+    normalize: asIs,
+  },
+  {
+    positional: "grid-arrays-close",
+    json: "grid-arrays-close",
+    args: [
+      { kind: "list", field: "a", values: [[], ["10"], ["10", "20"], ["10", "20", "30"]] },
+      { kind: "list", field: "b", values: [[], ["10"], ["10", "20.05"], ["10", "99"]] },
+      n("tolerance"),
+    ],
+    // The positional form is CSV, not pipe-joined — a different sub-encoding again.
+    toArgv: (v) => ["grid-arrays-close", (v[0] as string[]).join(","), (v[1] as string[]).join(","), num(v[2])],
+    toPayload: (v) => ({
+      a: (v[0] as string[]).map(Number),
+      b: (v[1] as string[]).map(Number),
+      tolerance: v[2],
+    }),
+    normalize: asIs,
+  },
+  {
+    positional: "grid-gcd",
+    json: "grid-gcd",
+    args: [{ kind: "int", field: "a", values: [0, 1, 24, -36] }, { kind: "int", field: "b", values: [0, 1, 36, -24] }],
+    toArgv: (v) => ["grid-gcd", int(v[0]), int(v[1])],
+    toPayload: (v) => ({ a: v[0], b: v[1] }),
+    normalize: asIs,
+  },
+  {
+    positional: "shift-classify-suspect",
+    json: "shift-classify-suspect",
+    // Base first, and non-degenerate: with 0 first, both deltas sat at 0 in every case
+    // and the rule returned one class throughout.
+    args: [
+      { kind: "number", field: "abs_height_delta", values: [20, 0, 3, 1.5] },
+      { kind: "number", field: "abs_top_delta", values: [3, 0, 20, 1.5] },
+    ],
+    toArgv: (v) => ["shift-classify-suspect", num(v[0]), num(v[1])],
+    toPayload: (v) => ({ abs_height_delta: v[0], abs_top_delta: v[1] }),
+    normalize: asIs,
+  },
+  {
+    positional: "quality-error-state-kind",
+    json: "quality-error-state-kind",
+    args: [
+      { kind: "number", field: "red_ratio", values: [0, 0.005, 0.05, 0.5] },
+      { kind: "number", field: "yellow_ratio", values: [0, 0.005, 0.05, 0.5] },
+    ],
+    toArgv: (v) => ["quality-error-state-kind", num(v[0]), num(v[1])],
+    toPayload: (v) => ({ red_ratio: v[0], yellow_ratio: v[1] }),
+    normalize: asIs,
+  },
+  {
+    positional: "quality-coverage-passed",
+    json: "quality-coverage-passed",
+    args: [
+      { kind: "int", field: "covered", values: [0, 7, 8, 10] },
+      { kind: "int", field: "total", values: [0, 10] },
+    ],
+    toArgv: (v) => ["quality-coverage-passed", int(v[0]), int(v[1])],
+    toPayload: (v) => ({ covered: v[0], total: v[1] }),
+    normalize: asIs,
+  },
+  {
+    positional: "landscape-cell-score",
+    json: "landscape-cell-score",
+    args: [n("r1"), n("g1"), n("b1"), n("l1"), n("i1"), n("r2"), n("g2"), n("b2"), n("l2"), n("i2")],
+    toArgv: (v) => ["landscape-cell-score", ...v.map(num)],
+    toPayload: (v) => ({
+      baseline: { r: v[0], g: v[1], b: v[2], l: v[3], ink: v[4] },
+      current: { r: v[5], g: v[6], b: v[7], l: v[8], ink: v[9] },
+    }),
+    normalize: asIs,
+  },
+  {
+    positional: "landscape-cell-hex",
+    json: "landscape-cell-hex",
+    args: [
+      { kind: "number", field: "r", values: [-5, 0, 128, 255, 300] },
+      { kind: "number", field: "g", values: [-5, 0, 128, 255, 300] },
+      { kind: "number", field: "b", values: [-5, 0, 128, 255, 300] },
+    ],
+    toArgv: (v) => ["landscape-cell-hex", num(v[0]), num(v[1]), num(v[2])],
+    toPayload: (v) => ({ r: v[0], g: v[1], b: v[2] }),
+    normalize: asIs,
+  },
+  {
+    positional: "landscape-default-grid",
+    json: "landscape-default-grid",
+    args: [
+      // Non-zero FIRST. The rule returns 0|0 unless both dimensions are positive, and
+      // single-argument variation holds the other at the base — so a 0 base made every
+      // case return 0|0 and tested nothing.
+      { kind: "int", field: "width", values: [1280, 0, 720] },
+      { kind: "int", field: "height", values: [720, 0, 1280] },
+    ],
+    toArgv: (v) => ["landscape-default-grid", int(v[0]), int(v[1])],
+    toPayload: (v) => ({ width: v[0], height: v[1] }),
+    normalize: (r) => {
+      const o = r as { cols: number; rows: number };
+      return `${o.cols}|${o.rows}`;
+    },
+  },
+  {
+    positional: "visual-classify-region",
+    json: "visual-classify-region",
+    args: [
+      disc("region_type", ["text", "block", "unknown"]),
+      { kind: "int", field: "width", values: [0, 20, 100] },
+      { kind: "int", field: "height", values: [0, 20, 100] },
+      { kind: "int", field: "diff_pixel_count", values: [0, 50, 2000] },
+      { kind: "int", field: "total_pixels", values: [0, 2000] },
+      { kind: "bool", field: "has_color_sample", values: BOOLS },
+      ch("baseline_r"), ch("baseline_g"), ch("baseline_b"),
+      ch("current_r"), ch("current_g"), ch("current_b"),
+    ],
+    toArgv: (v) => ["visual-classify-region", String(v[0]), int(v[1]), int(v[2]), int(v[3]), int(v[4]),
+      String(v[5]), int(v[6]), int(v[7]), int(v[8]), int(v[9]), int(v[10]), int(v[11])],
+    toPayload: (v) => ({
+      region_type: v[0],
+      width: v[1],
+      height: v[2],
+      diff_pixel_count: v[3],
+      total_pixels: v[4],
+      // `has_color_sample` becomes the presence of the two colours — the reconstruction
+      // this migration introduced, so the sweep must cross it with both values.
+      ...(v[5]
+        ? {
+          baseline_color: { r: v[6], g: v[7], b: v[8] },
+          current_color: { r: v[9], g: v[10], b: v[11] },
+        }
+        : {}),
+    }),
+    normalize: asIs,
+  },
+  {
+    positional: "visual-is-likely-page-surface",
+    json: "visual-is-likely-page-surface",
+    args: [ch("r"), ch("g"), ch("b")],
+    toArgv: (v) => ["visual-is-likely-page-surface", int(v[0]), int(v[1]), int(v[2])],
+    toPayload: (v) => ({ r: v[0], g: v[1], b: v[2] }),
+    normalize: asIs,
+  },
+  {
+    positional: "region-classify-kind",
+    json: "region-classify-kind",
+    args: [
+      { kind: "int", field: "area", values: [0, 200, 5000] },
+      { kind: "number", field: "aspect", values: [0.2, 1, 4.5] },
+      { kind: "number", field: "luma_std", values: [0, 20, 60] },
+      { kind: "int", field: "color_count", values: [0, 2, 12] },
+      { kind: "int", field: "stripe_rows", values: [0, 3] },
+    ],
+    toArgv: (v) => ["region-classify-kind", int(v[0]), num(v[1]), num(v[2]), int(v[3]), int(v[4])],
+    toPayload: (v) => ({ area: v[0], aspect: v[1], luma_std: v[2], color_count: v[3], stripe_rows: v[4] }),
+    normalize: asIs,
+  },
+  {
+    positional: "semantic-drilldown-select-index",
+    json: "semantic-drilldown-select-index",
+    // Three index-correlated parallel arrays became one array of records. The values
+    // below keep them the same length, because a length mismatch is the bug the record
+    // form makes unrepresentable rather than a behaviour to compare.
+    args: [
+      // Populated FIRST: with `[]` at base, every single-argument variation had at least
+      // one empty array, `Math.min` truncated the candidate list to zero, and the rule
+      // never chose anything.
+      { kind: "list", field: "flows", values: [["layout", "decoration"], [], ["layout"], ["decoration", "layout"]] },
+      { kind: "list", field: "priority_scores", values: [["0.2", "0.9"], [], ["0.2"], ["0.9", "0.2"]] },
+      { kind: "list", field: "orders", values: [["1", "0"], [], ["0"], ["0", "1"]] },
+    ],
+    toArgv: (v) => ["semantic-drilldown-select-index",
+      (v[0] as string[]).join("|"), (v[1] as string[]).join("|"), (v[2] as string[]).join("|")],
+    toPayload: (v) => {
+      const flows = v[0] as string[];
+      const scores = v[1] as string[];
+      const orders = v[2] as string[];
+      const length = Math.min(flows.length, scores.length, orders.length);
+      return {
+        candidates: Array.from({ length }, (_, i) => ({
+          flow: flows[i],
+          priority_score: Number(scores[i]),
+          order: Number(orders[i]),
+        })),
+      };
+    },
+    normalize: asIs,
+  },
+  {
+    positional: "semantic-drilldown-policy",
+    json: "semantic-drilldown-policy",
+    args: [
+      { kind: "number", field: "layout_score", values: [0, 0.3, 0.8] },
+      { kind: "number", field: "decoration_score", values: [0, 0.2, 0.9] },
+      { kind: "int", field: "heatmap_kind_count", values: [0, 1, 3] },
+    ],
+    toArgv: (v) => ["semantic-drilldown-policy", num(v[0]), num(v[1]), int(v[2])],
+    toPayload: (v) => ({ layout_score: v[0], decoration_score: v[1], heatmap_kind_count: v[2] }),
+    normalize: (r) => {
+      const o = r as { flow: string; priority_score: number; reason_id: string };
+      return `${o.flow}|${o.priority_score}|${o.reason_id}`;
+    },
+  },
+  {
+    positional: "merge-component-probe-states",
+    json: "merge-component-probe-states",
+    args: [
+      { kind: "list", field: "explicit", values: [[], ["hover"], ["hover", "focus"]] },
+      { kind: "list", field: "injected", values: [[], ["hover"], ["scrolled", "hover"]] },
+    ],
+    toArgv: (v) => ["merge-component-probe-states", (v[0] as string[]).join("|"), (v[1] as string[]).join("|")],
+    toPayload: (v) => ({ explicit: v[0], injected: v[1] }),
+    normalize: (r) => (r as string[]).join("|"),
+  },
+];
+
+describe("nested-payload commands match their positional arms", { timeout: 300_000 }, () => {
+  it("covers every nested command the JSON boundary claims", async () => {
+    const { markupCoreJsonCommands } = await import("./markup-core-runtime.ts");
+    const covered = new Set([
+      ...COMMANDS.map((c) => c.json),
+      ...NESTED_COMMANDS.map((c) => c.json),
+    ]);
+    // `landscape-diff-summary` has its own test: its positional twin takes a
+    // sub-encoded stat blob and returns a "mismatch|..." sentinel instead of raising,
+    // so the two are not comparable case-for-case. See below.
+    const exempt = new Set(["interaction-issues", "goal-status", "landscape-diff-summary"]);
+    const uncovered = markupCoreJsonCommands().filter((name) => !covered.has(name) && !exempt.has(name));
+    assert.deepEqual(uncovered, [], `migrated with no differential coverage: ${uncovered.join(", ")}`);
+  });
+
+  for (const command of NESTED_COMMANDS) {
+    const cases = casesFor(command as unknown as CommandSpec);
+    it(`${command.json} (${cases.length} cases)`, () => {
+      const disagreements: string[] = [];
+      const results = new Set<string>();
+      for (const { label, values } of cases) {
+        const reference = runMarkupCore(command.toArgv(values));
+        const migrated = callMarkupCoreJson<unknown>(command.json, command.toPayload(values));
+        const normalized = command.normalize(migrated);
+        if (reference !== normalized) {
+          disagreements.push(`${label}: positional=${JSON.stringify(reference)} json=${JSON.stringify(normalized)}`);
+        }
+        results.add(normalized);
+      }
+      assert.deepEqual(disagreements, []);
+      assert.ok(results.size >= 2, `${command.json}: every case returned ${[...results][0]}`);
+    });
+  }
+});
+
+/**
+ * `landscape-diff-summary`, which needs its own comparison for two reasons.
+ *
+ * **Its input carried a second positional encoding.** `baseline_stats` was one string
+ * holding `"r,g,b,l,ink|r,g,b,l,ink|…"` — five positional fields per cell, comma
+ * delimited, inside a pipe-delimited list, inside a tab-delimited argument list, parsed
+ * by an `idx == 0 / 1 / 2 / 3 / 4` chain. So the generic table's `toArgv` / `toPayload`
+ * pair is not a re-ordering here, it is a whole encoder, and the cases have to be built
+ * from cell records rather than from scalar sweeps.
+ *
+ * **Its error path changed deliberately.** The positional arm returns
+ * `"mismatch|<total>|<base>|<curr>"` — a success-shaped string a caller must sniff — with
+ * a comment saying it does so "rather than raising, so the FFI surface stays string-only".
+ * The JSON handler raises. That is the one intended behaviour difference in this batch, so
+ * it is asserted rather than swept: agreement on well-formed input, and a raise where the
+ * old form returned a sentinel.
+ */
+describe("landscape-diff-summary matches its positional arm", { timeout: 120_000 }, () => {
+  interface Cell { r: number; g: number; b: number; l: number; ink: number }
+
+  const encodeStats = (cells: Cell[]): string =>
+    cells.map((c) => [c.r, c.g, c.b, c.l, c.ink].join(",")).join("|");
+
+  /** Deterministic cells; `seed` shifts them so baseline and current differ per case. */
+  const cellsFor = (count: number, seed: number): Cell[] =>
+    Array.from({ length: count }, (_, i) => ({
+      r: (i * 37 + seed * 11) % 256,
+      g: (i * 53 + seed * 29) % 256,
+      b: (i * 71 + seed * 17) % 256,
+      l: (i * 43 + seed * 23) % 256,
+      ink: ((i * 13 + seed * 7) % 100) / 100,
+    }));
+
+  const GRIDS = [
+    { cols: 1, rows: 1 },
+    { cols: 2, rows: 1 },
+    { cols: 4, rows: 4 },
+    { cols: 3, rows: 5 },
+  ];
+  const THRESHOLDS = [0, 0.05, 0.5, 1];
+  const TOP_NS = [0, 1, 3, 100];
+
+  it("agrees on mean, similarity, changed, total and the top-cell list", () => {
+    const disagreements: string[] = [];
+    let compared = 0;
+    for (const { cols, rows } of GRIDS) {
+      for (const threshold of THRESHOLDS) {
+        for (const topN of TOP_NS) {
+          const total = cols * rows;
+          const baseline = cellsFor(total, 1);
+          const current = cellsFor(total, 5);
+          const reference = runMarkupCore([
+            "landscape-diff-summary",
+            String(cols), String(rows), String(threshold), String(topN),
+            encodeStats(baseline), encodeStats(current),
+          ], { cache: false });
+          const migrated = callMarkupCoreJson<{
+            mean: number; similarity: number; changed: number; total: number;
+            top: { index: number; score: number }[];
+          }>("landscape-diff-summary", {
+            cols, rows, changed_threshold: threshold, top_n: topN, baseline, current,
+          });
+          // Rebuild the joined form the positional arm returns. Stated here rather than
+          // hidden in a helper, because this mapping IS the migration's output claim.
+          const normalized = [
+            String(migrated.mean),
+            String(migrated.similarity),
+            String(migrated.changed),
+            String(migrated.total),
+            ...migrated.top.map((cell) => `${cell.index}:${cell.score}`),
+          ].join("|");
+          compared++;
+          if (reference !== normalized) {
+            disagreements.push(
+              `${cols}x${rows} threshold=${threshold} top=${topN}: positional=${reference} json=${normalized}`,
+            );
+          }
+        }
+      }
+    }
+    assert.deepEqual(disagreements, []);
+    assert.equal(compared, GRIDS.length * THRESHOLDS.length * TOP_NS.length);
+  });
+
+  it("raises on a cell-count mismatch where the positional arm returned a sentinel", () => {
+    const short = cellsFor(3, 1);
+    const reference = runMarkupCore([
+      "landscape-diff-summary", "2", "2", "0.1", "2",
+      encodeStats(short), encodeStats(cellsFor(4, 2)),
+    ], { cache: false });
+    // The old contract: an error delivered as data, in the same shape as a result.
+    assert.match(reference, /^mismatch\|4\|3\|4$/);
+
+    assert.throws(
+      () => callMarkupCoreJson("landscape-diff-summary", {
+        cols: 2, rows: 2, changed_threshold: 0.1, top_n: 2,
+        baseline: short, current: cellsFor(4, 2),
+      }),
+      /cell count mismatch: expected 4 \(2x2\), baseline has 3, current has 4/,
+      "the raise must name the counts — the sentinel's only virtue was carrying them",
+    );
+  });
+
+  it("returns the empty-grid result for a zero-cell grid, as the positional arm does", () => {
+    const reference = runMarkupCore([
+      "landscape-diff-summary", "0", "0", "0.1", "2", "", "",
+    ], { cache: false });
+    assert.equal(reference, "1|0|0|0");
+    const migrated = callMarkupCoreJson<{ mean: number; similarity: number; changed: number; total: number }>(
+      "landscape-diff-summary",
+      { cols: 0, rows: 0, changed_threshold: 0.1, top_n: 2, baseline: [], current: [] },
+    );
+    assert.deepEqual(migrated, { mean: 1, similarity: 0, changed: 0, total: 0, top: [] });
+  });
+});
+
 describe("migrated wrappers survive malformed input", { timeout: 240_000 }, () => {
   const viewport = (width: unknown) =>
     computeUiContractViewportIssueIds({

--- a/packages/vlmkit-markup/src/markup-core-quality.ts
+++ b/packages/vlmkit-markup/src/markup-core-quality.ts
@@ -1,7 +1,7 @@
 /**
  * Thin TS wrapper over the MoonBit `quality-*` policy commands.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, intOr, runMarkupCore } from "./markup-core-runtime.ts";
 
 export type QualityErrorStateKind = "error" | "warning" | "none";
 
@@ -9,24 +9,19 @@ export function computeQualityErrorStateKind(
   redRatio: number,
   yellowRatio: number,
 ): QualityErrorStateKind {
-  const out = runMarkupCore([
-    "quality-error-state-kind",
-    doubleArg(redRatio),
-    doubleArg(yellowRatio),
-  ]);
+  const out = callMarkupCoreJson<string>("quality-error-state-kind", {
+    red_ratio: finiteOr(redRatio),
+    yellow_ratio: finiteOr(yellowRatio),
+  });
   if (out === "error" || out === "warning" || out === "none") return out;
   throw new Error(`markup-core quality-error-state-kind unexpected: ${out}`);
 }
 
 export function computeQualityCoveragePassed(covered: number, total: number): boolean {
-  const out = runMarkupCore([
-    "quality-coverage-passed",
-    intArg(covered),
-    intArg(total),
-  ]);
-  if (out === "true") return true;
-  if (out === "false") return false;
-  throw new Error(`markup-core quality-coverage-passed unexpected: ${out}`);
+  return callMarkupCoreJson<boolean>("quality-coverage-passed", {
+    covered: intOr(covered),
+    total: intOr(total),
+  });
 }
 
 export type QualityDiffSeverity = "large" | "small";
@@ -44,6 +39,3 @@ function doubleArg(value: number): string {
   return String(Number.isFinite(value) ? value : 0);
 }
 
-function intArg(value: number): string {
-  return String(Number.isFinite(value) ? Math.trunc(value) : 0);
-}

--- a/packages/vlmkit-markup/src/markup-core-region-classify.ts
+++ b/packages/vlmkit-markup/src/markup-core-region-classify.ts
@@ -1,7 +1,7 @@
 /**
  * Thin TS wrapper over the MoonBit `region-classify-*` policy commands.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, intOr } from "./markup-core-runtime.ts";
 
 export type RegionKind = "text" | "filled-rect" | "icon" | "image" | "unknown";
 
@@ -17,14 +17,13 @@ export function regionClassifyKind(input: {
   colorCount: number;
   stripeRows: number;
 }): RegionKindResult {
-  const out = runMarkupCore([
-    "region-classify-kind",
-    intArg(input.area),
-    doubleArg(input.aspect),
-    doubleArg(input.lumaStd),
-    intArg(input.colorCount),
-    intArg(input.stripeRows),
-  ]);
+  const out = callMarkupCoreJson<string>("region-classify-kind", {
+    area: intOr(input.area),
+    aspect: finiteOr(input.aspect),
+    luma_std: finiteOr(input.lumaStd),
+    color_count: intOr(input.colorCount),
+    stripe_rows: intOr(input.stripeRows),
+  });
   const [kind, confidence] = out.split("|");
   const parsed = Number(confidence);
   if (!isRegionKind(kind) || !Number.isFinite(parsed)) {
@@ -43,10 +42,3 @@ function isRegionKind(value: string): value is RegionKind {
   );
 }
 
-function intArg(value: number): string {
-  return String(Number.isFinite(value) ? Math.trunc(value) : 0);
-}
-
-function doubleArg(value: number): string {
-  return String(Number.isFinite(value) ? value : 0);
-}

--- a/packages/vlmkit-markup/src/markup-core-runtime.ts
+++ b/packages/vlmkit-markup/src/markup-core-runtime.ts
@@ -202,12 +202,18 @@ export function callMarkupCoreJson<TOut>(command: string, input: unknown): TOut 
  * `Missing field width`. **The one input a validator has to survive is an invalid
  * document.**
  *
+ * Exported because the per-domain wrapper modules (`markup-core-a11y-*`,
+ * `markup-core-landscape.ts`, …) each had their own private copy of the old
+ * `doubleArg` / `intArg`. Those normalised on the way to a string; on the JSON path
+ * the normalisation has to happen before serializing instead, and having six
+ * near-identical private copies is how one of them ends up different.
+ *
  * This is normalisation, not coercion: a missing number becomes the same `0` the
  * old wire sent, so the rule sees what it always saw and reports what it always
  * reported. Nothing is silently reinterpreted — a string `"1280"` becomes `0` and
  * is reported as non-positive, exactly as before.
  */
-function finiteOr(value: unknown, fallback = 0): number {
+export function finiteOr(value: unknown, fallback = 0): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
@@ -217,12 +223,12 @@ function optionalFinite(value: unknown): number | undefined {
 }
 
 /** `intArg`'s truncation, kept because MoonBit's `Int` would reject a fraction. */
-function intOr(value: unknown, fallback = 0): number {
+export function intOr(value: unknown, fallback = 0): number {
   return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : fallback;
 }
 
 /** `boolArg`: anything not a boolean was `false` on the wire. */
-function flag(value: unknown): boolean {
+export function flag(value: unknown): boolean {
   return value === true;
 }
 

--- a/packages/vlmkit-markup/src/markup-core-runtime.ts
+++ b/packages/vlmkit-markup/src/markup-core-runtime.ts
@@ -31,6 +31,17 @@ const directArgSeparator = "\t";
 const directEmptyArg = "__VLMKIT_EMPTY_ARG__";
 const injectedDirectModuleKey = "__MIZCHI_VLMKIT_MARKUP_CORE_API__";
 let directModule: DirectMarkupCoreModule | undefined;
+/**
+ * Where `directModule` came from, which decides what a MISSING entry point means.
+ *
+ * From `"generated"` (this workspace, read off disk) a missing function can be a stale
+ * `_build`, and building then retrying is the right response. From `"injected"` — the
+ * bundled CLI handing over its statically-imported bridge — it cannot be stale: it is
+ * whatever the bundle contains, there is no MoonBit toolchain to rebuild with, and
+ * `moon build` is precisely what the injection exists to avoid. Conflating the two is
+ * what let a broken JSON boundary ship looking healthy.
+ */
+let directModuleSource: "injected" | "generated" | undefined;
 let directModuleUnavailable = false;
 let runtimeBackend: "direct-js" | "spawn" = "spawn";
 
@@ -275,6 +286,20 @@ function runMarkupCoreJsonRaw(command: string, payload: string): string {
   };
   const first = direct();
   if (first !== undefined) return first;
+  // An injected API that lacks the JSON entry point is a PACKAGING bug, and the two
+  // fallbacks below are both wrong for it: `moon build` needs a toolchain the injection
+  // exists to avoid, and the spawned CLI needs a `_build` the root package does not ship.
+  // Silently trying them is how this shipped broken — the CLI kept answering positional
+  // commands, so only a JSON command failed, and only outside the workspace. Say what is
+  // actually wrong instead.
+  if (directModuleSource === "injected") {
+    throw new Error(
+      `markup-core JSON command "${command}" is unavailable: the injected markup-core API `
+      + "has no run_markup_core_json. The bundled entrypoint (scripts/vlmkit-bundled.mjs) "
+      + "must hand over the whole generated bridge, and the bridge must be rebuilt after "
+      + "adding a JSON entry point. This is a build/packaging fault, not a bad payload.",
+    );
+  }
   ensureMarkupCoreCli();
   const second = direct();
   if (second !== undefined) return second;
@@ -285,7 +310,7 @@ function runMarkupCoreJsonRaw(command: string, payload: string): string {
 /** Commands the MoonBit side accepts, for a test that the two views agree. */
 export function markupCoreJsonCommands(): string[] {
   const api = loadMarkupCoreApi();
-  if (!api?.markup_core_json_commands) {
+  if (!api?.markup_core_json_commands && directModuleSource !== "injected") {
     ensureMarkupCoreCli();
   }
   const loaded = loadMarkupCoreApi();
@@ -348,6 +373,7 @@ function loadMarkupCoreApi(): DirectMarkupCoreModule | undefined {
   )[injectedDirectModuleKey];
   if (typeof injected?.run_markup_core === "function") {
     directModule = pickDirectApi(injected);
+    directModuleSource = "injected";
     return directModule;
   }
   if (directModuleUnavailable) return undefined;
@@ -355,6 +381,7 @@ function loadMarkupCoreApi(): DirectMarkupCoreModule | undefined {
     const loaded = requireGenerated(apiPath) as Partial<DirectMarkupCoreModule>;
     if (typeof loaded.run_markup_core === "function") {
       directModule = pickDirectApi(loaded);
+      directModuleSource = "generated";
       return directModule;
     }
   } catch {

--- a/packages/vlmkit-markup/src/markup-core-shift.ts
+++ b/packages/vlmkit-markup/src/markup-core-shift.ts
@@ -1,7 +1,7 @@
 /**
  * Thin TS wrapper over the MoonBit `shift-*` policy commands.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, finiteOr, runMarkupCore } from "./markup-core-runtime.ts";
 
 export function computeShiftRoundDelta(value: number): number {
   const out = runMarkupCore(["shift-round-delta", doubleArg(value)]);
@@ -18,11 +18,10 @@ export function computeShiftClassifySuspect(
   absHeightDelta: number,
   absTopDelta: number,
 ): ShiftSuspectedAxis {
-  const out = runMarkupCore([
-    "shift-classify-suspect",
-    doubleArg(absHeightDelta),
-    doubleArg(absTopDelta),
-  ]);
+  const out = callMarkupCoreJson<string>("shift-classify-suspect", {
+    abs_height_delta: finiteOr(absHeightDelta),
+    abs_top_delta: finiteOr(absTopDelta),
+  });
   if (out === "height" || out === "margin/padding-above" || out === "y-position") {
     return out;
   }

--- a/packages/vlmkit-markup/src/markup-core-visual-semantic.ts
+++ b/packages/vlmkit-markup/src/markup-core-visual-semantic.ts
@@ -1,7 +1,7 @@
 /**
  * Thin TS wrapper over the MoonBit `visual-*` policy commands.
  */
-import { runMarkupCore } from "./markup-core-runtime.ts";
+import { callMarkupCoreJson, intOr, runMarkupCore } from "./markup-core-runtime.ts";
 import type { VisualChangeType } from "@mizchi/vlmkit-core/types.ts";
 
 export interface VisualClassifyInput {
@@ -22,23 +22,23 @@ export interface VisualClassifyResult {
 }
 
 export function classifyRegionPolicy(input: VisualClassifyInput): VisualClassifyResult {
-  const baseline = input.colorSample?.baseline ?? { r: 0, g: 0, b: 0 };
-  const current = input.colorSample?.current ?? { r: 0, g: 0, b: 0 };
-  const out = runMarkupCore([
-    "visual-classify-region",
-    input.regionType === "shift" ? "shift" : "",
-    intArg(input.width),
-    intArg(input.height),
-    intArg(input.diffPixelCount),
-    intArg(input.totalPixels),
-    boolArg(Boolean(input.colorSample)),
-    intArg(baseline.r),
-    intArg(baseline.g),
-    intArg(baseline.b),
-    intArg(current.r),
-    intArg(current.g),
-    intArg(current.b),
-  ]);
+  // `colorSample` is already optional in this interface, and the positional wire
+  // flattened it into `has_color_sample` plus six numbers that meant nothing when the
+  // flag was false. `Rgb?` carries the same thing the TypeScript type always said.
+  const rgb = (c: { r: number; g: number; b: number }) => ({ r: intOr(c.r), g: intOr(c.g), b: intOr(c.b) });
+  const out = callMarkupCoreJson<string>("visual-classify-region", {
+    region_type: input.regionType === "shift" ? "shift" : "",
+    width: intOr(input.width),
+    height: intOr(input.height),
+    diff_pixel_count: intOr(input.diffPixelCount),
+    total_pixels: intOr(input.totalPixels),
+    ...(input.colorSample
+      ? {
+        baseline_color: rgb(input.colorSample.baseline),
+        current_color: rgb(input.colorSample.current),
+      }
+      : {}),
+  });
   const [type, confidence] = out.split("|");
   const parsed = Number(confidence);
   if (!isVisualChangeType(type) || !Number.isFinite(parsed)) {
@@ -48,12 +48,11 @@ export function classifyRegionPolicy(input: VisualClassifyInput): VisualClassify
 }
 
 export function isLikelyPageSurface(color: { r: number; g: number; b: number }): boolean {
-  const out = runMarkupCore([
-    "visual-is-likely-page-surface",
-    intArg(color.r),
-    intArg(color.g),
-    intArg(color.b),
-  ]);
+  const out = callMarkupCoreJson<string>("visual-is-likely-page-surface", {
+    r: intOr(color.r),
+    g: intOr(color.g),
+    b: intOr(color.b),
+  });
   if (out === "true") return true;
   if (out === "false") return false;
   throw new Error(`markup-core visual-is-likely-page-surface unexpected: ${out}`);
@@ -83,10 +82,4 @@ function isVisualChangeType(value: string): value is VisualChangeType {
   );
 }
 
-function intArg(value: number): string {
-  return String(Number.isFinite(value) ? Math.trunc(value) : 0);
-}
 
-function boolArg(value: boolean): string {
-  return value ? "true" : "false";
-}

--- a/scripts/smoke-bundled-json.mjs
+++ b/scripts/smoke-bundled-json.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * The built CLI must answer a JSON-boundary command with no MoonBit toolchain present.
+ *
+ * This is the one environment nothing else tested, and the one every npm consumer of the
+ * `vlmkit` CLI is in. The root package ships `dist/**` and nothing else: no `_build`, no
+ * `.mbt` sources. So the CLI's only route to MoonBit is the bridge that
+ * `scripts/vlmkit-bundled.mjs` imports and hands over on a global — and if that hand-off
+ * is incomplete, every fallback the runtime has is also unavailable here. `moon build`
+ * needs a toolchain; the spawned `markup-core-cli` needs the `_build` that is not shipped.
+ *
+ * It shipped broken exactly once, and the shape of the miss is worth keeping in mind:
+ *
+ *  - `pnpm test` runs from **source**, where the runtime finds the bridge on disk through
+ *    `apiPath` and never reads the global. Green.
+ *  - `smoke:pack:workspaces` installs the **library** packages, and
+ *    `@mizchi/vlmkit-markup` *does* ship `_build/.../markup-core-api.js`. Green.
+ *  - The type checker cannot help: the global is assigned in a `.mjs` file to a
+ *    `Partial<DirectMarkupCoreModule>`, where a missing field is legal.
+ *
+ * Every safety net was in a different room. So this one deliberately reproduces the
+ * consumer's constraints instead of approximating them: run the built entrypoint with
+ * `moon` removed from PATH, and require a gate that goes through the JSON boundary to
+ * succeed. With `moon` gone, a silent fallback cannot pretend to work — it fails, which is
+ * the point.
+ *
+ * Assert on a gate rather than on the presence of a symbol, because "the name is exported"
+ * is what the unit test already covers and is not the same claim as "the CLI works".
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const CLI = join(REPO_ROOT, "dist", "vlmkit.mjs");
+const FIXTURE = join(REPO_ROOT, "fixtures", "css-challenge", "page.html");
+
+function fail(message) {
+  console.error(`FAIL: ${message}`);
+  process.exit(1);
+}
+
+if (!existsSync(CLI)) fail(`${CLI} is missing — run \`pnpm build\` first`);
+if (!existsSync(FIXTURE)) fail(`${FIXTURE} is missing`);
+
+/**
+ * PATH with every directory containing a `moon` executable removed.
+ *
+ * Removing only `~/.moon/bin` would be a guess about where it is installed; this makes the
+ * toolchain unreachable wherever it lives, which is the condition being reproduced.
+ */
+function pathWithoutMoon() {
+  const entries = (process.env.PATH ?? "").split(delimiter);
+  const kept = entries.filter((entry) => entry && !existsSync(join(entry, "moon")));
+  const dropped = entries.length - kept.length;
+  console.log(`==> removed ${dropped} PATH entr${dropped === 1 ? "y" : "ies"} containing \`moon\``);
+  return kept.join(delimiter);
+}
+
+const env = { ...process.env, PATH: pathWithoutMoon(), NO_COLOR: "1" };
+// Belt and braces: if `moon` is somehow still reachable, this makes the fallback's build
+// fail anyway, so a silent fallback cannot masquerade as success.
+env.MOON_HOME = join(REPO_ROOT, "does-not-exist");
+
+// Sanity-check the check: if `moon` is still runnable the run below proves nothing.
+try {
+  execFileSync("moon", ["version"], { env, stdio: "ignore" });
+  fail("`moon` is still reachable after sanitizing PATH — this smoke would pass vacuously");
+} catch {
+  // Expected: the toolchain is unreachable, so the CLI must succeed without it.
+}
+
+// `check a11y contrast` calls `evaluateA11yContrast`, which goes through the JSON
+// boundary. Named here so a future reader knows what to change if this gate moves off it.
+console.log("==> running `check a11y contrast` from the built CLI, without MoonBit");
+let output;
+try {
+  output = execFileSync(process.execPath, [CLI, "check", "a11y", "contrast", FIXTURE], {
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 180_000,
+  });
+} catch (error) {
+  const combined = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  // Exit 1 is a legitimate outcome — the gate reports contrast failures on this fixture.
+  // What must not appear is the runtime reaching for a toolchain that is not there.
+  if (/moon|not in a Moon project|ENOENT|run_markup_core_json|is unavailable/i.test(combined)) {
+    fail(
+      "the built CLI could not reach markup-core over the JSON boundary:\n"
+      + `${combined.split("\n").slice(0, 12).join("\n")}\n\n`
+      + "scripts/vlmkit-bundled.mjs must hand the runtime the complete generated bridge "
+      + "(namespace import), and the bridge must be rebuilt after adding an entry point.",
+    );
+  }
+  output = combined;
+}
+
+if (!/contrast/i.test(output)) {
+  fail(`the gate produced no contrast output:\n${output.slice(0, 600)}`);
+}
+console.log("==> bundled CLI answered a JSON-boundary command with no MoonBit toolchain");

--- a/scripts/vlmkit-bundled.mjs
+++ b/scripts/vlmkit-bundled.mjs
@@ -5,10 +5,36 @@
  * The source workspace can compile MoonBit lazily, but npm consumers should
  * not need the MoonBit toolchain. Import the generated JS bridge statically so
  * tsdown bundles it, then inject that implementation before loading the CLI.
+ *
+ * ## Every entry point, not just the positional one
+ *
+ * This file listed only `run_markup_core` for as long as that was the only entry
+ * point, and adding the JSON boundary did not update it. The consequence was
+ * invisible in the workspace and total in the shipped CLI: `loadMarkupCoreApi` found
+ * the injected global, `api.run_markup_core_json` was `undefined`, and every JSON
+ * command fell through to `ensureMarkupCoreCli()` — which runs `moon build`, the one
+ * thing an npm consumer is guaranteed not to have. Positional commands kept working,
+ * so the CLI looked healthy.
+ *
+ * Nothing caught it because the tests run from source, where the runtime finds the
+ * generated bridge through `apiPath` and never consults this global at all. The
+ * bundled layout is the only place these two lines matter.
+ *
+ * **Adding an entry point to `DirectMarkupCoreModule` means adding it here.**
+ * `markup-core-injection.test.ts` fails if the two drift, because the whole
+ * failure mode is a name that is missing rather than wrong.
  */
-import { run_markup_core } from "../packages/vlmkit-markup/_build/js/debug/build/markup-core-api/markup-core-api.js";
+import {
+  markup_core_json_commands,
+  run_markup_core,
+  run_markup_core_json,
+} from "../packages/vlmkit-markup/_build/js/debug/build/markup-core-api/markup-core-api.js";
 
-globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__ = { run_markup_core };
+globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__ = {
+  run_markup_core,
+  run_markup_core_json,
+  markup_core_json_commands,
+};
 
 const { runCli } = await import("../src/cli/cli.ts");
 

--- a/scripts/vlmkit-bundled.mjs
+++ b/scripts/vlmkit-bundled.mjs
@@ -2,39 +2,35 @@
 /**
  * Distribution-only CLI entrypoint.
  *
- * The source workspace can compile MoonBit lazily, but npm consumers should
- * not need the MoonBit toolchain. Import the generated JS bridge statically so
- * tsdown bundles it, then inject that implementation before loading the CLI.
+ * The root package ships `dist/**` and nothing else — no `_build`, no `.mbt` sources —
+ * so an npm consumer of the `vlmkit` CLI has no MoonBit toolchain and no generated
+ * bridge on disk to find. (The `@mizchi/vlmkit-markup` *library* package does ship
+ * `_build/js/debug/build/markup-core-api/markup-core-api.js`, which is why importing it
+ * directly has always worked. Only the CLI depends on what happens below.)
  *
- * ## Every entry point, not just the positional one
+ * So: import the generated bridge statically, which makes the bundler include it, and
+ * hand it to the runtime through a global before the CLI loads.
  *
- * This file listed only `run_markup_core` for as long as that was the only entry
- * point, and adding the JSON boundary did not update it. The consequence was
- * invisible in the workspace and total in the shipped CLI: `loadMarkupCoreApi` found
- * the injected global, `api.run_markup_core_json` was `undefined`, and every JSON
- * command fell through to `ensureMarkupCoreCli()` — which runs `moon build`, the one
- * thing an npm consumer is guaranteed not to have. Positional commands kept working,
- * so the CLI looked healthy.
+ * ## Why this is a namespace import
  *
- * Nothing caught it because the tests run from source, where the runtime finds the
- * generated bridge through `apiPath` and never consults this global at all. The
- * bundled layout is the only place these two lines matter.
+ * It used to name its exports: `import { run_markup_core }`, then
+ * `globalThis.… = { run_markup_core }`. That is a hand-written list which has to agree
+ * with `DirectMarkupCoreModule` in `markup-core-runtime.ts`, and when the JSON boundary
+ * added two entry points, nobody updated it. The result was invisible in the workspace
+ * and total in the shipped CLI: `loadMarkupCoreApi` found this global,
+ * `run_markup_core_json` read as `undefined`, and every JSON command fell through to
+ * `ensureMarkupCoreCli()` — which shells out to `moon build`, the one thing this file
+ * exists to make unnecessary. Positional commands kept working, so nothing looked wrong.
  *
- * **Adding an entry point to `DirectMarkupCoreModule` means adding it here.**
- * `markup-core-injection.test.ts` fails if the two drift, because the whole
- * failure mode is a name that is missing rather than wrong.
+ * A namespace import has no list to forget. Every export of the bridge crosses over,
+ * so adding an entry point on the MoonBit side connects it here by construction rather
+ * than by remembering. `pickDirectApi` on the other side selects what it understands and
+ * ignores the rest, and the runtime now raises rather than silently degrading if
+ * something it needs is missing — see `runMarkupCoreJsonRaw`.
  */
-import {
-  markup_core_json_commands,
-  run_markup_core,
-  run_markup_core_json,
-} from "../packages/vlmkit-markup/_build/js/debug/build/markup-core-api/markup-core-api.js";
+import * as markupCoreApi from "../packages/vlmkit-markup/_build/js/debug/build/markup-core-api/markup-core-api.js";
 
-globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__ = {
-  run_markup_core,
-  run_markup_core_json,
-  markup_core_json_commands,
-};
+globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__ = markupCoreApi;
 
 const { runCli } = await import("../src/cli/cli.ts");
 

--- a/tests/markup-core-injection.test.mjs
+++ b/tests/markup-core-injection.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * The bundled CLI must inject every markup-core entry point the runtime can use.
+ *
+ * `scripts/vlmkit-bundled.mjs` exists because npm consumers have no MoonBit toolchain:
+ * it imports the generated JS bridge so the bundler includes it, and hands it to the
+ * runtime through a global. The runtime prefers that global over its on-disk lookup.
+ *
+ * The failure mode is a **missing name**, and it is silent in a specific way. When the
+ * JSON boundary landed, this file still injected only `run_markup_core`. In the shipped
+ * CLI `loadMarkupCoreApi` therefore returned an API whose `run_markup_core_json` was
+ * `undefined`, so every JSON command fell through to `ensureMarkupCoreCli()` — which
+ * shells out to `moon build`. Positional commands kept working, so nothing looked
+ * broken until a gate that used a JSON command was run from `dist/`.
+ *
+ * No existing test could see it:
+ *
+ *  - Unit and integration tests run from **source**, where the runtime resolves the
+ *    generated bridge through `apiPath` and never reads this global.
+ *  - `markup-core-json.test.ts` asserts the backend is `direct-js`, which is true from
+ *    source for the same reason.
+ *  - Type checking cannot help: the global is assigned in a `.mjs` file to a
+ *    `Partial<DirectMarkupCoreModule>`, where absent is legal.
+ *
+ * So this compares the two lists as text: the entry points the runtime declares, and
+ * the ones the bundled entrypoint injects. Reading source rather than executing is
+ * deliberate — the bug lives in the bundled layout, and reproducing that in a test
+ * would mean depending on build order.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
+const RUNTIME = resolve(REPO_ROOT, "packages/vlmkit-markup/src/markup-core-runtime.ts");
+const BUNDLED = resolve(REPO_ROOT, "scripts/vlmkit-bundled.mjs");
+
+/** Field names of `interface DirectMarkupCoreModule`. */
+function declaredEntryPoints() {
+  const source = readFileSync(RUNTIME, "utf8");
+  const start = source.indexOf("interface DirectMarkupCoreModule {");
+  assert.notEqual(start, -1, "DirectMarkupCoreModule interface not found — did it move or get renamed?");
+  const body = source.slice(start, source.indexOf("\n}", start));
+  return [...body.matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]).sort();
+}
+
+/** Property names assigned to the injected global. */
+function injectedEntryPoints() {
+  const source = readFileSync(BUNDLED, "utf8");
+  const start = source.indexOf("globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__");
+  assert.notEqual(start, -1, "the injection assignment is gone — the bundled CLI would have no direct API at all");
+  const body = source.slice(start, source.indexOf("};", start));
+  // `{ run_markup_core, run_markup_core_json }` shorthand, one per line.
+  return [...body.matchAll(/^\s{2}(\w+),?$/gm)].map((m) => m[1]).sort();
+}
+
+describe("bundled CLI injects the whole markup-core API", () => {
+  it("injects every entry point the runtime declares", () => {
+    const declared = declaredEntryPoints();
+    const injected = injectedEntryPoints();
+    assert.ok(declared.length >= 3, `expected at least 3 entry points, parsed ${declared.join(", ")}`);
+    assert.deepEqual(
+      injected,
+      declared,
+      "scripts/vlmkit-bundled.mjs must inject every field of DirectMarkupCoreModule. A missing one "
+      + "does not fail loudly: the runtime finds the global, the missing function reads as undefined, "
+      + "and that command silently falls back to spawning `moon build` — which npm consumers do not have.",
+    );
+  });
+
+  it("imports those names from the generated bridge", () => {
+    // Injecting a name that was never imported yields `undefined` with no error, which
+    // is the same silent failure by a different route.
+    const source = readFileSync(BUNDLED, "utf8");
+    const importBlock = source.slice(source.indexOf("import {"), source.indexOf("markup-core-api.js"));
+    for (const name of injectedEntryPoints()) {
+      assert.match(
+        importBlock,
+        new RegExp(`\\b${name}\\b`),
+        `${name} is injected but never imported — it would be injected as undefined`,
+      );
+    }
+  });
+});

--- a/tests/markup-core-injection.test.mjs
+++ b/tests/markup-core-injection.test.mjs
@@ -1,85 +1,118 @@
 /**
- * The bundled CLI must inject every markup-core entry point the runtime can use.
+ * The bundled CLI must hand the runtime a *complete* markup-core API.
  *
- * `scripts/vlmkit-bundled.mjs` exists because npm consumers have no MoonBit toolchain:
- * it imports the generated JS bridge so the bundler includes it, and hands it to the
- * runtime through a global. The runtime prefers that global over its on-disk lookup.
+ * The root package ships `dist/**` only — no `_build`, no `.mbt` sources — so the CLI's
+ * one route to MoonBit is `scripts/vlmkit-bundled.mjs`, which statically imports the
+ * generated bridge and puts it on a global before the CLI loads. If anything the runtime
+ * needs is missing from that hand-off, the CLI has no way to recover: `moon build` needs a
+ * toolchain npm consumers do not have, and the spawned CLI needs a `_build` the package
+ * does not ship.
  *
- * The failure mode is a **missing name**, and it is silent in a specific way. When the
- * JSON boundary landed, this file still injected only `run_markup_core`. In the shipped
- * CLI `loadMarkupCoreApi` therefore returned an API whose `run_markup_core_json` was
- * `undefined`, so every JSON command fell through to `ensureMarkupCoreCli()` — which
- * shells out to `moon build`. Positional commands kept working, so nothing looked
- * broken until a gate that used a JSON command was run from `dist/`.
+ * That is exactly what happened. The file used to name its exports —
+ * `import { run_markup_core }` then `globalThis.… = { run_markup_core }` — a hand-written
+ * list that had to agree with `DirectMarkupCoreModule`, and the JSON boundary landed
+ * without updating it. In `dist/`, `run_markup_core_json` read as `undefined` and every
+ * JSON command silently fell back to shelling out. Positional commands kept working.
  *
- * No existing test could see it:
+ * Nothing could catch it: the suite runs from source, where the runtime finds the bridge
+ * on disk through `apiPath` and never reads the global; the existing `direct-js` backend
+ * assertion is true from source for the same reason; and the global is assigned in a
+ * `.mjs` file to a `Partial<DirectMarkupCoreModule>`, where a missing field is legal.
  *
- *  - Unit and integration tests run from **source**, where the runtime resolves the
- *    generated bridge through `apiPath` and never reads this global.
- *  - `markup-core-json.test.ts` asserts the backend is `direct-js`, which is true from
- *    source for the same reason.
- *  - Type checking cannot help: the global is assigned in a `.mjs` file to a
- *    `Partial<DirectMarkupCoreModule>`, where absent is legal.
+ * So this checks the two halves of "always connected" separately:
  *
- * So this compares the two lists as text: the entry points the runtime declares, and
- * the ones the bundled entrypoint injects. Reading source rather than executing is
- * deliberate — the bug lives in the bundled layout, and reproducing that in a test
- * would mean depending on build order.
+ *  1. **Structural** — the hand-off is a namespace import, so there is no list to drift.
+ *     A named-import version is rejected even if it currently happens to be complete,
+ *     because completeness by remembering is the thing that failed.
+ *  2. **Behavioural** — the generated bridge really does export every entry point the
+ *     runtime declares, and a run against the injected global actually answers a JSON
+ *     command. Reading source alone would pass against a bridge that was never rebuilt.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
 const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
 const RUNTIME = resolve(REPO_ROOT, "packages/vlmkit-markup/src/markup-core-runtime.ts");
 const BUNDLED = resolve(REPO_ROOT, "scripts/vlmkit-bundled.mjs");
+const BRIDGE = resolve(
+  REPO_ROOT,
+  "packages/vlmkit-markup/_build/js/debug/build/markup-core-api/markup-core-api.js",
+);
 
 /** Field names of `interface DirectMarkupCoreModule`. */
 function declaredEntryPoints() {
   const source = readFileSync(RUNTIME, "utf8");
   const start = source.indexOf("interface DirectMarkupCoreModule {");
-  assert.notEqual(start, -1, "DirectMarkupCoreModule interface not found — did it move or get renamed?");
+  assert.notEqual(start, -1, "DirectMarkupCoreModule not found — did it move or get renamed?");
   const body = source.slice(start, source.indexOf("\n}", start));
-  return [...body.matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]).sort();
+  const fields = [...body.matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]).sort();
+  assert.ok(fields.length >= 3, `expected at least 3 entry points, parsed ${fields.join(", ")}`);
+  return fields;
 }
 
-/** Property names assigned to the injected global. */
-function injectedEntryPoints() {
-  const source = readFileSync(BUNDLED, "utf8");
-  const start = source.indexOf("globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__");
-  assert.notEqual(start, -1, "the injection assignment is gone — the bundled CLI would have no direct API at all");
-  const body = source.slice(start, source.indexOf("};", start));
-  // `{ run_markup_core, run_markup_core_json }` shorthand, one per line.
-  return [...body.matchAll(/^\s{2}(\w+),?$/gm)].map((m) => m[1]).sort();
-}
+describe("bundled CLI is structurally connected to markup-core", () => {
+  it("hands over the whole bridge as a namespace, with no per-name list", () => {
+    const source = readFileSync(BUNDLED, "utf8");
+    assert.match(
+      source,
+      /import \* as (\w+) from "[^"]*markup-core-api\.js";/,
+      "the bridge must be imported as a namespace — a named-import list is what drifted",
+    );
+    const namespaceName = source.match(/import \* as (\w+) from "[^"]*markup-core-api\.js";/)[1];
+    assert.match(
+      source,
+      new RegExp(`globalThis\\.__MIZCHI_VLMKIT_MARKUP_CORE_API__ = ${namespaceName};`),
+      "the namespace must be assigned directly; rebuilding an object re-introduces the list",
+    );
+    // The specific regression: no `{ a, b }` object literal standing in for the bridge.
+    const assignment = source.slice(source.indexOf("globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__"));
+    assert.doesNotMatch(
+      assignment.split("\n")[0],
+      /\{/,
+      "assigning an object literal means naming entry points by hand again",
+    );
+  });
+});
 
-describe("bundled CLI injects the whole markup-core API", () => {
-  it("injects every entry point the runtime declares", () => {
-    const declared = declaredEntryPoints();
-    const injected = injectedEntryPoints();
-    assert.ok(declared.length >= 3, `expected at least 3 entry points, parsed ${declared.join(", ")}`);
+describe("the generated bridge exports every entry point the runtime declares", () => {
+  it("exports all of them", async (t) => {
+    if (!existsSync(BRIDGE)) {
+      t.skip("generated bridge absent — run `moon build` in packages/vlmkit-markup");
+      return;
+    }
+    const bridge = await import(BRIDGE);
+    const missing = declaredEntryPoints().filter((name) => typeof bridge[name] !== "function");
     assert.deepEqual(
-      injected,
-      declared,
-      "scripts/vlmkit-bundled.mjs must inject every field of DirectMarkupCoreModule. A missing one "
-      + "does not fail loudly: the runtime finds the global, the missing function reads as undefined, "
-      + "and that command silently falls back to spawning `moon build` — which npm consumers do not have.",
+      missing,
+      [],
+      `the bridge is missing ${missing.join(", ")}. A namespace import cannot fix an export `
+      + "that does not exist: markup-core-api/main.mbt must expose it, and _build must be rebuilt.",
     );
   });
 
-  it("imports those names from the generated bridge", () => {
-    // Injecting a name that was never imported yields `undefined` with no error, which
-    // is the same silent failure by a different route.
-    const source = readFileSync(BUNDLED, "utf8");
-    const importBlock = source.slice(source.indexOf("import {"), source.indexOf("markup-core-api.js"));
-    for (const name of injectedEntryPoints()) {
-      assert.match(
-        importBlock,
-        new RegExp(`\\b${name}\\b`),
-        `${name} is injected but never imported — it would be injected as undefined`,
+  it("answers a JSON command through the injected global, not a fallback", async (t) => {
+    if (!existsSync(BRIDGE)) {
+      t.skip("generated bridge absent");
+      return;
+    }
+    // Drive the runtime the way the bundled CLI does — global first, then load — and
+    // assert it reports `direct-js`. If the hand-off were incomplete this now raises a
+    // packaging error rather than quietly spawning, which is the behaviour under test.
+    const bridge = await import(BRIDGE);
+    globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__ = bridge;
+    try {
+      const runtime = await import("@mizchi/vlmkit-markup/markup-core-runtime.ts");
+      assert.equal(
+        runtime.callMarkupCoreJson("grid-gcd", { a: 24, b: 36 }),
+        12,
+        "a JSON command must answer from the injected bridge",
       );
+      assert.equal(runtime.getMarkupCoreRuntimeBackend(), "direct-js");
+    } finally {
+      delete globalThis.__MIZCHI_VLMKIT_MARKUP_CORE_API__;
     }
   });
 });


### PR DESCRIPTION
Finishes the migration started in #115 and #119: **all 32 commands with mutually swappable
positions are now on the JSON boundary.** Then fixes a packaging bug the last conversion
exposed, which is the more important half of this PR.

## The last 18 commands

Mechanical once the differential harness existed — a struct, a dispatch arm, a spec row —
but three were worth more than their argument count suggested.

**`landscape-diff-summary` carried a second positional encoding inside a positional
argument.** `baseline_stats` was a `String` holding `"r,g,b,l,ink|r,g,b,l,ink|…"`: five
positional fields per cell, comma-delimited, inside a pipe-delimited list, inside a
tab-delimited argument list, parsed by a hand-written `idx == 0 / 1 / 2 / 3 / 4` chain. No
value at any level could contain a comma or a pipe and nothing enforced it.

It also returned `"mismatch|<total>|<base>|<curr>"` on a cell-count error — an error in the
shape of a result — with a comment saying it did so *"rather than raising, so the FFI
surface stays string-only"*. That constraint is gone, so it raises and names the counts. On
the TypeScript side `parseSummary` was 36 lines and six throw sites; none of it survives.

**`semantic-drilldown-select-index` took three index-correlated parallel arrays** —
`flows`, `priority_scores`, `orders` — with nothing tying them together. Filter one and not
the others and you get a well-typed call that scores the wrong candidate. One
`Array[DrilldownCandidate]` makes that unrepresentable.

**`landscape-cell-score` and `a11y-contrast-evaluate` were the swap-risk worst cases**
(10-of-10 and 6-of-8 positions) and both were *pairs of samples*: two 5-field cells, two
RGB triples. Nesting removes the class rather than renaming it.

Four commands also stopped returning composites as strings. `"cols|rows"`,
`"ratio|required|level"`, `"flow|priority|reason_id"` and the diff summary each had a
TypeScript reader that split, coerced and hand-validated against a literal union.
`derive(ToJson)` deletes both halves.

## The bug this uncovered

Converting `evaluateA11yContrast` broke `check a11y contrast` **in the built CLI while 2249
tests passed.** The cause was not the conversion.

`scripts/vlmkit-bundled.mjs` hands the generated MoonBit bridge to the runtime through a
global so npm consumers need no toolchain — and it listed `run_markup_core` by hand, from
before the JSON boundary existed. Adding the boundary never updated it. So in `dist/`,
`loadMarkupCoreApi` found the global, `run_markup_core_json` read as `undefined`, and every
JSON command fell through to `ensureMarkupCoreCli()`, which shells out to `moon build`.
**Positional commands kept working, so the CLI looked healthy — the JSON boundary has been
dead in the shipped CLI since it landed.**

### Why every safety net missed it

They were each in a different room:

- `pnpm test` runs from **source**, where the runtime resolves the bridge through `apiPath`
  and never reads the global.
- The existing `getMarkupCoreRuntimeBackend() === "direct-js"` assertion is true from
  source for the same reason.
- `smoke:pack:workspaces` installs the **library** packages, and `@mizchi/vlmkit-markup`
  *does* ship `_build/.../markup-core-api.js`. Only the **root** package — `dist/**` and
  nothing else — depends on the hand-off, and nothing ran the root package the way a
  consumer does.
- Type checking cannot help: the global is assigned in a `.mjs` file to a
  `Partial<DirectMarkupCoreModule>`, where a missing field is legal.

### Connected structurally, not by remembering

Adding the two missing names would have left the list, and the list is the defect. Three
changes instead:

1. **No list.** The bundled entrypoint hands over a **namespace import**, assigned directly
   to the global. Every export crosses, so adding an entry point in
   `markup-core-api/main.mbt` connects it without touching this file.
2. **No silent degradation.** The runtime records whether the API was `injected` or read off
   disk as `generated`. From `generated`, a missing function can be a stale `_build`, so
   build-and-retry stays right. From `injected` it cannot be stale — no toolchain to rebuild
   with, and no `_build` shipped for the spawned CLI — so **both** old fallbacks were
   guaranteed to fail. It raises, naming the packaging fault.
3. **A smoke in the consumer's environment.** `pnpm smoke:bundled-json` runs the built CLI
   with every `moon`-containing PATH entry stripped and requires a JSON-boundary gate to
   succeed. It asserts `moon` is genuinely unreachable first, or it would pass vacuously.
   Added to `package-install-smoke`.

## Verification

Every guard is mutation-verified against the state it guards — each fails now and failed
nothing before:

| Mutation | Result |
|---|---|
| Restore the original named-import list | structural test fails; smoke exits 1 with the runtime naming `contrast-evaluate` |
| Namespace import rebuilt into an object literal (complete today, drifts tomorrow) | structural test fails |
| Injected API missing `run_markup_core_json` | raises; positional commands keep working — the asymmetry that hid it |

Also, the differential harness caught four mistakes in **my own** new specs: its vacuity
assertion fired where `touch-in-cluster` returned `true` for all 17 cases and
`landscape-default-grid` `0|0` for all 7. Same cause each time — `baseValues` takes
`values[0]`, so a degenerate first value means single-argument variation never reaches the
rule. That is the straddle-the-guard lesson one step earlier, and it is now in the doc.

- **2252 tests pass, 0 fail.**
- `smoke:pack:workspaces` and `smoke:bundled-json` both pass.
- `check a11y contrast` from the built CLI returns output identical to `main`.
- `landscape-diff-summary` has its own differential test: agreement on well-formed input
  across 64 grid/threshold/top-N combinations, plus assertions that the old form returned
  `mismatch|4|3|4` where the new one raises, and that both give `1|0|0|0` for a zero-cell
  grid.

## Deliberately not done

The 29 remaining positional commands are single-argument or all-distinct-type, so a struct
buys them nothing and there is no wiring bug available to make. Deleting the positional
dispatch entirely would need all 61 — worth doing for the 1,487 duplicated lines and the
`__VLMKIT_EMPTY_ARG__` sentinel it removes, but that is a uniformity argument, not a risk
one, and should be made explicitly rather than arrived at by drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a2DaLhFa2b1Switx8hEg3

---
_Generated by [Claude Code](https://claude.ai/code/session_011a2DaLhFa2b1Switx8hEg3)_