### PR TITLE
Support the canvas/game-engine pattern: image-only `check integrity`, and fix small-frame region attribution

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -209,8 +209,11 @@ vlmkit diff html <baseline> <variant>          # HTML/URL pair → multi-viewpor
 vlmkit diff agent <report.json>                # Render report.json as agent-friendly Markdown
 vlmkit diff png <baseline.png> <current.png>   # Direct PNG pixel diff + heatmap
   # per region: measured colorSamples, translation estimate (shift dx/dy),
-  # image-size delta; add --elements-html <url> for a deterministic DOM
-  # selector candidate per region (no VLM, no API key)
+  # image-size delta; add --elements-html <url> (or --elements-json <path>) for a
+  # deterministic DOM selector candidate per region (no VLM, no API key)
+  # --region-grid <px>   region-detection cell size; default adapts to the image
+  #                      (32 at >=720px short side, 16 at >=480, else 8)
+  # --elements-top <N>   report N attribution candidates per region, not just the winner
 vlmkit diff elements [options]                 # Element-level diff with shift isolation
 vlmkit diff browsers <html|url>                # chromium / firefox / webkit parity
 vlmkit diff runs <dir...>                      # Aggregate multiple VRT runs into one table

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -255,6 +255,39 @@ vlmkit check integrity http://localhost:3000/ \
   --wait-until domcontentloaded --timeout 60000 --har fixtures/app.har
 ```
 
+#### Without a DOM: canvas / WebGPU / native renderers
+
+A canvas UI has one `<canvas>` element, so every `getBoundingClientRect` rule finds
+nothing and the gate reports `clean` on a frame that may be visibly broken. Pass element
+rects instead of a page — no browser, no DOM:
+
+```bash
+vlmkit check integrity --elements elements.json --image frame.png
+```
+
+`elements.json` is the same schema `diff png --elements-json` accepts (`path`, `tag`,
+`top`, `left`, `width`, `height`), plus optional fields that each unlock one rule:
+
+| field | unlocks |
+|---|---|
+| `text` | `text-collision` |
+| `text_measured: {width,height}` + `clip: {top,left,width,height}` | `text-clipped` |
+| `overlay`, `z_index`, `aria_hidden` | excludes layered / decorative text from collisions |
+
+Containment comes from `path` prefixes (`hud[0]>bar[0]`), so protrusion, collapsed
+containers and near-misalignment need no extra fields. Because the capture may omit
+uninteresting nodes, findings name the **nearest recorded ancestor** rather than claiming
+a parent.
+
+**Six of eighteen rules are evaluable this way**, and the report lists the other twelve
+with the reason each needs a DOM. That is deliberate: a `clean` verdict is only worth
+what it rules out, so the gap is printed next to the verdict rather than left implicit.
+`--elements` and a page source are mutually exclusive — the two modes evaluate different
+rule sets, so a combined run's verdict would be ambiguous.
+
+Text drawn wider than its box is **not** reported as clipped unless a `clip` rect says so:
+on a canvas that overdraws, which the collision and protrusion rules cover.
+
 ### Check (gates: a11y / tokens / design / theme / perf / drift)
 
 ```bash

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -986,3 +986,43 @@ satisfied 化(許可行は provenance 付き列挙 + 台帳計上 — 監査可�
 skip link は実装手法によりクラスが割れる(MDN=unreachable、W3C=
 zero-size、web.dev=transparent、Wikipedia=visually-hidden)— そもそも
 manifest に入れない。`docs/reports/2026-07-31-copy-invisible-real-site-audit.md`
+
+## Diff-region granularity drives attribution (2026-08-08)
+
+Reported as two problems (vlmkit#117) on a 640x360 canvas HUD whose only change was an
+HP bar's fill, `(106,16) 90x20`:
+
+1. the region came back `(96,0) 128x64` — **larger than the 200x20 element that caused it**
+2. attribution named `.hud-root` (the whole frame) instead of `.hp-bar`
+
+**They are one problem.** `regionCoverage` carries weight 0.7 in
+`matchRegionBboxToElement`, so a region coarser than the element hands a containing
+ancestor a free `1.0` while starving the leaf. Measured on that case:
+
+| grid | region | `.hud-root` | `.hp-bar` |
+|--:|---|--:|--:|
+| 32 | 128x64 | **0.391** (penalised) | 0.385 |
+| 16 | 128x32 | 0.388 | **0.590** |
+| 8 | 96x24 | 0.387 | **0.727** |
+
+The ancestor won by 0.006 at grid 32 and loses decisively at 16 — with **no change to the
+scoring function**. So the near-tie was a symptom; the cell size was the cause.
+
+Consequences worth remembering:
+
+- `detectDiffRegions`' cell size is now `adaptiveRegionCellSize(w, h)`: 32 at short side
+  ≥720, 16 at ≥480, else 8. **Bucketed, not continuous** — a continuous function would
+  move region bboxes on nearly every existing image, and those bboxes appear in baselines,
+  approvals and reports. Override with `diff png --region-grid <px>`.
+- Keyed on the **short side**, not area: a 2000x300 strip is small in the dimension that
+  matters.
+- A near-tie rule (within 0.02, and the winner at most half the area) is second-line
+  insurance for when the grid cannot be fine enough. It deliberately does not reorder
+  same-scale siblings.
+- `--elements-top N` reports runners-up. They were always computed and discarded, and a
+  wrong winner otherwise hides every alternative.
+
+**None of this had test coverage before.** `heatmap-regions.test.ts` covers
+`findHeatmapRegionsFromRgba`, a different function; nothing exercised `detectDiffRegions`'
+grid, so the full suite stayed green through both the defect and the fix. See
+`packages/vlmkit-markup/src/region-attribution.test.ts`.

--- a/packages/vlmkit-core/src/heatmap.ts
+++ b/packages/vlmkit-core/src/heatmap.ts
@@ -70,12 +70,14 @@ export async function compareScreenshots(
     threshold?: number;
     outputDir?: string;
     skipHeatmap?: boolean;
+    /** Override the adaptive grid. See `adaptiveRegionCellSize`. */
+    regionCellSize?: number;
   } = {}
 ): Promise<VrtDiff | null> {
   if (!snapshot.baselinePath) return null;
 
   const r = await runPixelDiff(snapshot.baselinePath, snapshot.screenshotPath, snapshot.testId, opts);
-  const regions = detectDiffRegions(r.diffOutput, r.width, r.height);
+  const regions = detectDiffRegions(r.diffOutput, r.width, r.height, opts.regionCellSize);
   attachRegionColorSamples(regions, r.resizedBaseline, r.resizedCurrent);
   attachRegionShiftEstimates(regions, r.resizedBaseline, r.resizedCurrent);
 
@@ -90,6 +92,33 @@ export async function compareScreenshots(
 }
 
 /**
+ * Cell size for region detection, scaled to the image.
+ *
+ * A fixed 32px grid is right for a page screenshot and wrong for a game frame, and the
+ * failure is not cosmetic — it changes which element gets blamed. Measured on a 640x360
+ * HUD whose only change was an HP bar's fill (`(106,16) 90x20`, vlmkit#117): the reported
+ * region was `(96,0) 128x64`, larger than the `200x20` element that caused it, and
+ * attribution then scored the full-frame ancestor at 0.391 against the real cause at
+ * 0.385. The ancestor won by 0.006.
+ *
+ * That near-tie is a *symptom*, not a second bug. `regionCoverage` is the dominant term
+ * (weight 0.7), and a region coarser than the element hands the ancestor a free 1.0 while
+ * starving the leaf. At a 16px grid the same case scores 0.590 for the leaf against 0.388
+ * for the ancestor — no change to the scoring function required.
+ *
+ * So: keep 32 wherever it has been working, and refine only the small frames where it
+ * cannot be right. Bucketed rather than continuous (`min/40` or similar) because a
+ * continuous function would shift region geometry on nearly every existing image, and
+ * region bboxes appear in baselines, approvals and reports.
+ */
+export function adaptiveRegionCellSize(width: number, height: number): number {
+  const shortSide = Math.min(width, height);
+  if (shortSide >= 720) return 32;
+  if (shortSide >= 480) return 16;
+  return 8;
+}
+
+/**
  * Grid-based diff region detection.
  * Splits image into cells and clusters cells exceeding the diff threshold.
  */
@@ -97,7 +126,7 @@ function detectDiffRegions(
   diffData: Uint8Array,
   width: number,
   height: number,
-  cellSize: number = 32
+  cellSize: number = adaptiveRegionCellSize(width, height)
 ): DiffRegion[] {
   const cols = Math.ceil(width / cellSize);
   const rows = Math.ceil(height / cellSize);
@@ -569,12 +598,14 @@ export async function generateDiffReport(
     outputDir?: string;
     skipHeatmap?: boolean;
     detectShift?: boolean;
+    /** Override the adaptive grid. See `adaptiveRegionCellSize`. */
+    regionCellSize?: number;
   } = {},
 ): Promise<DiffReport | null> {
   if (!snapshot.baselinePath) return null;
 
   const r = await runPixelDiff(snapshot.baselinePath, snapshot.screenshotPath, snapshot.testId, opts);
-  const regions = detectDiffRegions(r.diffOutput, r.width, r.height);
+  const regions = detectDiffRegions(r.diffOutput, r.width, r.height, opts.regionCellSize);
 
   // Shift detection
   let globalShift = 0;

--- a/packages/vlmkit-core/src/types.ts
+++ b/packages/vlmkit-core/src/types.ts
@@ -100,6 +100,15 @@ export interface DiffRegionSelectorCandidate {
   tag: string;
   regionCoverage: number;
   elementCoverage: number;
+  /**
+   * Runners-up, best first — present only when more than one candidate was requested
+   * (`diff png --elements-top N`), so the default JSON shape is unchanged.
+   *
+   * Attribution picks one element out of several overlapping ones, and when it picks
+   * wrong the alternatives are what a reader needs; without them the report asserts a
+   * cause with no way to see what it beat.
+   */
+  alternates?: Omit<DiffRegionSelectorCandidate, "alternates">[];
 }
 
 export interface DiffRegionColor {

--- a/packages/vlmkit-markup/src/gates/arg-helpers.ts
+++ b/packages/vlmkit-markup/src/gates/arg-helpers.ts
@@ -31,6 +31,11 @@ const COMMON_VALUE_FLAGS = [
   "--storage-state",
   "--allow",
   "--contract",
+  // `check integrity --elements <json> --image <png>`: without these, the flag values
+  // would be read as the positional page source and image mode would look like it had
+  // been given a page.
+  "--elements",
+  "--image",
 ] as const;
 
 export function firstPositional(
@@ -38,10 +43,23 @@ export function firstPositional(
   usage: string,
   valueFlags: readonly string[] = [],
 ): string {
-  const positionals = readPositionals(argv, [...COMMON_VALUE_FLAGS, ...valueFlags]);
-  const first = positionals[0];
+  const first = firstPositionalOrUndefined(argv, valueFlags);
   if (!first) throw new UsageError(`missing required argument. Usage: ${usage}`);
   return first;
+}
+
+/**
+ * The first positional, or `undefined` when there is none.
+ *
+ * For gates whose source is optional because another flag supplies the input — the
+ * distinction `check integrity` needs in order to *reject* being given both a page and
+ * `--elements` rather than silently preferring one.
+ */
+export function firstPositionalOrUndefined(
+  argv: readonly string[],
+  valueFlags: readonly string[] = [],
+): string | undefined {
+  return readPositionals(argv, [...COMMON_VALUE_FLAGS, ...valueFlags])[0];
 }
 
 /**

--- a/packages/vlmkit-markup/src/gates/integrity.gate.ts
+++ b/packages/vlmkit-markup/src/gates/integrity.gate.ts
@@ -28,7 +28,12 @@ import {
   runIntegrityCheck,
 } from "../inspect/integrity-check.ts";
 import { ALLOW_HELP, parseAllowRules } from "../inspect/integrity-exemption.ts";
-import { firstPositional, numberList, optionalInt } from "./arg-helpers.ts";
+import {
+  IMAGE_MODE_SKIPPED_RULES,
+  type IntegrityImageReport,
+  runImageIntegrityCheck,
+} from "../inspect/integrity-image.ts";
+import { firstPositional, firstPositionalOrUndefined, numberList, optionalInt } from "./arg-helpers.ts";
 
 /** Heights the CLI has always paired with its default sweep widths. */
 const VIEWPORT_HEIGHTS: Record<number, number> = { 1280: 800, 768: 900, 375: 700 };
@@ -68,7 +73,19 @@ ${ALLOW_HELP}`,
     { id: "redirected", title: "Requested URL redirected elsewhere", severity: "suspect" },
   ],
   inputs: [
-    { name: "source", placeholder: "html-or-url", kind: "path-or-url", description: "Page to check", positional: 0, required: true },
+    { name: "source", placeholder: "html-or-url", kind: "path-or-url", description: "Page to check (omit when using --image/--elements)", positional: 0 },
+    {
+      name: "elements",
+      placeholder: "elements.json",
+      kind: "path",
+      description: "Element rects instead of a DOM — canvas/WebGPU, native, Flutter (no browser)",
+    },
+    {
+      name: "image",
+      placeholder: "frame.png",
+      kind: "path",
+      description: "Frame PNG for --elements mode; enables the ink-based empty-render rule",
+    },
     { name: "viewports", placeholder: "w,w,...", kind: "number-list", description: "Sweep widths", defaultDescription: "1280,768,375" },
     { name: "max-findings", kind: "number", description: "Per-class report cap", defaultDescription: "12" },
     { name: "timeout", placeholder: "ms", kind: "number", description: "Page navigation timeout", defaultDescription: "30000" },
@@ -88,7 +105,32 @@ ${ALLOW_HELP}`,
     { name: "allow", kind: "string", description: "Exempt an intentional pattern (see below)", repeatable: true },
   ],
   parse: (argv) => {
-    const source = firstPositional(argv, "vlmkit check integrity <html-or-url>");
+    const elements = readFlag(argv, "elements");
+    const image = readFlag(argv, "image");
+    if (elements) {
+      // Image mode. Deliberately mutually exclusive with a page source rather than
+      // "source wins" or "both are measured": the two paths evaluate different rule sets,
+      // so a run that quietly picked one would make its verdict ambiguous.
+      if (firstPositionalOrUndefined(argv)) {
+        throw new UsageError(
+          "check integrity takes either a page source or --elements, not both. The two modes "
+          + "evaluate different rule sets, so a combined run's verdict would be ambiguous.",
+        );
+      }
+      const maxFindingsForImage = optionalInt(argv, "max-findings", { min: 1 });
+      return {
+        source: image ?? elements,
+        imageMode: {
+          elementsPath: elements,
+          ...(image ? { imagePath: image } : {}),
+          ...(maxFindingsForImage !== undefined ? { maxFindings: maxFindingsForImage } : {}),
+        },
+      };
+    }
+    if (image) {
+      throw new UsageError("--image needs --elements: a PNG alone carries no element rects to judge.");
+    }
+    const source = firstPositional(argv, "vlmkit check integrity <html-or-url> | --elements <elements.json> [--image <frame.png>]");
     const widths = numberList(argv, "viewports");
     if (widths && widths.some((w) => w <= 0)) {
       throw new UsageError("--viewports must be positive px widths, e.g. --viewports 1280,768,375");
@@ -114,7 +156,9 @@ ${ALLOW_HELP}`,
       ...(allow.length > 0 ? { allow } : {}),
     };
   },
-  run: (options) => runIntegrityCheck(options),
+  run: (options) => (options.imageMode
+    ? runImageIntegrityCheck(options.imageMode)
+    : runIntegrityCheck(options)),
   findings: (report): Finding[] =>
     report.findings.map((finding) => ({
       rule: finding.kind,
@@ -130,9 +174,18 @@ ${ALLOW_HELP}`,
   headline: (report) => {
     const fails = report.findings.filter((f) => f.severity === "fail").length;
     const warns = report.findings.length - fails;
+    const image = report as IntegrityImageReport;
+    // In image mode the count of rules that did NOT run belongs in the headline, not
+    // buried in the report body. `CLEAN` covering six of eighteen rules is a different
+    // claim from `CLEAN` covering all of them, and the difference has to be visible at
+    // the point someone reads the verdict.
+    const coverage = image.skippedRules
+      ? ` [image mode: ${IMAGE_MODE_SKIPPED_RULES.length} rule(s) not evaluable`
+        + `${image.inertRules?.length ? `, ${image.inertRules.length} inert` : ""}]`
+      : "";
     return `${report.verdict === "clean" ? "CLEAN" : "DEFECTS"}`
       + ` (${fails} fail, ${warns} warn, ${report.exempted.length} exempted`
-      + `, ${report.viewports.length} viewport(s))`;
+      + `, ${report.viewports.length} viewport(s))${coverage}`;
   },
   ledger: (report, options) => ({
     tool: "check-integrity",

--- a/packages/vlmkit-markup/src/inspect/integrity-check.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-check.ts
@@ -1437,6 +1437,20 @@ export const COLLECT_STYLE_FINGERPRINT = `(() => {
 
 export interface IntegrityOptions {
   /**
+   * Set when the gate ran in image mode (`--elements`, optionally `--image`): no DOM, no
+   * browser, rules judged from element rects and frame pixels. See `integrity-image.ts`.
+   *
+   * Declared here rather than as a separate options type because the gate has one
+   * `parse` and one `run`, and splitting the type would mean two gates in the registry
+   * for what is one command with two input adapters.
+   */
+  imageMode?: {
+    elementsPath: string;
+    imagePath?: string;
+    maxFindings?: number;
+    viewport?: number;
+  };
+  /**
    * Playwright storage-state file so gates can measure pages behind a
    * login. Falls back to VLMKIT_STORAGE_STATE. See auth-state.ts.
    */
@@ -1738,6 +1752,32 @@ export function formatIntegrityReport(report: IntegrityReport): string {
   } else {
     lines.push("");
     lines.push(`${GREEN}No integrity defects detected.${RESET}`);
+  }
+  // Image mode evaluates 6 of 18 rules. A bare "No integrity defects detected." would let
+  // that read as full coverage, which is the one way this feature could do harm: the value
+  // of a gate is what a clean result rules out, and a clean result over a third of the
+  // rules rules out a third as much. Printed next to the verdict, not in a footnote.
+  const coverage = report as Partial<{
+    skippedRules: { rule: string; reason: string }[];
+    inertRules: { rule: string; reason: string }[];
+  }>;
+  if (coverage.skippedRules && coverage.skippedRules.length > 0) {
+    lines.push("");
+    lines.push(
+      `${YELLOW}Coverage: image mode — ${coverage.skippedRules.length} rule(s) cannot be`
+      + ` evaluated without a DOM${RESET}`,
+    );
+    for (const skipped of coverage.skippedRules) {
+      lines.push(`${DIM}  - ${skipped.rule}: ${skipped.reason}${RESET}`);
+    }
+    if (coverage.inertRules && coverage.inertRules.length > 0) {
+      lines.push(
+        `${DIM}  ${coverage.inertRules.length} rule(s) ran with no input to judge:${RESET}`,
+      );
+      for (const inert of coverage.inertRules) {
+        lines.push(`${DIM}  - ${inert.rule}: ${inert.reason}${RESET}`);
+      }
+    }
   }
   if (report.exempted.length > 0) {
     const user = report.exempted.filter((e) => e.reason.startsWith("user exemption"));

--- a/packages/vlmkit-markup/src/inspect/integrity-image.test.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-image.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Image-only `check integrity` (vlmkit#116).
+ *
+ * The rules are reused unchanged from `integrity-check.ts`, so what needs testing is the
+ * **adapter**: does element-rect input reach each judge in the shape it expects? Three of
+ * these tests exist because the first version got that wrong in ways a clean-fixture check
+ * would never have surfaced:
+ *
+ *  - `judgeCollapsedContainers` has no height check of its own; it trusts the caller to have
+ *    filtered. Passing every ancestor reported a 360px-tall root as "collapsed" because it
+ *    held 40px children.
+ *  - `clipX` / `clipY` are the *amounts clipped in px*, not the clip rect's origin. Passing
+ *    the origin produced "cuts off 16px" for a label whose only relation to 16 was its
+ *    `left`.
+ *  - Treating an element's own box as a clip rect reported a label with 90px of text in a
+ *    180px box as "cutting off 40px" — the opposite of true. On a canvas, oversized text
+ *    overdraws; it does not clip unless a clip rect says so.
+ *
+ * So the fixtures below are deliberately *broken in specific ways*, and the assertions
+ * include what must NOT be reported. A gate that finds nothing on a clean frame proves only
+ * that it is quiet.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  IMAGE_MODE_SKIPPED_RULES,
+  parseIntegrityImageElements,
+  runImageIntegrityCheck,
+} from "./integrity-image.ts";
+
+async function withElements(elements: unknown[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "vlmkit-integrity-image-"));
+  const path = join(dir, "elements.json");
+  await writeFile(path, JSON.stringify({ elements }));
+  return path;
+}
+
+const ROOT = { path: "hud[0]", tag: "hud", classes: "hud-root", top: 0, left: 0, width: 640, height: 360 };
+
+const kinds = (report: { findings: { kind: string }[] }) => report.findings.map((f) => f.kind);
+
+describe("text collision", () => {
+  it("reports two overlapping text blocks", async () => {
+    const path = await withElements([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20, text: "HP 9999999/9999999" },
+      { path: "hud[0]>a[1]", tag: "label", classes: "mp", top: 20, left: 40, width: 180, height: 20, text: "MP 500/500" },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(kinds(report).includes("text-collision"), kinds(report).join(", "));
+    assert.equal(report.verdict, "defects");
+  });
+
+  it("does not report blocks the caller marked as separate layers", async () => {
+    // Game HUDs stack layers on purpose. Without `overlay`, every layered HUD would be a
+    // wall of collisions and the feature would be unusable on its intended target.
+    const path = await withElements([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20, text: "HP 120/120" },
+      { path: "hud[0]>a[1]", tag: "label", classes: "toast", top: 16, left: 16, width: 200, height: 20, text: "Level up!", overlay: true, z_index: 10 },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(!kinds(report).includes("text-collision"), kinds(report).join(", "));
+  });
+
+  it("is inert, not silently passing, when no element carries text", async () => {
+    const path = await withElements([ROOT, { ...ROOT, path: "hud[0]>box[0]", classes: "box", height: 40 }]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(
+      report.inertRules.some((r) => r.rule === "text-collision"),
+      "an unevaluated rule must be reported as inert, not counted as passing",
+    );
+  });
+});
+
+describe("text clipped", () => {
+  it("reports the amount actually clipped, not a coordinate", async () => {
+    const path = await withElements([
+      ROOT,
+      {
+        path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20,
+        text: "HP 9999999/9999999",
+        text_measured: { width: 320, height: 18 },
+        clip: { top: 16, left: 16, width: 200, height: 20 },
+      },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    const finding = report.findings.find((f) => f.kind === "text-clipped");
+    assert.ok(finding, kinds(report).join(", "));
+    // 320 measured - 200 clip = 120. Not 16 (the `left`), which is what the first version
+    // reported by passing the rect origin into a field meaning "px clipped".
+    assert.match(finding!.message, /120px/);
+    assert.equal(finding!.evidence?.clipX, 120);
+  });
+
+  it("does not report text that fits its clip rect", async () => {
+    const path = await withElements([
+      ROOT,
+      {
+        path: "hud[0]>a[0]", tag: "label", classes: "mp", top: 20, left: 40, width: 180, height: 20,
+        text: "MP 500/500",
+        text_measured: { width: 90, height: 18 },
+        clip: { top: 20, left: 40, width: 180, height: 20 },
+      },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(!kinds(report).includes("text-clipped"), kinds(report).join(", "));
+  });
+
+  it("does not treat oversized text without a clip rect as clipped", async () => {
+    // On a canvas that overdraws — a collision or protrusion concern, not a clip. Reporting
+    // it as "cut off" would name the wrong repair.
+    const path = await withElements([
+      ROOT,
+      {
+        path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20,
+        text: "HP 9999999/9999999",
+        text_measured: { width: 320, height: 18 },
+      },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(!kinds(report).includes("text-clipped"), kinds(report).join(", "));
+    assert.ok(report.inertRules.some((r) => r.rule === "text-clipped" && /overdraw/.test(r.reason)));
+  });
+});
+
+describe("containment, derived from the path", () => {
+  it("reports a child protruding past its nearest recorded ancestor", async () => {
+    const path = await withElements([
+      ROOT,
+      { path: "hud[0]>badge[0]", tag: "badge", classes: "badge", top: 330, left: 600, width: 120, height: 40 },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(kinds(report).includes("container-protrusion"), kinds(report).join(", "));
+  });
+
+  it("skips a level when the intermediate element was not recorded", async () => {
+    // The DOM capture only records elements that carry a class or are semantic, so a path
+    // can reference an ancestor that is absent. Falling back to the nearest recorded one is
+    // what makes this usable on real captures.
+    const path = await withElements([
+      ROOT,
+      { path: "hud[0]>wrap[0]>deep[0]>badge[0]", tag: "badge", classes: "badge", top: 330, left: 600, width: 120, height: 40 },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(kinds(report).includes("container-protrusion"), kinds(report).join(", "));
+  });
+
+  it("reports a zero-height container holding tall children", async () => {
+    const path = await withElements([
+      ROOT,
+      { path: "hud[0]>panel[0]", tag: "panel", classes: "empty-panel", top: 100, left: 100, width: 200, height: 0 },
+      { path: "hud[0]>panel[0]>item[0]", tag: "item", classes: "item", top: 100, left: 100, width: 180, height: 60 },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(kinds(report).includes("collapsed-container"), kinds(report).join(", "));
+  });
+
+  it("does NOT call a tall container collapsed just because its children are shorter", async () => {
+    // The regression that made the first run report 3 collapses on a 9-element HUD, two of
+    // them nonsense: `judgeCollapsedContainers` reports every candidate it is given.
+    const path = await withElements([
+      ROOT,
+      { path: "hud[0]>row[0]", tag: "row", classes: "btn-row", top: 260, left: 40, width: 560, height: 40 },
+      { path: "hud[0]>row[0]>button[0]", tag: "button", classes: "btn-a", top: 264, left: 40, width: 100, height: 32 },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.deepEqual(
+      kinds(report).filter((k) => k === "collapsed-container"),
+      [],
+      "a 360px root and a 40px row are not collapsed containers",
+    );
+  });
+});
+
+describe("near-misalignment", () => {
+  it("reports siblings a few px off a shared edge", async () => {
+    const path = await withElements([
+      ROOT,
+      { path: "hud[0]>row[0]", tag: "row", classes: "row", top: 260, left: 40, width: 560, height: 40 },
+      { path: "hud[0]>row[0]>b[0]", tag: "button", classes: "b1", top: 264, left: 40, width: 100, height: 32 },
+      { path: "hud[0]>row[0]>b[1]", tag: "button", classes: "b2", top: 267, left: 160, width: 100, height: 32 },
+      { path: "hud[0]>row[0]>b[2]", tag: "button", classes: "b3", top: 264, left: 280, width: 100, height: 32 },
+    ]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.ok(kinds(report).includes("near-misalignment"), kinds(report).join(", "));
+  });
+});
+
+describe("coverage is reported, not implied", () => {
+  it("names every rule it could not evaluate", async () => {
+    const path = await withElements([ROOT]);
+    const report = await runImageIntegrityCheck({ elementsPath: path });
+    assert.equal(report.verdict, "clean");
+    assert.equal(report.skippedRules.length, IMAGE_MODE_SKIPPED_RULES.length);
+    // The specific danger: a clean verdict over a third of the rules reading as a clean
+    // verdict over all of them. Every skipped rule carries a reason so the gap is auditable
+    // rather than a number to shrug at.
+    assert.ok(report.skippedRules.every((r) => r.reason.length > 10), JSON.stringify(report.skippedRules));
+    for (const needsDom of ["low-contrast-text", "occluded-text", "js-error"]) {
+      assert.ok(report.skippedRules.some((r) => r.rule === needsDom), `${needsDom} must be listed`);
+    }
+  });
+});
+
+describe("parsing", () => {
+  it("accepts a bare array and both field-name conventions", () => {
+    // The caller writes this JSON from a non-JS language; rejecting `text_measured` would
+    // be a gratuitous obstacle.
+    const parsed = parseIntegrityImageElements(JSON.stringify([
+      { path: "a[0]", tag: "a", top: 0, left: 0, width: 10, height: 10, text_measured: { width: 5, height: 5 }, aria_hidden: true, z_index: 3 },
+    ]));
+    assert.equal(parsed.length, 1);
+    assert.deepEqual(parsed[0]!.textMeasured, { width: 5, height: 5 });
+    assert.equal(parsed[0]!.ariaHidden, true);
+    assert.equal(parsed[0]!.zIndex, 3);
+  });
+
+  it("throws on a row missing geometry instead of dropping it", () => {
+    // Silently skipping an unplaceable row would make a typo look like a clean frame — the
+    // same failure mode the coverage reporting above exists to prevent.
+    assert.throws(
+      () => parseIntegrityImageElements(JSON.stringify([{ path: "a[0]", tag: "a", top: 0, left: 0 }])),
+      /needs path\/top\/left\/width\/height/,
+    );
+  });
+
+  it("rejects input that is neither an array nor {elements}", () => {
+    assert.throws(() => parseIntegrityImageElements(JSON.stringify({ nodes: [] })), /must be an array/);
+  });
+});

--- a/packages/vlmkit-markup/src/inspect/integrity-image.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-image.ts
@@ -1,0 +1,502 @@
+/**
+ * `check integrity` without a DOM: a frame PNG plus an element-rect JSON.
+ *
+ * Requested in vlmkit#116 by a canvas/WebGPU game engine. In a canvas UI the DOM holds a
+ * single `<canvas>` element, so every `getBoundingClientRect`-based rule finds nothing to
+ * look at and the gate reports `clean` on a frame that may be visibly broken. The same
+ * applies to native renderers (GLFW / SDL / wgpu), Flutter / Skia, and engine editor UIs.
+ *
+ * The measurement functions in `integrity-check.ts` are reused unchanged. They were already
+ * pure over candidate structs — `findTextCollisions(IntegrityTextBlock[])`,
+ * `judgeProtrusions(ProtrusionCandidate[])` and so on — so this file is an adapter, not a
+ * second implementation of the rules. **That is the whole point: the DOM becomes one adapter
+ * among several rather than the only way in.**
+ *
+ * ## What it will not do
+ *
+ * Six of the gate's eighteen rules are evaluable from this input. The other twelve need
+ * computed styles, a network log, or a live page. This module **names the ones it skipped**
+ * rather than omitting them, because a `clean` verdict that quietly covered a third of the
+ * rules it usually covers is worth much less than it looks — the same reason `check story`
+ * distinguishes `story-drift` (a finding) from `mount-failed` (nothing was measured).
+ *
+ * ## Parentage
+ *
+ * `path` is `tag[0]>tag[1]>…`, so containment relationships come from string prefixes and
+ * need no CSS. One caveat, respected below: the DOM capture only records elements that carry
+ * a class or are semantic, so a recorded path can skip levels and a node's true parent may be
+ * absent from the input. What is derived is therefore the **nearest recorded ancestor**, and
+ * the findings say so — claiming "parent" would be a claim the data cannot support.
+ */
+import { readFile } from "node:fs/promises";
+import { PNG } from "pngjs";
+import {
+  type AlignmentGroup,
+  type ClipCandidate,
+  type CollapseCandidate,
+  type IntegrityExemption,
+  type IntegrityFinding,
+  type IntegrityReport,
+  type IntegrityTextBlock,
+  type ProtrusionCandidate,
+  findTextCollisions,
+  judgeAlignment,
+  judgeClippedText,
+  judgeCollapsedContainers,
+  judgeProtrusions,
+  measureInkRatio,
+} from "./integrity-check.ts";
+
+/**
+ * One element rect, as the caller's renderer knows it.
+ *
+ * A superset of the `--elements-json` schema `diff png` already accepts, so an engine that
+ * emits that shape can pass the same file here. Everything past the six required geometry
+ * fields is optional and unlocks a specific rule — stated per field, because "add more
+ * fields and more things happen" is not a contract anyone can plan against.
+ */
+export interface IntegrityImageElement {
+  path: string;
+  tag: string;
+  id?: string;
+  classes?: string;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  /** Text drawn in this element. Required for text-collision and text-clipped. */
+  text?: string;
+  /**
+   * The text's measured extent, which only the renderer can know. With it,
+   * text-clipped can fire; without it, a caller gets no clipping analysis rather than a
+   * guess from glyph counts.
+   */
+  textMeasured?: { width: number; height: number };
+  /** Clip rect applied to this element, if any. Defaults to the element's own box. */
+  clip?: { top: number; left: number; width: number; height: number };
+  /** On a separate compositing layer. Overlapping layers are not collisions. */
+  overlay?: boolean;
+  /** Stacking order. Blocks on different z are layered, not colliding. */
+  zIndex?: number;
+  /** Decorative / not announced. Excluded from text rules, like `aria-hidden`. */
+  ariaHidden?: boolean;
+}
+
+export interface IntegrityImageOptions {
+  /** Frame PNG. Optional: without it the ink-based degenerate-render rule cannot run. */
+  imagePath?: string;
+  elementsPath: string;
+  maxFindings?: number;
+  /**
+   * Width reported on findings. Defaults to the image width, else the widest element
+   * right edge — the rules take a viewport only to label findings.
+   */
+  viewport?: number;
+}
+
+/** Rules this input cannot support, each with the reason. Reported, not hidden. */
+export const IMAGE_MODE_SKIPPED_RULES: { rule: string; reason: string }[] = [
+  { rule: "js-error", reason: "needs a live page's console" },
+  { rule: "broken-image", reason: "needs the network log" },
+  { rule: "failed-stylesheet", reason: "needs the network log" },
+  { rule: "broken-font", reason: "needs the network log" },
+  { rule: "redirected", reason: "needs the navigation result" },
+  { rule: "unstyled-page", reason: "needs computed styles" },
+  { rule: "page-overflow-x", reason: "needs the document scroll size" },
+  { rule: "clipped-content", reason: "needs overflow computed styles" },
+  { rule: "nested-scroll", reason: "needs overflow computed styles" },
+  { rule: "invisible-text", reason: "needs computed color / opacity / visibility" },
+  { rule: "low-contrast-text", reason: "needs computed text and background colors" },
+  { rule: "occluded-text", reason: "needs paint order, which element rects do not carry" },
+];
+
+export interface IntegrityImageReport extends IntegrityReport {
+  /** Rules that did not run, and why. */
+  skippedRules: { rule: string; reason: string }[];
+  /** Rules that ran but had no input — e.g. no element carried `text`. */
+  inertRules: { rule: string; reason: string }[];
+}
+
+export async function runImageIntegrityCheck(
+  options: IntegrityImageOptions,
+): Promise<IntegrityImageReport> {
+  const elements = parseIntegrityImageElements(await readFile(options.elementsPath, "utf-8"));
+  const maxFindings = options.maxFindings ?? 12;
+
+  let image: { data: Uint8Array; width: number; height: number } | undefined;
+  if (options.imagePath) {
+    const png = PNG.sync.read(await readFile(options.imagePath));
+    image = {
+      data: new Uint8Array(png.data.buffer, png.data.byteOffset, png.data.byteLength),
+      width: png.width,
+      height: png.height,
+    };
+  }
+
+  const viewport = options.viewport
+    ?? image?.width
+    ?? Math.max(0, ...elements.map((e) => e.left + e.width));
+
+  const findings: IntegrityFinding[] = [];
+  const exempted: IntegrityExemption[] = [];
+  const inertRules: { rule: string; reason: string }[] = [];
+
+  // --- degenerate render (the one rule that reads pixels) ---
+  const inkRatio = image ? measureInkRatio(image.data, image.width, image.height) : 0;
+  if (!image) {
+    inertRules.push({ rule: "degenerate-render", reason: "no --image given" });
+  } else if (elements.length === 0 && inkRatio < 0.001) {
+    findings.push({
+      kind: "degenerate-render",
+      severity: "fail",
+      viewport,
+      message: `The frame contains no elements and almost no ink (ink ratio ${(inkRatio * 100).toFixed(2)}%) — nothing but background painted.`,
+      evidence: { inkRatio, elements: 0 },
+    });
+  }
+
+  const withText = elements.filter((e) => (e.text ?? "").trim().length > 0);
+
+  // --- text collision ---
+  if (withText.length < 2) {
+    inertRules.push({
+      rule: "text-collision",
+      reason: withText.length === 0
+        ? "no element carried `text`"
+        : "only one element carried `text`; a collision needs two",
+    });
+  } else {
+    const collisions = findTextCollisions(withText.map(toTextBlock), viewport, { maxFindings });
+    findings.push(...collisions.findings);
+    exempted.push(...collisions.exempted);
+  }
+
+  // --- text clipped ---
+  //
+  // Requires an explicit `clip` rect, not just an oversized text extent. In a DOM the
+  // clip comes from `overflow: hidden|clip` and the amount from `scrollWidth -
+  // clientWidth`; on a canvas, text drawn wider than its box is not clipped at all — it
+  // *overdraws*, which is what the collision and protrusion rules are for. Treating the
+  // element's own box as a clip rect reported a label whose 90px of text sat in a 180px
+  // box as "cutting off 40px", which is the opposite of true.
+  const clipCandidates = withText
+    .filter((element) => element.textMeasured && element.clip)
+    .map(toClipCandidate)
+    .filter(isMeaningfullyClipped);
+  if (clipCandidates.length === 0) {
+    inertRules.push({
+      rule: "text-clipped",
+      reason: withText.some((e) => e.textMeasured)
+        ? "no element declared a `clip` rect its text exceeds; oversized text without a clip overdraws rather than clipping"
+        : "no element carried both `text` and `textMeasured`; the renderer must supply the measured extent",
+    });
+  } else {
+    const clipped = judgeClippedText(clipCandidates, viewport, maxFindings);
+    findings.push(...clipped.findings);
+    exempted.push(...clipped.exempted);
+  }
+
+  // --- protrusion and collapse, both from nearest recorded ancestor ---
+  const byPath = new Map(elements.map((element) => [element.path, element]));
+  const protrusions: ProtrusionCandidate[] = [];
+  const collapseByPath = new Map<string, CollapseCandidate>();
+  for (const element of elements) {
+    const ancestor = nearestRecordedAncestor(element, byPath);
+    if (!ancestor) continue;
+    collectCollapse(element, ancestor, collapseByPath);
+    const overflow = protrusionAmount(element, ancestor);
+    if (overflow) {
+      protrusions.push({
+        parent: describe(ancestor),
+        child: describe(element),
+        amount: overflow.amount,
+        axis: overflow.axis,
+        // No computed styles, so neither exemption can be established. Both default to
+        // false, which means an intentionally-positioned badge WILL be reported here —
+        // set `overlay` on the element to opt it out.
+        positioned: element.overlay === true,
+        negBreakout: false,
+      });
+    }
+  }
+  if (protrusions.length === 0) {
+    inertRules.push({ rule: "container-protrusion", reason: "no element exceeded its nearest recorded ancestor's box" });
+  } else {
+    const judged = judgeProtrusions(protrusions, viewport, maxFindings);
+    findings.push(...judged.findings);
+    exempted.push(...judged.exempted);
+  }
+
+  const collapsed = judgeCollapsedContainers([...collapseByPath.values()], viewport);
+  findings.push(...collapsed.findings);
+  exempted.push(...collapsed.exempted);
+
+  // --- near-misalignment: siblings share a parent path prefix ---
+  const groups = alignmentGroups(elements, byPath);
+  if (groups.length === 0) {
+    inertRules.push({ rule: "near-misalignment", reason: "no recorded ancestor had two or more recorded children" });
+  } else {
+    findings.push(...judgeAlignment(groups, viewport, Math.min(maxFindings, 8)));
+  }
+
+  return {
+    source: options.imagePath ?? options.elementsPath,
+    verdict: findings.some((f) => f.severity === "fail") ? "defects" : "clean",
+    findings,
+    exempted,
+    viewports: [{
+      width: image?.width ?? viewport,
+      height: image?.height ?? Math.max(0, ...elements.map((e) => e.top + e.height)),
+      components: elements.length,
+      inkRatio,
+      textBlocks: withText.length,
+    }],
+    kickback: findings.map((f) => `${f.kind}${f.selector ? ` (${f.selector})` : ""}: ${f.message}`),
+    skippedRules: IMAGE_MODE_SKIPPED_RULES,
+    inertRules,
+  };
+}
+
+/**
+ * The browser collector's thresholds, replicated so the two adapters agree.
+ *
+ * `judgeCollapsedContainers` has no height check of its own — it trusts the caller to have
+ * filtered to containers that actually collapsed. The first version of this adapter passed
+ * every ancestor and reported a 360px-tall root as "collapsed" because it held 40px
+ * children; the judge had no way to know better.
+ */
+const COLLAPSE_MAX_HEIGHT = 4;
+const COLLAPSE_MIN_CHILD_HEIGHT = 24;
+
+function collectCollapse(
+  element: IntegrityImageElement,
+  ancestor: IntegrityImageElement,
+  into: Map<string, CollapseCandidate>,
+): void {
+  if (ancestor.height > COLLAPSE_MAX_HEIGHT || ancestor.width <= 0) return;
+  if (element.height < COLLAPSE_MIN_CHILD_HEIGHT) return;
+  const existing = into.get(ancestor.path) ?? {
+    selector: describe(ancestor),
+    height: ancestor.height,
+    tallestChild: 0,
+    anyInFlowChild: false,
+    overflowHidden: false,
+  };
+  if (element.height > existing.tallestChild) existing.tallestChild = element.height;
+  if (element.overlay !== true) existing.anyInFlowChild = true;
+  into.set(ancestor.path, existing);
+}
+
+function toTextBlock(element: IntegrityImageElement): IntegrityTextBlock {
+  return {
+    selector: describe(element),
+    text: element.text ?? "",
+    x: element.left,
+    y: element.top,
+    width: element.width,
+    height: element.height,
+    overlay: element.overlay === true,
+    zIndex: element.zIndex ?? 0,
+    ariaHidden: element.ariaHidden === true,
+    // No font metrics without a DOM. 0 means "shrink the box by nothing", which is the
+    // same default the DOM path uses when canvas metrics were unavailable.
+    inkInset: 0,
+  };
+}
+
+/**
+ * `clipX` / `clipY` are **amounts clipped in px**, not the clip rect's origin.
+ *
+ * The DOM path computes them as `scrollWidth - clientWidth`, and `judgeClippedText`
+ * interpolates them straight into "cuts off Npx of text". Passing the rect's `left`/`top`
+ * instead produced a message that read like a measurement and was not one: a label at
+ * `left: 16` was reported as "cuts off 16px".
+ */
+function toClipCandidate(element: IntegrityImageElement): ClipCandidate {
+  const clip = element.clip!;
+  const measured = element.textMeasured!;
+  const clipX = Math.max(0, Math.round(measured.width - clip.width));
+  const clipY = Math.max(0, Math.round(measured.height - clip.height));
+  const visibleWidth = Math.max(0, Math.min(measured.width, clip.width));
+  const visibleHeight = Math.max(0, Math.min(measured.height, clip.height));
+  return {
+    selector: describe(element),
+    text: element.text ?? "",
+    clipX,
+    clipY,
+    // Neither is knowable without CSS. Empty means "no ellipsis declared", so a genuinely
+    // clipped string is reported rather than excused — the safe direction for a gate.
+    textOverflow: "",
+    lineClamp: "",
+    textVisibleArea: visibleWidth * visibleHeight,
+    srOnlyShaped: element.width <= 2 && element.height <= 2,
+    replacement: false,
+  };
+}
+
+/**
+ * The DOM collector's threshold, replicated: `clipX < 4 && clipY < max(4, lineHeight*0.6)`
+ * is not a clip worth reporting. `judgeClippedText` has no such check — it reports every
+ * candidate handed to it — so without this filter every clipped-or-not label became a
+ * finding.
+ */
+function isMeaningfullyClipped(candidate: ClipCandidate): boolean {
+  const lineHeight = Math.max(1, candidate.textVisibleArea > 0 ? candidate.clipY + 1 : 1);
+  return candidate.clipX >= 4 || candidate.clipY >= Math.max(4, lineHeight * 0.6);
+}
+
+/**
+ * The longest recorded path that is a strict prefix of this element's.
+ *
+ * Not "the parent": the capture skips uninteresting nodes, so the true parent may not be in
+ * the input. Callers get the closest thing the data supports, and the finding text says
+ * "nearest recorded ancestor" so nobody reads more into it.
+ */
+function nearestRecordedAncestor(
+  element: IntegrityImageElement,
+  byPath: Map<string, IntegrityImageElement>,
+): IntegrityImageElement | undefined {
+  const segments = element.path.split(">");
+  for (let cut = segments.length - 1; cut > 0; cut--) {
+    const candidate = byPath.get(segments.slice(0, cut).join(">"));
+    if (candidate) return candidate;
+  }
+  return undefined;
+}
+
+function protrusionAmount(
+  child: IntegrityImageElement,
+  parent: IntegrityImageElement,
+): { amount: number; axis: "horizontal" | "vertical" } | null {
+  const right = (child.left + child.width) - (parent.left + parent.width);
+  const left = parent.left - child.left;
+  const bottom = (child.top + child.height) - (parent.top + parent.height);
+  const top = parent.top - child.top;
+  const horizontal = Math.max(right, left);
+  const vertical = Math.max(bottom, top);
+  const amount = Math.max(horizontal, vertical);
+  if (amount <= 0) return null;
+  return { amount, axis: horizontal >= vertical ? "horizontal" : "vertical" };
+}
+
+function alignmentGroups(
+  elements: IntegrityImageElement[],
+  byPath: Map<string, IntegrityImageElement>,
+): AlignmentGroup[] {
+  const children = new Map<string, IntegrityImageElement[]>();
+  for (const element of elements) {
+    const ancestor = nearestRecordedAncestor(element, byPath);
+    if (!ancestor) continue;
+    const list = children.get(ancestor.path) ?? [];
+    list.push(element);
+    children.set(ancestor.path, list);
+  }
+  const groups: AlignmentGroup[] = [];
+  for (const [parentPath, list] of children) {
+    if (list.length < 2) continue;
+    groups.push({
+      parent: describe(byPath.get(parentPath)!),
+      children: list.map((element) => ({
+        selector: describe(element),
+        left: element.left,
+        right: element.left + element.width,
+        centerX: element.left + element.width / 2,
+        top: element.top,
+      })),
+    });
+  }
+  return groups;
+}
+
+/**
+ * A stable label for an element.
+ *
+ * `.class` then `#id` then `tag`, matching `selectorForElement` in
+ * `region-selector-match.ts`, so the same element reads the same way whether it surfaced
+ * through `diff png --elements-json` or here. Falls back to the path, which is always
+ * present and always unique.
+ */
+function describe(element: IntegrityImageElement): string {
+  const className = (element.classes ?? "").split(/\s+/).find((token) => /^-?[A-Za-z_][\w-]*$/.test(token));
+  if (className) return `.${className}`;
+  if (element.id && /^-?[A-Za-z_][\w-]*$/.test(element.id)) return `#${element.id}`;
+  if (/^[A-Za-z][\w-]*$/.test(element.tag)) return element.tag;
+  return element.path;
+}
+
+/**
+ * Parse the elements file.
+ *
+ * Accepts `{elements:[…]}` or a bare array, like `diff png --elements-json`, and both
+ * `snake_case` and `camelCase` for the optional fields — the reporting engine writes JSON
+ * from a non-JS language, and rejecting `text_measured` would be a gratuitous obstacle.
+ */
+export function parseIntegrityImageElements(source: string): IntegrityImageElement[] {
+  const parsed: unknown = JSON.parse(source);
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : (parsed as { elements?: unknown })?.elements;
+  if (!Array.isArray(rows)) {
+    throw new Error("elements JSON must be an array or an object with an `elements` array");
+  }
+  const out: IntegrityImageElement[] = [];
+  for (const [index, row] of rows.entries()) {
+    if (typeof row !== "object" || row === null) continue;
+    const record = row as Record<string, unknown>;
+    const path = str(record.path);
+    const numbers = ["top", "left", "width", "height"].map((key) => num(record[key]));
+    if (!path || numbers.some((value) => value === undefined)) {
+      // A row missing geometry cannot be placed, and silently dropping it would make a
+      // typo look like a clean frame.
+      throw new Error(
+        `elements[${index}] needs path/top/left/width/height (got ${JSON.stringify(record).slice(0, 120)})`,
+      );
+    }
+    const [top, left, width, height] = numbers as [number, number, number, number];
+    const measured = record.textMeasured ?? record.text_measured;
+    const element: IntegrityImageElement = {
+      path,
+      tag: str(record.tag) ?? "node",
+      top, left, width, height,
+      ...(str(record.id) ? { id: str(record.id)! } : {}),
+      ...(str(record.classes) ? { classes: str(record.classes)! } : {}),
+      ...(str(record.text) !== undefined ? { text: str(record.text)! } : {}),
+      ...(parseBox(measured) ? { textMeasured: parseBox(measured)! } : {}),
+      ...(parseRect(record.clip) ? { clip: parseRect(record.clip)! } : {}),
+      ...(record.overlay === true ? { overlay: true } : {}),
+      ...(num(record.zIndex ?? record.z_index) !== undefined
+        ? { zIndex: num(record.zIndex ?? record.z_index)! }
+        : {}),
+      ...((record.ariaHidden ?? record.aria_hidden) === true ? { ariaHidden: true } : {}),
+    };
+    out.push(element);
+  }
+  return out;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseBox(value: unknown): { width: number; height: number } | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const width = num(record.width);
+  const height = num(record.height);
+  return width !== undefined && height !== undefined ? { width, height } : undefined;
+}
+
+function parseRect(
+  value: unknown,
+): { top: number; left: number; width: number; height: number } | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const parts = ["top", "left", "width", "height"].map((key) => num(record[key]));
+  if (parts.some((part) => part === undefined)) return undefined;
+  const [top, left, width, height] = parts as [number, number, number, number];
+  return { top, left, width, height };
+}

--- a/packages/vlmkit-markup/src/png-diff.ts
+++ b/packages/vlmkit-markup/src/png-diff.ts
@@ -5,7 +5,7 @@ import { readPngDimensions } from "@mizchi/vlmkit-core/image-resize.ts";
 import { classifyVisualDiff } from "./visual-semantic.ts";
 import {
   captureRegionElementsFromHtml,
-  matchRegionBboxToElement,
+  matchRegionBboxToElements,
   parseRegionElementsJson,
   parseRegionElementsViewport,
   type RegionElementRect,
@@ -28,6 +28,18 @@ export interface PngDiffCliOptions {
   elementsViewport?: RegionElementsViewport;
   /** Directory to write one baseline/current/diff crop triple per region. */
   cropRegions?: string;
+  /**
+   * Region-detection grid in pixels. Omitted means adaptive — see
+   * `adaptiveRegionCellSize`. Set it when the default bucket is wrong for your frames.
+   */
+  regionGrid?: number;
+  /**
+   * How many attribution candidates to report per region (default 1).
+   *
+   * Worth raising when a report blames something implausible: the runners-up are already
+   * computed, and one wrong winner otherwise hides every alternative.
+   */
+  elementsTop?: number;
 }
 
 export interface PngDiffRegionCrop {
@@ -66,7 +78,13 @@ Options:
   --elements-viewport <WxH>
                         Viewport for --elements-html (default: current PNG size)
   --crop-regions <dir>  Write a baseline/current/diff crop triple per region
-                        into <dir> for direct inspection (no VLM)`;
+                        into <dir> for direct inspection (no VLM)
+  --region-grid <px>    Region-detection cell size. Default adapts to the image
+                        (32 at >=720px short side, 16 at >=480, else 8) because a
+                        region coarser than the element that changed misattributes
+                        the cause. Lower it for small frames with fine detail.
+  --elements-top <N>    Report the top N attribution candidates per region
+                        (default 1) instead of only the winner`;
 }
 
 export function parsePngDiffArgs(args: string[]): PngDiffCliOptions {
@@ -76,6 +94,8 @@ export function parsePngDiffArgs(args: string[]): PngDiffCliOptions {
   let skipHeatmap = false;
   let json = false;
   let elementsJson: string | undefined;
+  let regionGrid: number | undefined;
+  let elementsTop: number | undefined;
   let elementsHtml: string | undefined;
   let elementsViewport: RegionElementsViewport | undefined;
   let cropRegions: string | undefined;
@@ -99,6 +119,24 @@ export function parsePngDiffArgs(args: string[]): PngDiffCliOptions {
         const value = args[++i];
         if (!value) throw new PngDiffCliError(`Missing value for ${arg}\n\n${formatPngDiffUsage()}`, 1);
         elementsHtml = value;
+        break;
+      }
+      case "--region-grid": {
+        const value = args[++i];
+        const parsed = Number(value);
+        if (!value || !Number.isInteger(parsed) || parsed < 1) {
+          throw new PngDiffCliError(`--region-grid requires a positive integer, got: ${value ?? "(missing)"}`, 2);
+        }
+        regionGrid = parsed;
+        break;
+      }
+      case "--elements-top": {
+        const value = args[++i];
+        const parsed = Number(value);
+        if (!value || !Number.isInteger(parsed) || parsed < 1) {
+          throw new PngDiffCliError(`--elements-top requires a positive integer, got: ${value ?? "(missing)"}`, 2);
+        }
+        elementsTop = parsed;
         break;
       }
       case "--elements-viewport": {
@@ -157,6 +195,8 @@ export function parsePngDiffArgs(args: string[]): PngDiffCliOptions {
     ...(elementsHtml ? { elementsHtml } : {}),
     ...(elementsViewport ? { elementsViewport } : {}),
     ...(cropRegions ? { cropRegions } : {}),
+    ...(regionGrid !== undefined ? { regionGrid } : {}),
+    ...(elementsTop !== undefined ? { elementsTop } : {}),
   };
 }
 
@@ -176,12 +216,18 @@ async function resolveElements(
   return null;
 }
 
-function attachSelectorCandidates(regions: DiffRegion[], elements: RegionElementRect[]): void {
+function attachSelectorCandidates(
+  regions: DiffRegion[],
+  elements: RegionElementRect[],
+  limit = 1,
+): void {
   for (const region of regions) {
-    const match = matchRegionBboxToElement(
+    const matches = matchRegionBboxToElements(
       { left: region.x, top: region.y, width: region.width, height: region.height },
       elements,
+      limit,
     );
+    const [match, ...runnersUp] = matches;
     if (!match) continue;
     region.selectorCandidate = {
       selector: match.selector,
@@ -190,6 +236,20 @@ function attachSelectorCandidates(regions: DiffRegion[], elements: RegionElement
       tag: match.evidence.tag,
       regionCoverage: match.evidence.regionCoverage,
       elementCoverage: match.evidence.elementCoverage,
+      // Only when asked for: the field is absent at the default limit of 1, so existing
+      // JSON consumers see exactly the shape they saw before.
+      ...(runnersUp.length > 0
+        ? {
+          alternates: runnersUp.map((alternate) => ({
+            selector: alternate.selector,
+            confidence: alternate.confidence,
+            path: alternate.evidence.path,
+            tag: alternate.evidence.tag,
+            regionCoverage: alternate.evidence.regionCoverage,
+            elementCoverage: alternate.evidence.elementCoverage,
+          })),
+        }
+        : {}),
     };
   }
 }
@@ -212,6 +272,7 @@ export async function runPngDiff(options: PngDiffCliOptions) {
     outputDir: options.skipHeatmap ? undefined : options.outputDir,
     skipHeatmap: options.skipHeatmap,
     threshold: options.threshold,
+    ...(options.regionGrid !== undefined ? { regionCellSize: options.regionGrid } : {}),
   });
   if (!diff) {
     throw new Error("PNG diff requires both baseline and current screenshot paths");
@@ -230,7 +291,7 @@ export async function runPngDiff(options: PngDiffCliOptions) {
 
   const elements = await resolveElements(options, currentSize);
   if (elements && elements.length > 0) {
-    attachSelectorCandidates(diff.regions, elements);
+    attachSelectorCandidates(diff.regions, elements, options.elementsTop ?? 1);
   }
 
   const semantic = classifyVisualDiff(diff);

--- a/packages/vlmkit-markup/src/region-attribution.test.ts
+++ b/packages/vlmkit-markup/src/region-attribution.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Diff-region granularity and attribution, for small frames.
+ *
+ * Both come from vlmkit#117, reported against a 640x360 canvas HUD whose only change was
+ * an HP bar's fill (`(106,16) 90x20`). Reproduced before changing anything: the region came
+ * back as `(96,0) 128x64` — larger than the `200x20` element that caused it — and the
+ * selector named `.hud-root`, the full frame, instead of `.hp-bar`.
+ *
+ * The issue filed those as two problems. They are one. `regionCoverage` carries weight 0.7,
+ * so a region coarser than the element hands a containing ancestor a free `1.0` while
+ * starving the leaf; the resulting 0.391-vs-0.385 near-tie is the symptom, not a second
+ * defect. The arithmetic below is asserted directly, because "the grid caused the
+ * misattribution" is the claim the fix rests on and it is cheap to state as a test rather
+ * than as a paragraph.
+ *
+ * None of this had coverage. `heatmap-regions.test.ts` asserts exact bboxes from
+ * `findHeatmapRegionsFromRgba`, which is a different function; nothing exercised
+ * `detectDiffRegions`' grid at all, so the suite stayed green through the change that
+ * introduced the bug and through the change that fixed it.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { adaptiveRegionCellSize } from "@mizchi/vlmkit-core/heatmap.ts";
+import {
+  matchRegionBboxToElement,
+  matchRegionBboxToElements,
+  type RegionElementRect,
+} from "./region-selector-match.ts";
+
+/** The elements-json from the issue, verbatim. */
+const HUD: RegionElementRect[] = [
+  { path: "hud[0]", tag: "hud", id: "hud", classes: "hud-root", top: 0, left: 0, width: 640, height: 360 },
+  { path: "hud[0]>bar[0]", tag: "bar", id: "hp_bar", classes: "hp-bar", top: 16, left: 16, width: 200, height: 20 },
+  { path: "hud[0]>panel[1]", tag: "panel", id: "score_panel", classes: "score-panel", top: 16, left: 500, width: 124, height: 20 },
+  { path: "hud[0]>button[2]", tag: "button", id: "pause_button", classes: "pause-button", top: 320, left: 270, width: 100, height: 28 },
+];
+
+describe("adaptiveRegionCellSize", () => {
+  it("keeps 32px wherever it was already working", () => {
+    // Page screenshots. Changing these would move region bboxes that already appear in
+    // baselines, approvals and reports, so the buckets exist to leave them alone.
+    assert.equal(adaptiveRegionCellSize(1280, 720), 32);
+    assert.equal(adaptiveRegionCellSize(1280, 4000), 32);
+    assert.equal(adaptiveRegionCellSize(720, 720), 32);
+  });
+
+  it("refines small frames, where 32px cannot be right", () => {
+    assert.equal(adaptiveRegionCellSize(640, 360), 8, "the reported HUD size");
+    assert.equal(adaptiveRegionCellSize(320, 240), 8, "a dot-art HUD");
+    assert.equal(adaptiveRegionCellSize(640, 480), 16);
+  });
+
+  it("keys off the short side, not the area", () => {
+    // A 2000x300 strip is small in the dimension that matters: a 32px cell is a tenth of
+    // its height. Area-based bucketing would call it large and keep the coarse grid.
+    assert.equal(adaptiveRegionCellSize(2000, 300), 8);
+    assert.equal(adaptiveRegionCellSize(300, 2000), 8);
+  });
+
+  it("is bucketed, so nearby sizes do not shift region geometry", () => {
+    // A continuous function (min/40 or similar) would give a different grid for almost
+    // every image, changing bboxes on pages nobody was complaining about.
+    for (const height of [720, 800, 900, 1080, 1200]) {
+      assert.equal(adaptiveRegionCellSize(1280, height), 32, `height ${height}`);
+    }
+  });
+});
+
+describe("attribution on the vlmkit#117 HUD", () => {
+  it("blamed the full-frame ancestor at the old 32px grid", () => {
+    // The reproduction, kept as a test so the fix is anchored to a real failure rather
+    // than to a description of one. `(96,0) 128x64` is what a 32px grid produced.
+    const coarse = { left: 96, top: 0, width: 128, height: 64 };
+    const scores = matchRegionBboxToElements(coarse, HUD, 4);
+    const byName = new Map(scores.map((m) => [m.selector, m.evidence.score]));
+    // The issue quoted 0.391 / 0.385; `roundMetric` keeps four places, so these are the
+    // same numbers at full reported precision. The gap is 0.0058.
+    assert.equal(byName.get(".hud-root"), 0.3909, "ancestor score");
+    assert.equal(byName.get(".hp-bar"), 0.3851, "real cause, 0.0058 behind");
+  });
+
+  it("picks the real cause at that same coarse region, via the near-tie rule", () => {
+    // Insurance for cases where the grid cannot be fine enough: a 0.006 gap is not signal,
+    // and the smaller box is the more useful answer.
+    const coarse = { left: 96, top: 0, width: 128, height: 64 };
+    assert.equal(matchRegionBboxToElement(coarse, HUD)?.selector, ".hp-bar");
+  });
+
+  it("picks the real cause at the adaptive grid, without needing the tie-break", () => {
+    // What the CLI now produces for this frame: (104,16) 96x24. Here the leaf wins on
+    // score outright, which is the actual fix — the tie-break is a second line of defence.
+    const tight = { left: 104, top: 16, width: 96, height: 24 };
+    const best = matchRegionBboxToElements(tight, HUD, 4);
+    assert.equal(best[0]?.selector, ".hp-bar");
+    assert.ok(
+      best[0]!.evidence.score - (best[1]?.evidence.score ?? 0) > 0.2,
+      `expected a decisive win, got ${JSON.stringify(best.map((m) => [m.selector, m.evidence.score]))}`,
+    );
+  });
+});
+
+describe("near-tie rule does not reorder same-scale candidates", () => {
+  it("leaves similarly-sized siblings on score order", () => {
+    // The rule requires the winner to be at most half the area of the loser. Without that
+    // bound, a few thousandths of score would reshuffle overlapping siblings arbitrarily.
+    const siblings: RegionElementRect[] = [
+      { path: "a", tag: "div", classes: "left", top: 0, left: 0, width: 100, height: 40 },
+      { path: "b", tag: "div", classes: "right", top: 0, left: 60, width: 96, height: 40 },
+    ];
+    const region = { left: 0, top: 0, width: 100, height: 40 };
+    const ranked = matchRegionBboxToElements(region, siblings, 2);
+    assert.equal(ranked[0]?.selector, ".left", "the better-covered sibling still wins");
+    assert.ok(
+      ranked[0]!.evidence.score >= ranked[1]!.evidence.score,
+      "ranking must stay score-ordered among same-scale candidates",
+    );
+  });
+});
+
+describe("ranked candidates", () => {
+  it("returns runners-up best-first", () => {
+    const region = { left: 96, top: 0, width: 128, height: 64 };
+    const ranked = matchRegionBboxToElements(region, HUD, 3);
+    assert.ok(ranked.length >= 2, `expected at least 2 candidates, got ${ranked.length}`);
+    assert.deepEqual(
+      ranked.map((m) => m.selector).slice(0, 2),
+      [".hp-bar", ".hud-root"],
+      "the real cause first, the ancestor it beat second",
+    );
+  });
+
+  it("honours the limit and still applies the coverage floor", () => {
+    const region = { left: 96, top: 0, width: 128, height: 64 };
+    assert.equal(matchRegionBboxToElements(region, HUD, 1).length, 1);
+    // `.score-panel` and `.pause-button` do not intersect this region at all, so a limit
+    // above the number of real candidates must not invent any.
+    assert.ok(matchRegionBboxToElements(region, HUD, 10).length <= 2);
+  });
+
+  it("agrees with the singular helper on the winner", () => {
+    // `matchRegionBboxToElement` is now a wrapper; if the two disagreed, every existing
+    // caller would silently get a different answer from the new one.
+    for (const region of [
+      { left: 96, top: 0, width: 128, height: 64 },
+      { left: 104, top: 16, width: 96, height: 24 },
+      { left: 500, top: 16, width: 32, height: 32 },
+      { left: 270, top: 320, width: 64, height: 32 },
+    ]) {
+      assert.equal(
+        matchRegionBboxToElement(region, HUD)?.selector ?? null,
+        matchRegionBboxToElements(region, HUD, 1)[0]?.selector ?? null,
+        `disagreement at ${JSON.stringify(region)}`,
+      );
+    }
+  });
+
+  it("returns nothing when no element explains the region", () => {
+    const empty = { left: 400, top: 200, width: 16, height: 16 };
+    // Only `.hud-root` covers this, at 100% region coverage — so it IS returned. The
+    // assertion worth making is that a zero-area region yields nothing at all.
+    assert.deepEqual(matchRegionBboxToElements({ left: 0, top: 0, width: 0, height: 0 }, HUD), []);
+    assert.equal(matchRegionBboxToElements(empty, HUD, 3).length, 1);
+  });
+});

--- a/packages/vlmkit-markup/src/region-selector-match.ts
+++ b/packages/vlmkit-markup/src/region-selector-match.ts
@@ -54,14 +54,53 @@ export interface RegionElementsViewport {
   height: number;
 }
 
+/**
+ * How close two scores must be before box size decides between them.
+ *
+ * The weights above (0.7 / 0.3) and the 0.55 ancestor penalty are heuristics tuned to one
+ * decimal place, so a gap of a few thousandths is not signal — but the exact-equality
+ * tie-break in `compareSelectorMatches` only fires at 0. On the vlmkit#117 HUD the
+ * full-frame ancestor scored 0.391 against the real cause at 0.385 and won by 0.006.
+ *
+ * When the scores are that close, the smaller box is the more useful answer: an ancestor
+ * that merely *contains* the diff region repeats what the region already said, while a
+ * leaf that overlaps most of it names something to go and change.
+ */
+const SCORE_TIE_MARGIN = 0.02;
+
+/**
+ * How much smaller a box must be for the near-tie rule to prefer it.
+ *
+ * Deliberately not "any smaller": among same-scale siblings a few thousandths of score
+ * really is the only thing distinguishing them, and reordering those would be arbitrary
+ * churn. This targets the ancestor-versus-leaf case the rule exists for.
+ */
+const TIE_AREA_RATIO = 0.5;
+
 export function matchRegionBboxToElement(
   region: RectBox,
   elements: RegionElementRect[],
 ): RegionSelectorMatch | null {
-  const regionArea = areaOfBbox(region);
-  if (regionArea <= 0) return null;
+  return matchRegionBboxToElements(region, elements, 1)[0] ?? null;
+}
 
-  let best: (RegionSelectorMatch & { sortTop: number; sortLeft: number }) | null = null;
+/**
+ * Ranked attribution candidates, best first.
+ *
+ * `matchRegionBboxToElement` returns only the winner, and when the winner is wrong the
+ * evidence for every alternative is gone — the report says `.hud-root` and the reader has
+ * no way to see that `.hp-bar` was 0.006 behind. Returning the runners-up costs nothing
+ * (they are already computed) and turns a wrong answer into a short list.
+ */
+export function matchRegionBboxToElements(
+  region: RectBox,
+  elements: RegionElementRect[],
+  limit = 3,
+): RegionSelectorMatch[] {
+  const regionArea = areaOfBbox(region);
+  if (regionArea <= 0 || limit <= 0) return [];
+
+  const ranked: (RegionSelectorMatch & { sortTop: number; sortLeft: number })[] = [];
   for (const element of elements) {
     const selector = selectorForElement(element);
     if (!selector || element.width <= 0 || element.height <= 0) continue;
@@ -104,25 +143,33 @@ export function matchRegionBboxToElement(
       sortTop: element.top,
       sortLeft: element.left,
     };
-    if (!best || compareSelectorMatches(match, best) < 0) {
-      best = match;
-    }
+    ranked.push(match);
   }
-  if (!best || best.evidence.regionCoverage < 0.15) return null;
-  const { sortTop: _sortTop, sortLeft: _sortLeft, ...out } = best;
-  return out;
+  ranked.sort(compareSelectorMatches);
+  return ranked
+    // Same floor as before: a candidate covering under 15% of the region is not an
+    // explanation for it, and was never returned.
+    .filter((match) => match.evidence.regionCoverage >= 0.15)
+    .slice(0, limit)
+    .map(({ sortTop: _sortTop, sortLeft: _sortLeft, ...out }) => out);
 }
 
 function compareSelectorMatches(
   left: RegionSelectorMatch & { sortTop: number; sortLeft: number },
   right: RegionSelectorMatch & { sortTop: number; sortLeft: number },
 ): number {
+  const leftArea = areaOfBbox(left.evidence.bbox);
+  const rightArea = areaOfBbox(right.evidence.bbox);
+  // Near-tie: prefer the substantially smaller box. Before the exact-score comparison,
+  // because the whole point is that these scores are not meaningfully different.
+  if (Math.abs(left.evidence.score - right.evidence.score) <= SCORE_TIE_MARGIN) {
+    if (leftArea <= rightArea * TIE_AREA_RATIO) return -1;
+    if (rightArea <= leftArea * TIE_AREA_RATIO) return 1;
+  }
   if (left.evidence.score !== right.evidence.score) return right.evidence.score - left.evidence.score;
   if (left.evidence.regionCoverage !== right.evidence.regionCoverage) {
     return right.evidence.regionCoverage - left.evidence.regionCoverage;
   }
-  const leftArea = areaOfBbox(left.evidence.bbox);
-  const rightArea = areaOfBbox(right.evidence.bbox);
   if (leftArea !== rightArea) return leftArea - rightArea;
   if (left.sortTop !== right.sortTop) return left.sortTop - right.sortTop;
   if (left.sortLeft !== right.sortLeft) return left.sortLeft - right.sortLeft;

--- a/packages/vlmkit-mcp/src/gate-tool.test.ts
+++ b/packages/vlmkit-mcp/src/gate-tool.test.ts
@@ -158,3 +158,54 @@ describe("the published tool surface", () => {
     }
   });
 });
+
+/**
+ * Required-ness comes from `required`, not from being positional.
+ *
+ * `gateTool` used to mark an input required when `required === true` **or**
+ * `positional === 0`. That shortcut was redundant — 24 of the 25 positional-0 inputs in
+ * the registry set `required: true` themselves — and it became actively wrong for the
+ * 25th: `check integrity`'s source is optional now that `--elements` supplies element
+ * rects instead of a page. With the shortcut, the MCP schema demanded a page the gate
+ * would then reject as mutually exclusive, so image mode was reachable from the CLI and
+ * unreachable over MCP.
+ *
+ * Both halves are asserted, because dropping the clause is only safe if the 24 really do
+ * declare themselves required. Reading the live registry rather than a fixture: the claim
+ * is about every gate that ships, and a fixture would answer a different question.
+ */
+describe("required-ness follows `required`, not `positional`", () => {
+  it("keeps every other gate's positional source required", async () => {
+    const { loadGateRegistry } = await import("../../../src/cli/gate-registry.ts");
+    const registry = await loadGateRegistry({ builtinsOnly: true });
+    const notRequired: string[] = [];
+    for (const { gate } of registry.list()) {
+      for (const input of gate.inputs ?? []) {
+        if (input.positional !== 0) continue;
+        if (input.required === true) continue;
+        notRequired.push(`${gate.command.join(" ")} :: ${input.name}`);
+      }
+    }
+    // `check integrity` is the intended exception. Anything else appearing here means a
+    // gate is relying on the removed shortcut and its MCP schema just went optional.
+    assert.deepEqual(
+      notRequired,
+      ["check integrity :: source"],
+      "a positional-0 input without `required: true` is now OPTIONAL in the MCP schema — "
+      + "add `required: true` unless it is genuinely optional",
+    );
+  });
+
+  it("leaves check integrity's source optional so image mode is callable", async () => {
+    const { integrityGate } = await import("@mizchi/vlmkit-markup/gates/integrity.gate.ts");
+    const tool = gateTool(integrityGate, { description: "x" });
+    assert.equal(tool.inputSchema.source!.isOptional(), true, "source must be optional");
+    assert.equal(tool.inputSchema.elements!.isOptional(), true);
+    assert.equal(tool.inputSchema.image!.isOptional(), true);
+    // And the argv it builds for image mode must carry neither a positional nor a page.
+    assert.deepEqual(
+      gateToolArgv(integrityGate, { elements: "e.json", image: "f.png" }, { description: "" }),
+      ["--elements", "e.json", "--image", "f.png"],
+    );
+  });
+});

--- a/packages/vlmkit-mcp/src/gate-tool.ts
+++ b/packages/vlmkit-mcp/src/gate-tool.ts
@@ -146,8 +146,14 @@ export function gateTool(gate: AnyGateDefinition, options: GateToolOptions): Mcp
       continue;
     }
     const schema = zodFor(input);
+    // `required` only. `|| input.positional === 0` used to be here, and it was redundant
+    // for 24 of the 25 positional-0 inputs in the registry — every one of them already
+    // sets `required: true`. The 25th is `check integrity`, whose source became optional
+    // when image mode (`--elements`) landed: with the shortcut, an MCP client was forced
+    // to send a page it must not send, so image mode was unreachable over MCP while
+    // working fine on the CLI. `gate-tool.test.ts` asserts the 24 stayed required.
     inputSchema[options.aliases?.[input.name] ?? camel(input.name)] =
-      input.required === true || input.positional === 0 ? schema : schema.optional();
+      input.required === true ? schema : schema.optional();
   }
   return {
     name: gateToolName(gate),


### PR DESCRIPTION
Closes #116. Closes #117.

Both from the same adoption report: a canvas/WebGPU game engine ([kagura](https://github.com/mizchi/kagura))
where the pixel gates worked but every DOM-dependent gate found nothing to look at.

## #117 — the two reported problems are one problem

Reproduced before changing anything, on the reported 640x360 HUD whose only change was an
HP bar's fill at `(106,16) 90x20`. Output matched the issue exactly: `0.78% (1800/230400)`,
region `(96,0) 128x64`, selector `.hud-root`.

`detectDiffRegions` hard-coded a 32px cell, so a 90x20 change became a 128x64 box — larger
than the 200x20 element responsible. `regionCoverage` carries weight 0.7 in the attribution
score, so a region coarser than the element hands a containing ancestor a free `1.0` while
starving the leaf:

| grid | region | `.hud-root` | `.hp-bar` |
|--:|---|--:|--:|
| 32 | 128x64 | **0.391** | 0.385 |
| 16 | 128x32 | 0.388 | **0.590** |
| 8 | 96x24 | 0.387 | **0.727** |

The ancestor won by 0.006 at grid 32 and loses decisively at 16, **with no change to the
scoring function**. The near-tie filed as problem 2 was a symptom of problem 1.

So the cell size adapts: 32 at short side ≥720, 16 at ≥480, else 8. Bucketed rather than
continuous, because a continuous function would shift region geometry on nearly every
existing image and those bboxes appear in baselines, approvals and reports — every
page-sized screenshot stays exactly where it was. Keyed on the short side, since a 2000x300
strip is small in the dimension that matters. `--region-grid <px>` overrides.

Two additions useful independently of the grid:

- **A near-tie rule**: within 0.02 of score, prefer a box at most half the area. The
  existing tie-break only fired at exact equality, and the weights it compares are
  heuristics tuned to one decimal place. Bounded by the area ratio so same-scale siblings
  are not reshuffled.
- **`--elements-top N`** reports runners-up. They were always computed and discarded, and a
  wrong winner otherwise hides every alternative. `alternates` is absent at the default
  limit of 1, so existing JSON consumers see an unchanged shape.

## #116 — image-only `check integrity`

    vlmkit check integrity --elements elements.json --image frame.png

The measurement functions are reused **unchanged** — they were already pure over candidate
structs, so this is an adapter, not a second implementation of the rules. The DOM becomes
one adapter among several rather than the only way in.

Containment comes from `path` prefixes (`hud[0]>bar[0]`), so protrusion, collapsed
containers and near-misalignment need no extra fields. Since the capture only records
elements carrying a class or semantic tag, a path can reference an absent ancestor;
findings therefore name the **nearest recorded ancestor** rather than claiming a parent.

### Coverage is printed, not implied

Six of eighteen rules are evaluable from this input. The report names the other twelve with
the reason each needs a DOM, **next to the verdict** rather than in a footnote — a `clean`
result is only worth what it rules out, and one covering a third of the rules rules out a
third as much. Rules that ran with nothing to judge are listed separately as inert, so "no
findings" cannot be read as "nothing was measured". The DOM path's output is unchanged.

`--elements` and a page source are mutually exclusive, and `--image` alone is rejected: the
two modes evaluate different rule sets, so a combined run's verdict would be ambiguous.

### Three adapter bugs a clean fixture would never have found

Found by testing against a deliberately broken HUD, which is why the test fixtures are
broken rather than tidy. All three are the same shape — the judges have no input validation
because the DOM collectors pre-filter, and my first version did not:

- `judgeCollapsedContainers` reports every candidate handed to it. Passing every ancestor
  called a 360px-tall root "collapsed" for holding 40px children; 2 of 3 collapse findings
  were nonsense. The browser collector's filter (`height <= 4`, `width > 0`, children
  `>= 24px`) is now replicated.
- `clipX`/`clipY` are amounts clipped in px, not the clip rect's origin, and the judge
  interpolates them into "cuts off Npx". Passing the origin reported "cuts off 16px" for a
  label whose only relation to 16 was its `left`. Now 120px for 320px of text in a 200px
  clip.
- Treating an element's own box as its clip rect reported a label with 90px of text in a
  180px box as "cutting off 40px" — the opposite of true. On a canvas, oversized text
  **overdraws**; calling it a clip names the wrong repair. Clipping now requires an explicit
  `clip`.

## Verification

- **2279 tests pass, 0 fail.**
- #117 end to end from the built CLI: default reports `(104,16) 96x24 -> .hp-bar` (medium,
  0.8333); `--region-grid 32` reproduces the old coarse region but still recovers `.hp-bar`
  via the tie-break, showing the two fixes work independently; `--elements-top 3` lists
  `.hud-root` as the runner-up it beat; `--region-grid 0` is rejected.
- #116 both directions: the broken HUD reports 5 findings, each correct (collision, one clip
  at the right amount, two protrusions, one real collapse), exit 1. The clean HUD reports
  none, exit 0, while still printing the twelve unevaluable rules. A clean fixture returning
  `OK` is not evidence a gate can detect anything.

### On the suite staying green

It stayed green through the #117 change *before* any tests were added, and that was not
reassuring: nothing covered `detectDiffRegions`' grid at all — `heatmap-regions.test.ts`
tests `findHeatmapRegionsFromRgba`, a different function. So the suite would have stayed
green through the original defect too. `region-attribution.test.ts` covers it now, including
the 0.3909-vs-0.3851 arithmetic asserted directly.

## Not in scope

#118's four smaller items (image-only `check copy`, `--ignore-region`, `baseline pin
--from-png`, a small-screen preset for `scan component`). `check copy` extends the same
elements-json adapter added here; the rest touch the baseline/snapshot workflow, which is a
separate surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a2DaLhFa2b1Switx8hEg3

---
_Generated by [Claude Code](https://claude.ai/code/session_011a2DaLhFa2b1Switx8hEg3)_