### PR TITLE
Close the four remaining canvas/game-engine adoption gaps (#118)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -129,6 +129,11 @@ vlmkit baseline pin                                       # on main
 vlmkit baseline verify                                    # in PR
 vlmkit baseline post --pr owner/repo#123                  # send summary.md as PR comment
 
+# No URL to open? Start from PNGs — native renderers, or a broken headless capture.
+vlmkit baseline pin    --from-dir captures/                # no browser launched
+vlmkit baseline verify --from-dir current/                 # thresholds + summary + approvals
+vlmkit baseline pin    --from-png f.png --route hud --viewport desktop
+
 # Legacy internal-dogfood verification loop (vlmkit's own e2e suite)
 vlmkit workflow init
 vlmkit workflow capture
@@ -255,6 +260,46 @@ requests not present in the recording:
 vlmkit check integrity http://localhost:3000/ \
   --wait-until domcontentloaded --timeout 60000 --har fixtures/app.har
 ```
+
+#### Baselines from PNGs, with no URL (`--from-dir` / `--from-png`)
+
+For the case where the frames exist but a page cannot be opened: a native renderer writing
+PNGs, or a headless canvas capture that does not work (the reporter's Linux/Dawn build never
+completes `copyTextureToBuffer` + `mapAsync`, and canvas screenshots come back transparent).
+`diff png` already compares two files, but that is a one-shot — it has no per-route
+thresholds, no markdown summary and no region-level approvals. `--from-dir` puts PNG-only
+callers inside the real `baseline verify` workflow instead.
+
+**File → route mapping.** Identity on disk is already the pair `(route.name, viewport
+label)`, so nothing new was invented. A file matches only if its path equals one of these
+for a **declared** pair:
+
+| form | when |
+|---|---|
+| `<route>/<viewport>.png` | canonical — identical to the pinned layout, so `--from-dir <baselineDir>` round-trips |
+| `<route>-<viewport>.png` | flat; the separator `snapshot.ts` already uses |
+| `<route>.png` | only when exactly one viewport is declared, since otherwise the viewport is unknowable |
+
+Matching is against the declared cross-product rather than by splitting on `-`, which is
+what makes the flat form safe: `"form-app-mobile".split("-")` gives route `form`, while
+comparing against `` `${route.name}-${vp}` `` does not. A stem two pairs both claim is
+reported ambiguous, never guessed. Any disagreement is an error naming both sides — an
+unmapped file, two files for one pair, or a declared pair with no file — and nothing is
+pinned. Arbitrary renderer filenames use the single-file escape hatch
+(`--from-png f.png --route r --viewport v`, both halves required); there is no sidecar
+manifest to version.
+
+**What verify can and cannot do from PNGs.** Working: pixel diff, per-route and per-viewport
+thresholds, markdown summary, worst offenders, region-bbox approvals from `approval.json`,
+exit code, run dir with heatmaps. Not possible without a page, and **reported as not
+evaluated rather than passed**: a11y (contrast / touch / focus-order / semantic),
+media-variants, cross-browser. A run that names one route prints
+`**Partial run**: 1 of 2 declared route(s) checked` rather than letting the others show an
+empty green row.
+
+**File mode honours the viewport label as declared**, so `"viewports": ["frame"]` works — a
+supplied PNG carries its own dimensions. The browser path still intersects labels with its
+three built-ins; changing that would need real dimensions per custom label.
 
 #### `check copy` without a DOM
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -214,6 +214,7 @@ vlmkit diff png <baseline.png> <current.png>   # Direct PNG pixel diff + heatmap
   # --region-grid <px>   region-detection cell size; default adapts to the image
   #                      (32 at >=720px short side, 16 at >=480, else 8)
   # --elements-top <N>   report N attribution candidates per region, not just the winner
+  # --ignore-region "<x>,<y>,<w>x<h>"   repeatable; area never measured
 vlmkit diff elements [options]                 # Element-level diff with shift isolation
 vlmkit diff browsers <html|url>                # chromium / firefox / webkit parity
 vlmkit diff runs <dir...>                      # Aggregate multiple VRT runs into one table
@@ -254,6 +255,85 @@ requests not present in the recording:
 vlmkit check integrity http://localhost:3000/ \
   --wait-until domcontentloaded --timeout 60000 --har fixtures/app.har
 ```
+
+#### `check copy` without a DOM
+
+Same input as image-only `check integrity`, for the same reason: canvas-drawn strings are
+invisible to the DOM text-block walk, so the gate finds nothing to compare a manifest
+against.
+
+```bash
+vlmkit check copy --elements elements.json --manifest copy.txt      # + optional --image frame.png
+```
+
+Each element's `text` is what the renderer drew; element order is treated as reading order
+(top, then left) so a manifest line can span two adjacent drawn strings the way it spans two
+text nodes in the DOM.
+
+Three of the five copy rules run here; `redirected` and `copy-image-mismatch` need a
+navigation result and a reference screenshot, and are named in the report's coverage block.
+`copy-invisible` covers 2 of its 7 reason classes — `zero-size` and, with `--image`,
+`unpainted` (a text bbox the frame shows as flat means the glyphs were never drawn: missing
+font, alpha 0, skipped draw call). The other five need computed styles.
+
+One rule is new and only fires here: **`copy-truncated`**. It needs `textMeasured` and a
+`clip` rect, and it exists because the manifest matches the string the *renderer* reports —
+so `Score: 1234567890` reads as satisfied while the user sees `Score: 12345…`. As in image
+mode for `check integrity`, text wider than its box with no clip rect *overdraws* rather
+than truncating, so a `clip` is required rather than assumed.
+
+`--target`, `--vlm`, `--out` and `--storage-state` are **rejected** in this mode rather than
+ignored, and there is no disclosure-state sweep (opening `<details>` and clicking tabs needs
+a live page), which the coverage block states.
+
+#### Masking areas that change every frame (`--ignore-region`)
+
+Particles, noise and timer readouts change by construction. `baseline approve --region`
+is the wrong instrument for them: it is an *approval*, so a permanently-noisy area
+pollutes the approval history on every run and shows up in the `gates suppressions`
+stocktake. `--ignore-region` is the other concept — **never measured**, rather than
+measured and forgiven — and it writes no state, so it is absent from that stocktake by
+construction.
+
+```bash
+vlmkit diff png base.png cur.png --ignore-region "0,300,640x60" --ignore-region "16,16,200x20"
+```
+
+**The ratio's denominator shrinks with the mask.** `diffRatio` is "the fraction of the
+pixels that were actually measured which changed", i.e.
+`imagePixels − ignoredPixels`. This is deliberate and it is the non-obvious part: with a
+full-frame denominator, adding a mask would make every *unrelated* regression look less
+severe than it did before the mask existed. Measured on a 640x360 frame — masking a
+38400px particle band takes a real HUD recolor from 1.84% to 2.08%; under a full-frame
+denominator the same regression would have read 1.74%, i.e. *better* than unmasked. The
+trade-off is that a masked run's ratio is not directly comparable to an unmasked one's,
+which is why the mask block always prints.
+
+Ignored pixels leave both the diff count **and** region detection. Masking only the count
+would leave a detected region with `diffPixelCount: 0`, which `--elements-json` would
+then confidently attribute to an element.
+
+Every masked run prints its own accounting, because a silently-shrunk diff is the
+dangerous failure here:
+
+```
+  diff:     0.00% (0 / 226400 px measured)
+  ignored:  1 region(s), 4000 px (1.7% of the 230400 px compared area) — never measured
+    (16,16) 200x20 — 4000 px, 1800 of them differed
+    1800 diff px discarded; denominator 230400 - 4000 = 226400
+```
+
+Note the last two lines: a mask that swallowed the entire finding still says how many
+diff pixels it swallowed, and the denominator arithmetic is spelled out so
+`compared − ignored = measured` is checkable. A rect that misses the frame prints
+`0 px — outside the compared area, masks nothing` rather than looking applied. In the
+heatmap PNG ignored pixels are painted pale blue, not white, so the hole is visible.
+
+Not masked, deliberately: shift detection (`globalShift` / `shiftRegions`) reads per-row
+luminance from the source images, and masking rows out of a row average would perturb the
+numbers on unmasked rows too. A surviving region's `colorSample` also averages over the
+source pixels — the mask governs what counts as a *difference*, not what a region's
+colours are.
 
 #### Without a DOM: canvas / WebGPU / native renderers
 
@@ -554,6 +634,9 @@ vlmkit build gallery <html|url> [--out dir/] [--selector .c-card] [--include-all
 
 # Detect components in a screenshot.
 vlmkit scan component <screenshot.png>         # Crop to standalone PNGs
+  # --top-n <N>          max components returned (default 8) — see the note below
+  # --min-area <px>      min filled px per component (default 200)
+  # --preset game-ui     = --min-area 24 --top-n 24, for small high-contrast frames
 vlmkit scan breakpoints <html-file>            # Discover responsive breakpoints
 vlmkit scan scroll <html|url>                  # Annotation-free scroll inventory: real scroll containers
                                                # (axis / overflow px / bbox), unintended page overflow-x

--- a/docs/design/gate-plugin-architecture.md
+++ b/docs/design/gate-plugin-architecture.md
@@ -280,13 +280,13 @@ The built-ins load through the same `createGateRegistry([...])` call. If the
 contract were not sufficient for them it would not be sufficient for anyone
 else, and making them its first consumer is the only way to keep that honest.
 
-## The 27 gates (119 tunable rules)
+## The 27 gates (120 tunable rules)
 
 | Gate | Rules | Plugin |
 |---|---|---|
 | `check integrity` | 18 | markup |
 | `check layout` | 11 | markup |
-| `check copy` | 5 | markup |
+| `check copy` | 6 | markup |
 | `check interactions` | 15 | markup |
 | `check a11y contrast` | 1 | markup |
 | `check a11y touch` | 1 | markup |

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1026,3 +1026,61 @@ Consequences worth remembering:
 `findHeatmapRegionsFromRgba`, a different function; nothing exercised `detectDiffRegions`'
 grid, so the full suite stayed green through both the defect and the fix. See
 `packages/vlmkit-markup/src/region-attribution.test.ts`.
+
+## `scan component` on small frames: the binding constraint is `--top-n`, not `--min-area` (2026-08-09)
+
+Reported (vlmkit#118) as "with a 320x240 pixel-art HUD the default `--min-area` makes
+elements hard to detect". **Measured, that diagnosis is wrong.** On a 16-element HUD:
+
+| setting | detected (of 16) |
+|---|--:|
+| defaults (`minArea 200 / topN 8`) | 8 |
+| `--min-area 24` alone | **8 — no change at all** |
+| `--top-n 24` alone | 12 |
+| both | 16 |
+
+`topN: 8` was the binding limit, `scan component` **exposed no `--top-n` flag**, and the
+cap binds identically at 1280x720 (also 6/16 on the agent's fixture). So when someone says
+"elements are hard to detect", `--top-n` is the first thing to try regardless of
+resolution. `--min-area` only starts to matter once the cap is lifted, and only below
+roughly 640x360.
+
+Manual floors, measured as the value that first reaches the detection ceiling with the cap
+lifted: 320x240 → 40, 480x270 → 48, 640x360 → 80, 720x480 → 100, ≥800x600 → 200
+(unchanged). Or just `--preset game-ui` (`--min-area 24 --top-n 24`).
+
+**Do not go below ~24.** On real page content downscaled to game-frame size, `minArea 24`
+roughly doubles the component count versus 40 (15 → 25) and 12 doubles it again (→ 31–50);
+the extras are glyph fragments. On a full 1280x1091 page, `minArea 200` yields 16
+components and `minArea 50` yields 168, nearly all glyphs.
+
+**Why a preset and not a size-adaptive default.** The adaptive candidate (bucket the floor
+by long side) was built and run against all 179 PNGs in the repo: 178 unchanged, 1 changed
+— a real 480x240 card render, where it adds 4 glyph blobs of the word "Dashboard" at areas
+114/121/143/166px. Those are **indistinguishable by area** from the 100–144px icons the HUD
+case needs found, so frame size alone cannot separate "12x12 HUD icon = signal" from
+"12x17 glyph = noise". The caller has to say which they have. `adaptiveRegionCellSize`'s
+reasoning applies with more force here, because component *rank* feeds `page-compose-diff`'s
+top-N seats.
+
+**Ceiling worth stating to users:** text runs never come back as one component. Labelling
+is 4-connectivity with no dilation, so an N-glyph label is N components or none, at every
+threshold. 14 of 16 was the maximum any setting reached — the 2 misses are both labels.
+Don't let anyone chase the last 2.
+
+## `diff png --ignore-region`: the denominator has to shrink (2026-08-09)
+
+For permanently non-deterministic areas (particles, timers), requested in vlmkit#118 as
+distinct from `baseline approve --region`: **never measured**, not measured-and-forgiven, so
+it writes no state and stays out of the `gates suppressions` stocktake.
+
+`diffRatio` denominator is `imagePixels − ignoredPixels`. Measured justification: masking a
+38400px particle band on a 640x360 frame takes a real HUD recolor from 1.84% to **2.08%**;
+under a full-frame denominator the same regression reads **1.74%** — adding a mask would
+have made an unrelated regression look *better than before the mask existed*. That is the
+silent-shrink failure the flag risks, so the denominator is chosen not to cause it.
+
+Ignored pixels leave both the diff count and region detection: masking only the count
+leaves a region with `diffPixelCount: 0` that `--elements-json` would then attribute to an
+element. `0/0` returns `0`, not `NaN` — `NaN` serialises to `null` and compares false
+against every threshold, so a gate would silently pass.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1084,3 +1084,23 @@ Ignored pixels leave both the diff count and region detection: masking only the 
 leaves a region with `diffPixelCount: 0` that `--elements-json` would then attribute to an
 element. `0/0` returns `0`, not `NaN` — `NaN` serialises to `null` and compares false
 against every threshold, so a gate would silently pass.
+
+## `baseline pin` destroyed the archive `baseline update` had just written (2026-08-09)
+
+Found while adding `--from-dir` (vlmkit#118), pre-existing on `main` and affecting the
+**browser path too**, not only the new file mode.
+
+`baseline update` is documented as a reversible golden refresh: it archives the current
+baselines to `<routeDir>/_history/<ts>/` and then re-pins. But `pin` cleared the route with
+`rm(routeDir, { recursive: true })` — and `_history` lives *inside* the route dir, so the
+archive it had written one step earlier was deleted in the same command. Reproduced directly:
+after the `rm -r`, `find baselines/hud` returns nothing.
+
+So "reversible" was false for the entire life of the feature, and nothing detected it because
+the archive's absence only matters at the moment someone tries to roll back. `pin` now removes
+only top-level `.png` files, which also makes a partial pin non-destructive to the rest of the
+route.
+
+The general shape is worth keeping: **a cleanup step whose blast radius is a directory, where
+something else stores durable state in that same directory.** The two features were written at
+different times and each is locally correct.

--- a/packages/vlmkit-core/src/heatmap.test.ts
+++ b/packages/vlmkit-core/src/heatmap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { detectWhiteout, detectEmptyContent } from "./heatmap.ts";
+import { detectWhiteout, detectEmptyContent, parseIgnoreRegionSpec } from "./heatmap.ts";
 
 function makePngData(
   width: number,
@@ -16,6 +16,21 @@ function makePngData(
   }
   return { width, height, data };
 }
+
+describe("parseIgnoreRegionSpec", () => {
+  it("accepts the spelling `diff png` prints regions in", () => {
+    assert.deepEqual(parseIgnoreRegionSpec("0,300,640x60"), { x: 0, y: 300, width: 640, height: 60 });
+    // Negative origins are legal — a rect that hangs off the top-left is clamped
+    // when applied, and rejecting it would make "mask the whole HUD" fiddly.
+    assert.deepEqual(parseIgnoreRegionSpec("-8,-8,16X16"), { x: -8, y: -8, width: 16, height: 16 });
+  });
+
+  it("rejects anything it cannot apply, rather than defaulting to no mask", () => {
+    for (const bad of ["0,300,640", "0,300,640x0", "0,300,0x60", "0,300,-4x60", "x", "1,2,3,4"]) {
+      assert.throws(() => parseIgnoreRegionSpec(bad), /invalid ignore region/, `"${bad}"`);
+    }
+  });
+});
 
 describe("detectWhiteout", () => {
   it("should detect all-white image", () => {

--- a/packages/vlmkit-core/src/heatmap.ts
+++ b/packages/vlmkit-core/src/heatmap.ts
@@ -1,6 +1,112 @@
-import type { VrtDiff, VrtSnapshot, DiffRegion, DiffRegionType, DiffReport, ShiftRegion, DiffRegionColor, DiffRegionColorSample, DiffRegionColorPair } from "./types.ts";
+import type { VrtDiff, VrtSnapshot, DiffRegion, DiffRegionType, DiffReport, ShiftRegion, DiffRegionColor, DiffRegionColorSample, DiffRegionColorPair, DiffIgnoreRegion, DiffIgnoredRegionReport, DiffMaskSummary } from "./types.ts";
 import { type PngData, cropImage, decodePng, encodePng } from "./png-utils.ts";
 import { estimateRegionShift } from "./region-shift.ts";
+
+// ---- Ignore regions ----
+
+/**
+ * Colour written into the heatmap over ignored pixels.
+ *
+ * Not white: white means "these pixels matched", and a reader who opens the
+ * heatmap to check a suspiciously clean result must be able to see the hole.
+ * Chosen so neither downstream hot-pixel test fires on it — `detectDiffRegions`
+ * and `generateCompact` want green < 128 (this is 200), and
+ * `findHeatmapRegionsFromRgba` wants red − max(green, blue) >= 60 (this is
+ * −85).
+ */
+const IGNORED_HEATMAP_RGB: readonly [number, number, number] = [170, 200, 255];
+
+/**
+ * Parse `"<x>,<y>,<w>x<h>"` (e.g. `"0,300,640x60"`) into an ignore rect.
+ *
+ * This spelling, rather than `baseline approve --region`'s `x=,y=,w=,h=`,
+ * because it is the spelling `diff png` already *prints* regions in — the
+ * round-trip from "the report says `(0,300) 640x60`" to "ignore that" should be
+ * copy-paste, not translation.
+ *
+ * Zero-area rects are rejected: `"0,0,0x0"` masks nothing, so accepting it
+ * would only ever mean the caller mistyped and got silence.
+ */
+export function parseIgnoreRegionSpec(value: string): DiffIgnoreRegion {
+  const match = /^\s*(-?\d+)\s*,\s*(-?\d+)\s*,\s*(\d+)\s*[xX*]\s*(\d+)\s*$/.exec(value);
+  if (!match) {
+    throw new Error(
+      `invalid ignore region "${value}" — expected "<x>,<y>,<w>x<h>", e.g. "0,300,640x60"`,
+    );
+  }
+  const [x, y, width, height] = match.slice(1, 5).map(Number) as [number, number, number, number];
+  if (width <= 0 || height <= 0) {
+    throw new Error(
+      `invalid ignore region "${value}" — width and height must be positive, got ${width}x${height}`,
+    );
+  }
+  return { x, y, width, height };
+}
+
+/**
+ * Blank ignored pixels out of the pixelmatch output and account for what was lost.
+ *
+ * Both halves of "never measured" happen here, and deliberately in one place:
+ * the pixels stop counting toward `diffPixels` *and* they disappear from the
+ * buffer `detectDiffRegions` clusters, so a noisy strip produces neither a
+ * ratio contribution nor a phantom region. Doing only the first would leave a
+ * region whose `diffPixelCount` is 0 — worse than useless for attribution.
+ *
+ * The `covered` bitmap exists so overlapping rects are counted once. Without it
+ * two rects that overlap by 100px would report 100 more ignored pixels than
+ * exist, and `imagePixels - ignoredPixels === totalPixels` would stop holding —
+ * which is the one identity a reader can use to audit the number.
+ *
+ * Known limitation: region *bboxes* are cell-aligned, so a diff cell touching a
+ * mask edge still yields a region whose box overlaps the mask, and that box's
+ * `colorSample` / `shift` are sampled from the source images, not from this
+ * buffer. Colours for a region abutting a mask can therefore still be tinted by
+ * ignored pixels. The mask governs what counts as a difference, not what a
+ * surviving region's colours are averaged over.
+ */
+function applyIgnoreRegions(
+  diffOutput: Uint8Array,
+  width: number,
+  height: number,
+  regions: DiffIgnoreRegion[],
+): DiffMaskSummary {
+  const covered = new Uint8Array(width * height);
+  const reported: DiffIgnoredRegionReport[] = [];
+
+  for (const region of regions) {
+    const left = Math.max(0, Math.trunc(region.x));
+    const top = Math.max(0, Math.trunc(region.y));
+    const right = Math.min(width, Math.trunc(region.x) + Math.trunc(region.width));
+    const bottom = Math.min(height, Math.trunc(region.y) + Math.trunc(region.height));
+    let pixels = 0;
+    let diffPixels = 0;
+    for (let y = top; y < bottom; y++) {
+      for (let x = left; x < right; x++) {
+        const index = y * width + x;
+        pixels++;
+        if (diffOutput[index * 4 + 1]! < 128) diffPixels++;
+        covered[index] = 1;
+      }
+    }
+    reported.push({ ...region, pixels, diffPixels });
+  }
+
+  let ignoredPixels = 0;
+  let ignoredDiffPixels = 0;
+  const [mr, mg, mb] = IGNORED_HEATMAP_RGB;
+  for (let index = 0; index < covered.length; index++) {
+    if (!covered[index]) continue;
+    ignoredPixels++;
+    const offset = index * 4;
+    if (diffOutput[offset + 1]! < 128) ignoredDiffPixels++;
+    diffOutput[offset] = mr;
+    diffOutput[offset + 1] = mg;
+    diffOutput[offset + 2] = mb;
+    diffOutput[offset + 3] = 255;
+  }
+
+  return { regions: reported, ignoredPixels, ignoredDiffPixels, imagePixels: width * height };
+}
 
 // ---- Shared diff pipeline ----
 
@@ -13,13 +119,19 @@ interface PixelDiffResult {
   threshold: number;
   resizedBaseline: PngData;
   resizedCurrent: PngData;
+  mask?: DiffMaskSummary;
 }
 
 async function runPixelDiff(
   baselinePath: string,
   screenshotPath: string,
   testId: string,
-  opts: { threshold?: number; outputDir?: string; skipHeatmap?: boolean },
+  opts: {
+    threshold?: number;
+    outputDir?: string;
+    skipHeatmap?: boolean;
+    ignoreRegions?: DiffIgnoreRegion[];
+  },
 ): Promise<PixelDiffResult & { heatmapPath?: string }> {
   const pixelmatch = (await import("pixelmatch")).default;
   const baseline = await decodePng(baselinePath);
@@ -41,22 +153,54 @@ async function runPixelDiff(
 
   const width = resizedBaseline.width;
   const height = resizedBaseline.height;
-  const totalPixels = width * height + overflowPixels;
   const diffOutput = new Uint8Array(width * height * 4);
   const threshold = opts.threshold ?? 0.1;
 
-  const diffPixels = overflowPixels + pixelmatch(
+  const rawDiffPixels = pixelmatch(
     resizedBaseline.data, resizedCurrent.data, diffOutput, width, height, { threshold },
   );
 
+  // Masks are applied to the *compared* area only. Overflow from a size mismatch
+  // is counted whole into both numerator and denominator and is not maskable —
+  // a 640x360 baseline against a 640x420 current contributes 38400 diff pixels
+  // that no rect inside the common 640x360 box can reach. Say so rather than
+  // pretend, because "I ignored the bottom strip and the ratio didn't move" has
+  // exactly this cause.
+  const mask = opts.ignoreRegions && opts.ignoreRegions.length > 0
+    ? applyIgnoreRegions(diffOutput, width, height, opts.ignoreRegions)
+    : undefined;
+
+  const ignoredPixels = mask?.ignoredPixels ?? 0;
+  const totalPixels = width * height - ignoredPixels + overflowPixels;
+  const diffPixels = overflowPixels + rawDiffPixels - (mask?.ignoredDiffPixels ?? 0);
+
   let heatmapPath: string | undefined;
-  if (opts.outputDir && diffPixels > 0 && !opts.skipHeatmap) {
+  // A fully-masked frame still gets a heatmap when anything was ignored, so the
+  // one artefact a reader can open shows the hole rather than nothing at all.
+  if (opts.outputDir && (diffPixels > 0 || ignoredPixels > 0) && !opts.skipHeatmap) {
     const safeName = testId.replace(/[/\\:]/g, "_");
     heatmapPath = `${opts.outputDir}/${safeName}_heatmap.png`;
     await encodePng(heatmapPath, { width, height, data: diffOutput });
   }
 
-  return { diffOutput, width, height, diffPixels, totalPixels, threshold, resizedBaseline, resizedCurrent, heatmapPath };
+  return {
+    diffOutput, width, height, diffPixels, totalPixels, threshold,
+    resizedBaseline, resizedCurrent, heatmapPath,
+    ...(mask ? { mask } : {}),
+  };
+}
+
+/**
+ * `diffPixels / totalPixels`, with the degenerate case named.
+ *
+ * A mask covering the whole compared area leaves nothing measured, and 0/0 must
+ * not surface as `NaN` — it serialises to `null` in JSON and compares false
+ * against every threshold, so a gate would silently pass. 0 with a mask summary
+ * saying `ignoredPixels === imagePixels` is the honest reading: nothing changed
+ * *of what was looked at*, and nothing was looked at.
+ */
+function safeDiffRatio(diffPixels: number, totalPixels: number): number {
+  return totalPixels > 0 ? diffPixels / totalPixels : 0;
 }
 
 // ---- Public API ----
@@ -72,6 +216,14 @@ export async function compareScreenshots(
     skipHeatmap?: boolean;
     /** Override the adaptive grid. See `adaptiveRegionCellSize`. */
     regionCellSize?: number;
+    /**
+     * Rectangles that are non-deterministic by construction (particles, a
+     * timer readout) and should never be measured. Distinct from an approval:
+     * nothing is recorded, nothing expires, and there is nothing for a
+     * suppression stocktake to list. See `applyIgnoreRegions` and
+     * `DiffMaskSummary` for the effect on `diffRatio`.
+     */
+    ignoreRegions?: DiffIgnoreRegion[];
   } = {}
 ): Promise<VrtDiff | null> {
   if (!snapshot.baselinePath) return null;
@@ -85,9 +237,10 @@ export async function compareScreenshots(
     snapshot,
     diffPixels: r.diffPixels,
     totalPixels: r.totalPixels,
-    diffRatio: r.diffPixels / r.totalPixels,
+    diffRatio: safeDiffRatio(r.diffPixels, r.totalPixels),
     heatmapPath: r.heatmapPath,
     regions,
+    ...(r.mask ? { mask: r.mask } : {}),
   };
 }
 
@@ -574,7 +727,7 @@ function generateCompact(
     }
   }
 
-  const matchPct = ((1 - diffPixels / totalPixels) * 100).toFixed(0);
+  const matchPct = ((1 - safeDiffRatio(diffPixels, totalPixels)) * 100).toFixed(0);
   const lines = [`diff:${diffPixels}/${totalPixels}(${matchPct}%match)`];
   const cellTotal = cellW * cellH;
   for (let gy = 0; gy < gridSize; gy++) {
@@ -600,6 +753,8 @@ export async function generateDiffReport(
     detectShift?: boolean;
     /** Override the adaptive grid. See `adaptiveRegionCellSize`. */
     regionCellSize?: number;
+    /** See `compareScreenshots`. Shift detection is NOT masked — see below. */
+    ignoreRegions?: DiffIgnoreRegion[];
   } = {},
 ): Promise<DiffReport | null> {
   if (!snapshot.baselinePath) return null;
@@ -607,7 +762,13 @@ export async function generateDiffReport(
   const r = await runPixelDiff(snapshot.baselinePath, snapshot.screenshotPath, snapshot.testId, opts);
   const regions = detectDiffRegions(r.diffOutput, r.width, r.height, opts.regionCellSize);
 
-  // Shift detection
+  // Shift detection reads the source images through a per-row luminance profile,
+  // not the masked diff buffer, so `globalShift` / `shiftRegions` /
+  // `compensatedDiffCount` still see ignored pixels. Masking them out of a row
+  // average would change what the correlation is computed over and silently
+  // alter shift numbers on unmasked rows too; leaving it measured and saying so
+  // is the smaller lie. A mask over an animated band therefore still perturbs
+  // the shift estimate for the rows it covers.
   let globalShift = 0;
   let shiftRegions: ShiftRegion[] = [];
   let compensated = r.diffPixels;
@@ -635,8 +796,9 @@ export async function generateDiffReport(
   return {
     diffPixels: r.diffPixels,
     totalPixels: r.totalPixels,
-    diffRatio: r.diffPixels / r.totalPixels,
+    diffRatio: safeDiffRatio(r.diffPixels, r.totalPixels),
     regions,
+    ...(r.mask ? { mask: r.mask } : {}),
     shiftOnly,
     contentChangeCount,
     globalShift,

--- a/packages/vlmkit-core/src/index.ts
+++ b/packages/vlmkit-core/src/index.ts
@@ -41,6 +41,7 @@ export {
   compareScreenshots,
   detectBandShifts,
   generateDiffReport,
+  parseIgnoreRegionSpec,
   detectWhiteout,
   detectEmptyContent,
 } from "./heatmap.ts";

--- a/packages/vlmkit-core/src/types.ts
+++ b/packages/vlmkit-core/src/types.ts
@@ -63,10 +63,60 @@ export interface VrtSnapshot {
 export interface VrtDiff {
   snapshot: VrtSnapshot;
   diffPixels: number;
+  /**
+   * The `diffRatio` denominator: pixels that were actually measured. Equals the
+   * compared image area unless `mask` is present, in which case the ignored
+   * pixels are subtracted. See `DiffMaskSummary` for why.
+   */
   totalPixels: number;
   diffRatio: number;
   heatmapPath?: string;
   regions: DiffRegion[];
+  /** Present only when the caller passed ignore regions. */
+  mask?: DiffMaskSummary;
+}
+
+/** A rectangle the caller declared permanently non-deterministic. */
+export interface DiffIgnoreRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DiffIgnoredRegionReport extends DiffIgnoreRegion {
+  /**
+   * Pixels this rect actually covered inside the compared area — less than
+   * `width * height` when the rect hangs off the edge, and 0 when it misses the
+   * frame entirely (a typo'd mask that silences nothing should be visible, not
+   * inferred).
+   */
+  pixels: number;
+  /**
+   * Diff pixels that fell inside this rect and were discarded. This is the
+   * number that says how much the mask is doing: 0 means it changed nothing.
+   * Per-rect counts double-count where rects overlap; `ignoredDiffPixels` is
+   * the de-duplicated total.
+   */
+  diffPixels: number;
+}
+
+/**
+ * What a set of ignore regions removed from the measurement.
+ *
+ * Always reported alongside the verdict, never only in `--json`: the failure
+ * mode of this feature is a mask over half the frame and a gate that then says
+ * 0.1%. `imagePixels - ignoredPixels === totalPixels` is the arithmetic a
+ * reader can check.
+ */
+export interface DiffMaskSummary {
+  regions: DiffIgnoredRegionReport[];
+  /** De-duplicated count of pixels inside at least one ignore region. */
+  ignoredPixels: number;
+  /** De-duplicated count of *differing* pixels that were discarded. */
+  ignoredDiffPixels: number;
+  /** The compared area before masking (excludes size-mismatch overflow). */
+  imagePixels: number;
 }
 
 export type DiffRegionType = "shift" | "content" | "edge";
@@ -146,9 +196,12 @@ export interface ShiftRegion {
 
 export interface DiffReport {
   diffPixels: number;
+  /** Measured pixels — see `VrtDiff.totalPixels`. */
   totalPixels: number;
   diffRatio: number;
   regions: DiffRegion[];
+  /** Present only when the caller passed ignore regions. */
+  mask?: DiffMaskSummary;
   shiftOnly: boolean;
   contentChangeCount: number;
   globalShift: number;

--- a/packages/vlmkit-markup/src/component/component-bbox.ts
+++ b/packages/vlmkit-markup/src/component/component-bbox.ts
@@ -49,9 +49,21 @@ export interface MatchedBbox {
 }
 
 export interface ExtractComponentsOptions {
-  /** Minimum filled-pixel count for a component to be kept. Default 200 (≈ 15×15). */
+  /**
+   * Minimum filled-pixel count for a component to be kept. Default 200
+   * (≈ 15×15). Only binds below roughly 640×360, and only once `topN` has been
+   * raised — see `EXTRACT_PRESETS`.
+   */
   minArea?: number;
-  /** How many components to return after sorting by area. Default 8. */
+  /**
+   * How many components to return after sorting by area. Default 8.
+   *
+   * This is the binding constraint on element-dense frames at *every* size, not
+   * a display nicety: a 16-element HUD reports 6 of them at 320×240 and 6 at
+   * 1280×720 until it is raised. Because the list is sorted by area descending,
+   * raising it can only append smaller components — it never displaces one that
+   * the old cap already returned.
+   */
   topN?: number;
   /**
    * Per-channel difference threshold for "foreground." Defaults to a value
@@ -71,9 +83,62 @@ export interface ExtractComponentsOptions {
   background?: [number, number, number];
 }
 
-const DEFAULT_MIN_AREA = 200;
-const DEFAULT_TOP_N = 8;
+export const DEFAULT_MIN_AREA = 200;
+export const DEFAULT_TOP_N = 8;
 const DEFAULT_BG_TOLERANCE = 12;
+
+/**
+ * Named threshold bundles for frames the defaults were not calibrated on.
+ *
+ * `game-ui` comes from vlmkit#118 §4: a canvas/WebGPU engine reported that a
+ * 320x240 pixel-art HUD "makes elements hard to detect" and asked for a preset.
+ * Measured on a 16-element synthetic HUD (`component-extract.test.ts` builds the
+ * same one), counting an element as detected at bbox IoU >= 0.5:
+ *
+ *   320x240   defaults (minArea 200, topN 8)  ->  6/16
+ *             minArea 24 alone                ->  6/16   (no change at all)
+ *             topN 24 alone                   ->  9/16
+ *             minArea 24 + topN 24            -> 14/16
+ *   1280x720  defaults                        ->  6/16
+ *             topN 24 alone                   -> 14/16   (minArea never binds)
+ *
+ * Two things that reading the issue would not predict. First, `minArea` — the
+ * threshold the report names — is worth nothing by itself: `topN` is the binding
+ * constraint, and it binds at *every* frame size, not just small ones. Second,
+ * `minArea` only starts to matter once `topN` is lifted, and only below roughly
+ * 640x360 (13/14 of the reachable ceiling at 640x360 on the historical 200,
+ * 9/14 at 320x240).
+ *
+ * 14/16 is the ceiling, not a shortfall: the two misses are glyph-run labels,
+ * and 4-connectivity cannot merge separated glyphs into one component at any
+ * threshold. The same 2 are missed at minArea 1.
+ *
+ * This is a preset rather than a size-adaptive default. `adaptiveRegionCellSize`
+ * (`@mizchi/vlmkit-core/heatmap.ts`) set the precedent for bucketing a default
+ * by image size, and its reasoning — a continuous function shifts geometry on
+ * nearly every existing image, and that geometry appears in baselines and
+ * reports — applies here with more force, because component *rank* feeds
+ * `page-compose-diff`'s top-N seats and the markup-verify calibrations keyed on
+ * them. And the measured counter-example is concrete: on a real 480x240 card
+ * render (`packages/vlmkit-heal/fixtures/.../dashboard-chromium-darwin.png`)
+ * dropping minArea to 50 adds 4 components that are all glyph blobs of the word
+ * "Dashboard" (areas 114-166 px) — indistinguishable by area from the 100-144 px
+ * icons the HUD case needs found. Frame size alone cannot separate the two, so
+ * the caller says which one they have.
+ */
+export const EXTRACT_PRESETS = {
+  /** Low-resolution, high-contrast frames with many small elements. */
+  "game-ui": { minArea: 24, topN: 24 },
+} as const satisfies Record<string, Pick<ExtractComponentsOptions, "minArea"> & { topN: number }>;
+
+export type ExtractPresetName = keyof typeof EXTRACT_PRESETS;
+
+export function isExtractPresetName(name: string): name is ExtractPresetName {
+  return Object.hasOwn(EXTRACT_PRESETS, name);
+}
+
+export const EXTRACT_PRESET_NAMES = Object.keys(EXTRACT_PRESETS) as ExtractPresetName[];
+
 /** Floor for the adaptive tolerance — below this, antialiasing halos start
  * forming their own components on clean renders. */
 const MIN_BG_TOLERANCE = 4;

--- a/packages/vlmkit-markup/src/component/component-extract.test.ts
+++ b/packages/vlmkit-markup/src/component/component-extract.test.ts
@@ -1,0 +1,291 @@
+/**
+ * `scan component` option plumbing + the game-UI preset measurement.
+ *
+ * The preset numbers quoted in `EXTRACT_PRESETS` were measured on a synthetic
+ * 16-element pixel-art HUD. `buildHud` below *is* that HUD, so the claims stay
+ * checkable: if the extractor changes, these assertions move with it instead of
+ * the comment quietly going stale.
+ */
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PNG } from "pngjs";
+import { runComponentExtract } from "./component-extract.ts";
+import {
+  extractComponentsFromRgba,
+  EXTRACT_PRESETS,
+  isExtractPresetName,
+  type ComponentBbox,
+} from "./component-bbox.ts";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
+const BG: [number, number, number] = [16, 24, 32];
+
+interface HudElement {
+  name: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * A 16-element game HUD laid out in 320x240 design units and scaled by `s`:
+ * three status bars, a portrait, a coin icon + numeric label, a minimap, three
+ * status icons, a crosshair, a dialog box, two buttons, a weapon icon and an
+ * ammo label. Elements are separated by background so each is one connected
+ * blob — except the two labels, which are glyph runs on purpose (4-connectivity
+ * cannot merge separated glyphs, so they cap the achievable score at 14/16).
+ */
+function buildHud(W: number, H: number, s: number): { png: PNG; elements: HudElement[] } {
+  const png = new PNG({ width: W, height: H });
+  for (let i = 0; i < W * H; i++) {
+    png.data[i * 4] = BG[0];
+    png.data[i * 4 + 1] = BG[1];
+    png.data[i * 4 + 2] = BG[2];
+    png.data[i * 4 + 3] = 255;
+  }
+  const S = (n: number) => Math.round(n * s);
+  const rect = (x: number, y: number, w: number, h: number, c: [number, number, number]) => {
+    for (let yy = y; yy < y + h; yy++) {
+      for (let xx = x; xx < x + w; xx++) {
+        if (xx < 0 || yy < 0 || xx >= W || yy >= H) continue;
+        const i = (yy * W + xx) * 4;
+        png.data[i] = c[0]; png.data[i + 1] = c[1]; png.data[i + 2] = c[2]; png.data[i + 3] = 255;
+      }
+    }
+  };
+  const frame = (x: number, y: number, w: number, h: number, c: [number, number, number], t: number) => {
+    rect(x, y, w, t, c); rect(x, y + h - t, w, t, c);
+    rect(x, y, t, h, c); rect(x + w - t, y, t, h, c);
+  };
+  const elements: HudElement[] = [];
+  const add = (name: string, left: number, top: number, width: number, height: number) =>
+    elements.push({ name, left, top, width, height });
+
+  const L = S(8), T = S(8);
+  rect(L, T, S(120), S(10), [60, 20, 24]);
+  rect(L, T, S(84), S(10), [220, 60, 60]);
+  add("hp-bar", L, T, S(120), S(10));
+  const mpY = T + S(14);
+  rect(L, mpY, S(120), S(6), [20, 28, 60]);
+  rect(L, mpY, S(52), S(6), [70, 130, 240]);
+  add("mp-bar", L, mpY, S(120), S(6));
+  const xpY = mpY + S(10);
+  rect(L, xpY, S(120), S(4), [40, 50, 30]);
+  rect(L, xpY, S(30), S(4), [190, 220, 90]);
+  add("xp-bar", L, xpY, S(120), S(4));
+
+  const stY = xpY + S(24);
+  ([[200, 90, 200], [90, 200, 120], [200, 180, 80]] as Array<[number, number, number]>)
+    .forEach((c, i) => {
+      const x = L + i * S(18);
+      rect(x, stY, S(12), S(12), c);
+      add(`status-${i + 1}`, x, stY, S(12), S(12));
+    });
+
+  const pX = L + S(128);
+  frame(pX, T - S(2), S(28), S(28), [230, 220, 180], Math.max(1, S(2)));
+  rect(pX + S(6), T + S(4), S(16), S(16), [180, 140, 110]);
+  add("portrait", pX, T - S(2), S(28), S(28));
+
+  const cX = pX + S(40);
+  rect(cX, T + S(2), S(10), S(10), [240, 200, 60]);
+  add("coin-icon", cX, T + S(2), S(10), S(10));
+  const lX = cX + S(16), glyphW = Math.max(1, S(5)), glyphAdv = Math.max(2, S(7));
+  for (let g = 0; g < 4; g++) rect(lX + g * glyphAdv, T + S(3), glyphW, Math.max(1, S(7)), [240, 240, 230]);
+  add("coin-label", lX, T + S(3), 3 * glyphAdv + glyphW, Math.max(1, S(7)));
+
+  const mm = S(60), mmX = W - S(8) - mm;
+  frame(mmX, T, mm, mm, [120, 200, 200], Math.max(1, S(2)));
+  let seed = 12345;
+  const rnd = () => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
+  for (let d = 0; d < 40; d++) {
+    rect(mmX + S(2) + Math.floor(rnd() * (mm - S(6))), T + S(2) + Math.floor(rnd() * (mm - S(6))),
+      Math.max(1, S(2)), Math.max(1, S(2)), [90, 160, 160]);
+  }
+  add("minimap", mmX, T, mm, mm);
+
+  const chW = S(12), chT = Math.max(1, S(2));
+  const chX = Math.round(W / 2 - chW / 2), chY = Math.round(H / 2 - chW / 2);
+  rect(chX, chY + Math.round((chW - chT) / 2), chW, chT, [240, 240, 240]);
+  rect(chX + Math.round((chW - chT) / 2), chY, chT, chW, [240, 240, 240]);
+  add("crosshair", chX, chY, chW, chW);
+
+  const dW = S(200), dH = S(40), dX = S(16), dY = H - S(60) - dH;
+  frame(dX, dY, dW, dH, [220, 220, 210], Math.max(1, S(2)));
+  rect(dX + S(8), dY + S(10), S(150), Math.max(1, S(4)), [200, 200, 190]);
+  rect(dX + S(8), dY + S(20), S(120), Math.max(1, S(4)), [200, 200, 190]);
+  add("dialog-box", dX, dY, dW, dH);
+
+  const bY = H - S(40);
+  rect(S(16), bY, S(36), S(14), [70, 110, 200]);
+  rect(S(30), bY + S(4), S(6), S(6), [255, 255, 255]);
+  add("btn-a", S(16), bY, S(36), S(14));
+  rect(S(60), bY, S(36), S(14), [200, 110, 70]);
+  rect(S(74), bY + S(4), S(6), S(6), [255, 255, 255]);
+  add("btn-b", S(60), bY, S(36), S(14));
+
+  const wX = W - S(104);
+  rect(wX, bY - S(4), S(24), S(16), [150, 150, 160]);
+  add("weapon-icon", wX, bY - S(4), S(24), S(16));
+  const aX = wX + S(34), agW = Math.max(1, S(6)), agAdv = Math.max(2, S(10));
+  for (let g = 0; g < 3; g++) rect(aX + g * agAdv, bY, agW, Math.max(1, S(8)), [240, 240, 230]);
+  add("ammo-label", aX, bY, 2 * agAdv + agW, Math.max(1, S(8)));
+
+  return { png, elements };
+}
+
+function iou(a: { left: number; top: number; width: number; height: number }, b: HudElement): number {
+  const ix = Math.max(a.left, b.left), iy = Math.max(a.top, b.top);
+  const ax = Math.min(a.left + a.width, b.left + b.width);
+  const ay = Math.min(a.top + a.height, b.top + b.height);
+  const inter = Math.max(0, ax - ix) * Math.max(0, ay - iy);
+  const uni = a.width * a.height + b.width * b.height - inter;
+  return uni > 0 ? inter / uni : 0;
+}
+
+/** Elements matched at bbox IoU >= 0.5 by at least one returned component. */
+function detected(components: ComponentBbox[], elements: HudElement[]): number {
+  return elements.filter((el) => components.some((c) => iou(c, el) >= 0.5)).length;
+}
+
+describe("game-ui preset (vlmkit#118 §4)", () => {
+  it("pins the thresholds the doc comment quotes", () => {
+    assert.deepEqual(EXTRACT_PRESETS["game-ui"], { minArea: 24, topN: 24 });
+  });
+
+  it("recovers 14 of 16 HUD elements at 320x240 where the defaults find 6", () => {
+    const { png, elements } = buildHud(320, 240, 1);
+    assert.equal(elements.length, 16);
+    const base = extractComponentsFromRgba(png.data, 320, 240);
+    const preset = extractComponentsFromRgba(png.data, 320, 240, EXTRACT_PRESETS["game-ui"]);
+    assert.equal(detected(base, elements), 6);
+    assert.equal(detected(preset, elements), 14);
+  });
+
+  it("holds up across frame sizes from 240x160 to 1280x720", () => {
+    // The defaults find 6-7 at every size — topN, not minArea, is what binds —
+    // and the preset reaches the 4-connectivity ceiling at each.
+    const cases: Array<[number, number, number, number, number]> = [
+      // W, H, scale, expected detected with defaults, expected with the preset
+      [240, 160, 0.75, 7, 13],
+      [320, 240, 1, 6, 14],
+      [640, 360, 1.5, 6, 14],
+      [1280, 720, 3, 6, 14],
+    ];
+    for (const [W, H, s, expectBase, expectPreset] of cases) {
+      const { png, elements } = buildHud(W, H, s);
+      const base = extractComponentsFromRgba(png.data, W, H);
+      const preset = extractComponentsFromRgba(png.data, W, H, EXTRACT_PRESETS["game-ui"]);
+      assert.equal(detected(base, elements), expectBase, `${W}x${H} defaults`);
+      assert.equal(detected(preset, elements), expectPreset, `${W}x${H} preset`);
+    }
+  });
+
+  it("minArea alone changes nothing — the cap is what binds", () => {
+    // This is the finding that makes the preset a bundle rather than one number:
+    // the threshold the issue names is inert until topN is raised.
+    const { png, elements } = buildHud(320, 240, 1);
+    const areaOnly = extractComponentsFromRgba(png.data, 320, 240, { minArea: 24 });
+    const capOnly = extractComponentsFromRgba(png.data, 320, 240, { topN: 24 });
+    assert.equal(detected(areaOnly, elements), 6);
+    assert.equal(detected(capOnly, elements), 9);
+  });
+
+  it("raising topN only appends — it never displaces a component the old cap returned", () => {
+    // Why the preset is safe for every caller that keeps the default cap: the
+    // list is sorted by area descending, so a lower floor can only add smaller
+    // entries below the existing ones.
+    const { png } = buildHud(640, 360, 1.5);
+    const narrow = extractComponentsFromRgba(png.data, 640, 360, { minArea: 24, topN: 8 });
+    const wide = extractComponentsFromRgba(png.data, 640, 360, { minArea: 24, topN: 24 });
+    assert.deepEqual(wide.slice(0, narrow.length), narrow);
+  });
+});
+
+describe("large-image non-regression", () => {
+  const pageShot = join(REPO_ROOT, "fixtures/auto-markup-proof/dashboard/target-desktop.png");
+
+  it("leaves a page screenshot's component set exactly as it was", async () => {
+    // The preset must be opt-in, not adaptive: on a page render the extra
+    // components are individual glyphs (measured on a real 480x240 card render:
+    // minArea 50 adds 4 blobs that are all letters of the word "Dashboard").
+    // So the *default* path has to stay byte-identical on large images.
+    const png = PNG.sync.read(await readFile(pageShot));
+    assert.ok(Math.max(png.width, png.height) > 640, "fixture must be a large frame");
+    const before = extractComponentsFromRgba(png.data, png.width, png.height);
+    const after = extractComponentsFromRgba(png.data, png.width, png.height, {});
+    assert.deepEqual(after, before);
+    assert.equal(before.length, 8);
+  });
+
+  it("does not attach a small-frame hint to a large frame", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-extract-large-"));
+    try {
+      const r = await runComponentExtract({ source: pageShot, outputDir: dir });
+      assert.equal(r.smallFrameHint, undefined);
+      assert.deepEqual(r.settings, { minArea: 200, topN: 8 });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runComponentExtract option resolution", () => {
+  let dir = "";
+  let hudPath = "";
+
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vlmkit-extract-"));
+    hudPath = join(dir, "hud.png");
+    await writeFile(hudPath, PNG.sync.write(buildHud(320, 240, 1).png));
+  });
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("reports the applied thresholds and defaults to 200/8", async () => {
+    const r = await runComponentExtract({ source: hudPath, outputDir: dir });
+    assert.deepEqual(r.settings, { minArea: 200, topN: 8 });
+    assert.equal(r.components.length, 8);
+  });
+
+  it("applies the preset", async () => {
+    const r = await runComponentExtract({ source: hudPath, outputDir: dir, preset: "game-ui" });
+    assert.deepEqual(r.settings, { minArea: 24, topN: 24, preset: "game-ui" });
+    assert.equal(r.components.length, 24);
+  });
+
+  it("lets an explicit flag widen the preset it was combined with", async () => {
+    const r = await runComponentExtract({
+      source: hudPath, outputDir: dir, preset: "game-ui", topN: 40,
+    });
+    assert.deepEqual(r.settings, { minArea: 24, topN: 40, preset: "game-ui" });
+  });
+
+  it("hints at the preset on a small frame, with measured numbers", async () => {
+    const r = await runComponentExtract({ source: hudPath, outputDir: dir });
+    assert.ok(r.smallFrameHint, "expected a hint on a 320x240 frame");
+    assert.equal(r.smallFrameHint.preset, "game-ui");
+    assert.equal(r.smallFrameHint.extraComponents, 16);
+    // A 12x12 status icon fills 144px — the largest thing minArea 200 drops here.
+    assert.equal(r.smallFrameHint.largestExcludedArea, 144);
+    const md = await readFile(r.reportPath, "utf8");
+    assert.match(md, /## Small frame/);
+    assert.match(md, /--min-area 24 --top-n 24/);
+  });
+
+  it("stops hinting once the frame is already scanned at preset settings", async () => {
+    const r = await runComponentExtract({ source: hudPath, outputDir: dir, preset: "game-ui" });
+    assert.equal(r.smallFrameHint, undefined);
+  });
+
+  it("names the valid presets", () => {
+    assert.equal(isExtractPresetName("game-ui"), true);
+    assert.equal(isExtractPresetName("gameui"), false);
+  });
+});

--- a/packages/vlmkit-markup/src/component/component-extract.ts
+++ b/packages/vlmkit-markup/src/component/component-extract.ts
@@ -25,14 +25,27 @@
  *
  *   vlmkit scan component <screenshot.png> --at 640,320
  *     # crop the component containing the given (x, y) point
+ *
+ *   vlmkit scan component <hud.png> --preset game-ui
+ *     # low-resolution / high-contrast frames with many small elements
+ *     # (see EXTRACT_PRESETS in component-bbox.ts for the measurements)
  */
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { basename, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { PNG } from "pngjs";
-import { extractComponentsFromFile, type ComponentBbox } from "./component-bbox.ts";
+import {
+  extractComponentsFromFile,
+  DEFAULT_MIN_AREA,
+  DEFAULT_TOP_N,
+  EXTRACT_PRESETS,
+  EXTRACT_PRESET_NAMES,
+  isExtractPresetName,
+  type ComponentBbox,
+  type ExtractPresetName,
+} from "./component-bbox.ts";
 import { classifyRegion } from "../region-classify.ts";
-import { handleCliError } from "@mizchi/vlmkit-core/cli-error.ts";
+import { handleCliError, UsageError } from "@mizchi/vlmkit-core/cli-error.ts";
 import { DIM, RESET, GREEN, BOLD, CYAN } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
 export interface ComponentExtractOptions {
@@ -49,6 +62,17 @@ export interface ComponentExtractOptions {
   cropPadding?: number;
   /** Minimum area for a component to be reported. Default inherits from extractor. */
   minArea?: number;
+  /**
+   * Cap on how many components are reported, sorted by area desc. Default
+   * inherits from the extractor (8). The single biggest lever on element-dense
+   * frames — see `EXTRACT_PRESETS`.
+   */
+  topN?: number;
+  /**
+   * Named threshold bundle (`game-ui`). Explicit `minArea` / `topN` win over
+   * the preset, so `--preset game-ui --top-n 40` is a legal widening.
+   */
+  preset?: ExtractPresetName;
 }
 
 export interface ExtractedComponent {
@@ -64,8 +88,32 @@ export interface ExtractedComponent {
 export interface ComponentExtractReport {
   source: string;
   imageSize: { width: number; height: number };
+  /** Thresholds actually applied, after preset resolution. */
+  settings: { minArea: number; topN: number; preset?: ExtractPresetName };
   components: ExtractedComponent[];
+  /**
+   * Present when the frame is small enough that the default thresholds are
+   * measurably leaving elements behind. See `probeSmallFrame`.
+   */
+  smallFrameHint?: SmallFrameHint;
   reportPath: string;
+}
+
+export interface SmallFrameHint {
+  /** Components the `game-ui` preset finds that the applied settings did not. */
+  extraComponents: number;
+  /** Filled-pixel area of the largest component the applied `minArea` excluded. */
+  largestExcludedArea: number;
+  preset: ExtractPresetName;
+}
+
+/** `--min-area abc` used to reach the extractor as NaN, which filters everything out. */
+function positiveInt(flag: string, raw: string | undefined): number {
+  const n = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(n) || n < 1) {
+    throw new UsageError(`${flag} expects a positive integer, got "${raw ?? ""}".`);
+  }
+  return n;
 }
 
 function parseArgs(argv: string[]) {
@@ -76,6 +124,8 @@ function parseArgs(argv: string[]) {
   let pointXY: { x: number; y: number } | undefined;
   let cropPadding = 0;
   let minArea: number | undefined;
+  let topN: number | undefined;
+  let preset: ExtractPresetName | undefined;
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -84,15 +134,61 @@ function parseArgs(argv: string[]) {
     else if (a === "--crop") cropRank = parseInt(argv[++i] ?? "0", 10);
     else if (a === "--crop-all") cropAll = true;
     else if (a === "--crop-padding") cropPadding = parseInt(argv[++i] ?? "0", 10);
-    else if (a === "--min-area") minArea = parseInt(argv[++i] ?? "0", 10);
-    else if (a === "--at") {
+    else if (a === "--min-area") minArea = positiveInt(a, argv[++i]);
+    else if (a === "--top-n") topN = positiveInt(a, argv[++i]);
+    else if (a === "--preset") {
+      const name = argv[++i] ?? "";
+      if (!isExtractPresetName(name)) {
+        throw new UsageError(
+          `Unknown --preset "${name}". Available: ${EXTRACT_PRESET_NAMES.join(", ")}.`,
+        );
+      }
+      preset = name;
+    } else if (a === "--at") {
       const parts = (argv[++i] ?? "").split(",").map((s) => parseInt(s.trim(), 10));
       if (parts.length === 2 && parts.every(Number.isFinite)) {
         pointXY = { x: parts[0]!, y: parts[1]! };
       }
     } else positional.push(a);
   }
-  return { positional, outputDir, report, cropRank, cropAll, pointXY, cropPadding, minArea };
+  return { positional, outputDir, report, cropRank, cropAll, pointXY, cropPadding, minArea, topN, preset };
+}
+
+/** Long side at or below which `probeSmallFrame` is worth running. */
+const SMALL_FRAME_LONG_SIDE = 640;
+/** Only advise the preset when it would find at least this many more components. */
+const HINT_MIN_EXTRA = 4;
+
+/**
+ * Would the `game-ui` preset find materially more on this frame?
+ *
+ * The defaults cannot be made size-adaptive without mislabelling small page
+ * renders (see `EXTRACT_PRESETS`), so instead of silently changing geometry the
+ * tool measures the gap and says so. Gated on the long side because that is
+ * what separates a game frame from a page screenshot — a full-page shot is tall
+ * even when it is narrow (the repo's mobile fixture is 378x3919) — and because
+ * the second extraction pass only costs anything on a large image. At 320x240 it
+ * is 77k pixels, i.e. free.
+ */
+async function probeSmallFrame(
+  sourcePath: string,
+  width: number,
+  height: number,
+  applied: { minArea: number; topN: number },
+  returnedCount: number,
+): Promise<SmallFrameHint | undefined> {
+  if (Math.max(width, height) > SMALL_FRAME_LONG_SIDE) return undefined;
+  const preset = "game-ui" satisfies ExtractPresetName;
+  const p = EXTRACT_PRESETS[preset];
+  if (applied.minArea <= p.minArea && applied.topN >= p.topN) return undefined;
+  const probed = await extractComponentsFromFile(sourcePath, p);
+  const extraComponents = probed.length - returnedCount;
+  if (extraComponents < HINT_MIN_EXTRA) return undefined;
+  const largestExcludedArea = Math.max(
+    0,
+    ...probed.filter((c) => c.area < applied.minArea).map((c) => c.area),
+  );
+  return { extraComponents, largestExcludedArea, preset };
 }
 
 function findContainingRank(components: ComponentBbox[], x: number, y: number): number | undefined {
@@ -139,9 +235,21 @@ export async function runComponentExtract(
   const sourceBuf = await readFile(sourcePath);
   const sourcePng = PNG.sync.read(sourceBuf);
 
+  // Preset first, explicit flags on top: `--preset game-ui --top-n 40` widens
+  // the preset rather than being rejected as a conflict.
+  const presetValues = options.preset ? EXTRACT_PRESETS[options.preset] : undefined;
+  const settings = {
+    minArea: options.minArea ?? presetValues?.minArea ?? DEFAULT_MIN_AREA,
+    topN: options.topN ?? presetValues?.topN ?? DEFAULT_TOP_N,
+    ...(options.preset ? { preset: options.preset } : {}),
+  };
   const rawComponents = await extractComponentsFromFile(sourcePath, {
-    minArea: options.minArea,
+    minArea: settings.minArea,
+    topN: settings.topN,
   });
+  const smallFrameHint = await probeSmallFrame(
+    sourcePath, sourcePng.width, sourcePng.height, settings, rawComponents.length,
+  );
 
   // Determine which rank(s) to crop.
   const ranksToCrop = new Set<number>();
@@ -190,12 +298,15 @@ export async function runComponentExtract(
   const md = renderReport({
     source: sourcePath,
     imageSize: { width: sourcePng.width, height: sourcePng.height },
+    settings,
     components,
+    smallFrameHint,
   });
   await writeFile(reportPath, md);
 
   console.log(`  ${BOLD}${CYAN}vlmkit scan component${RESET}`);
   console.log(`  ${DIM}source: ${sourcePath} (${sourcePng.width}×${sourcePng.height})${RESET}`);
+  console.log(`  ${DIM}settings: --min-area ${settings.minArea} --top-n ${settings.topN}${settings.preset ? ` (--preset ${settings.preset})` : ""}${RESET}`);
   console.log(`  ${DIM}found ${components.length} component(s)${RESET}`);
   for (const c of components.slice(0, 8)) {
     const fill = c.dominantColor?.hex ?? "—";
@@ -204,13 +315,27 @@ export async function runComponentExtract(
     console.log(`  ${DIM}#${c.rank}  ${c.bbox.left},${c.bbox.top} ${c.bbox.width}×${c.bbox.height}  fill ${fill}  ${kind}${RESET}${cropped}`);
   }
   if (components.length > 8) console.log(`  ${DIM}…${components.length - 8} more${RESET}`);
+  if (smallFrameHint) console.log(`  ${DIM}${smallFrameHintLine(smallFrameHint, settings)}${RESET}`);
   console.log(`  ${DIM}report: ${reportPath}${RESET}`);
 
   return {
     source: sourcePath,
     imageSize: { width: sourcePng.width, height: sourcePng.height },
-    components, reportPath,
+    settings,
+    components,
+    ...(smallFrameHint ? { smallFrameHint } : {}),
+    reportPath,
   };
+}
+
+function smallFrameHintLine(
+  hint: SmallFrameHint,
+  settings: { minArea: number; topN: number },
+): string {
+  const excluded = hint.largestExcludedArea > 0
+    ? `; largest region below --min-area ${settings.minArea} is ${hint.largestExcludedArea}px`
+    : "";
+  return `small frame: --preset ${hint.preset} finds ${hint.extraComponents} more component(s)${excluded}`;
 }
 
 function renderReport(r: Omit<ComponentExtractReport, "reportPath">): string {
@@ -219,12 +344,16 @@ function renderReport(r: Omit<ComponentExtractReport, "reportPath">): string {
   lines.push("");
   lines.push(`Source: \`${r.source}\` (${r.imageSize.width}×${r.imageSize.height})`);
   lines.push("");
+  lines.push(`Settings: \`--min-area ${r.settings.minArea} --top-n ${r.settings.topN}\`` +
+    (r.settings.preset ? ` (\`--preset ${r.settings.preset}\`)` : ""));
+  lines.push("");
   if (r.components.length === 0) {
     lines.push("## No components detected");
     lines.push("");
     lines.push("Either the image has no foreground content the connected-component " +
       "extractor recognizes, or every detected region was below the `--min-area` " +
       "threshold.");
+    if (r.smallFrameHint) lines.push("", ...smallFrameHintSection(r.smallFrameHint, r.settings));
     return lines.join("\n");
   }
   lines.push(`Detected **${r.components.length}** component(s), ranked by area.`);
@@ -240,6 +369,7 @@ function renderReport(r: Omit<ComponentExtractReport, "reportPath">): string {
   }
   if (r.components.length > 30) lines.push(`| _…${r.components.length - 30} more_ | | | | |`);
   lines.push("");
+  if (r.smallFrameHint) lines.push(...smallFrameHintSection(r.smallFrameHint, r.settings), "");
   lines.push("## Suggested next step");
   lines.push("");
   lines.push("1. Visually verify the rank → component mapping (open the source PNG, " +
@@ -252,9 +382,32 @@ function renderReport(r: Omit<ComponentExtractReport, "reportPath">): string {
   return lines.join("\n");
 }
 
+export function smallFrameHintSection(
+  hint: SmallFrameHint,
+  settings: { minArea: number; topN: number },
+): string[] {
+  const p = EXTRACT_PRESETS[hint.preset];
+  const lines = [
+    `## Small frame — \`--preset ${hint.preset}\` finds ${hint.extraComponents} more`,
+    "",
+    `This frame is small enough that the default thresholds are the limit, not the ` +
+    `image. \`--preset ${hint.preset}\` (\`--min-area ${p.minArea} --top-n ${p.topN}\`) ` +
+    `returns ${hint.extraComponents} component(s) beyond the ${settings.minArea}/${settings.topN} ` +
+    `run above.`,
+  ];
+  if (hint.largestExcludedArea > 0) {
+    lines.push("", `The largest region excluded by \`--min-area ${settings.minArea}\` fills ` +
+      `${hint.largestExcludedArea}px — for reference, a 12×12 HUD icon fills 144px and a ` +
+      `10×10 one fills 100px.`);
+  }
+  lines.push("", "Ignore this if the frame is a page render rather than a game/pixel-art " +
+    "frame: at page scale the extra components are usually individual glyphs.");
+  return lines;
+}
+
 async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "--help" || argv[0] === "-h") argv = [];
-  const { positional, outputDir, report, cropRank, cropAll, pointXY, cropPadding, minArea } = parseArgs(argv);
+  const { positional, outputDir, report, cropRank, cropAll, pointXY, cropPadding, minArea, topN, preset } = parseArgs(argv);
   if (positional.length === 0) {
     console.log("Usage: vlmkit scan component <screenshot.png> [options]");
     console.log("Options:");
@@ -262,7 +415,12 @@ async function main(argv = process.argv.slice(2)) {
     console.log("  --crop-all              Crop every detected component");
     console.log("  --at <x>,<y>            Crop the component containing the point");
     console.log("  --crop-padding <px>     Expand each crop bbox by N pixels (default 0)");
-    console.log("  --min-area <px>         Minimum area for a component to be reported");
+    console.log(`  --min-area <px>         Minimum filled area per component (default ${DEFAULT_MIN_AREA})`);
+    console.log(`  --top-n <n>             Cap on reported components (default ${DEFAULT_TOP_N});`);
+    console.log("                          the binding limit on element-dense frames");
+    console.log(`  --preset <name>         Threshold bundle: ${EXTRACT_PRESET_NAMES.join(", ")}.`);
+    console.log(`                          game-ui = --min-area ${EXTRACT_PRESETS["game-ui"].minArea} --top-n ${EXTRACT_PRESETS["game-ui"].topN},`);
+    console.log("                          for low-resolution / high-contrast frames");
     console.log("  --output-dir <dir>      Default: ./test-results/component-extract");
     console.log("  --report <path>         Markdown report path");
     process.exit(1);
@@ -271,7 +429,7 @@ async function main(argv = process.argv.slice(2)) {
     source: positional[0]!,
     outputDir: outputDir || join(process.cwd(), "test-results", "component-extract"),
     reportPath: report || undefined,
-    cropRank, cropAll, pointXY, cropPadding, minArea,
+    cropRank, cropAll, pointXY, cropPadding, minArea, topN, preset,
   });
 }
 

--- a/packages/vlmkit-markup/src/gates/copy.gate.ts
+++ b/packages/vlmkit-markup/src/gates/copy.gate.ts
@@ -7,6 +7,12 @@
  * usage error before any API key is resolved. The `--allow-invisible` reason
  * classes stay as they are — like integrity's `--allow`, that flag exempts a
  * *reason* and reports each accepted line, which rule settings do not replace.
+ *
+ * `--elements` selects element-rect mode (`../inspect/copy-image.ts`, vlmkit#118): text and
+ * bboxes come from the renderer instead of the DOM, so canvas/WebGPU and native UIs can be
+ * checked at all. It is mutually exclusive with a page source, for the reason image-mode
+ * `check integrity` gives: the two paths evaluate different rule sets, so a run that quietly
+ * picked one would make its verdict ambiguous.
  */
 
 import { defineGate } from "@mizchi/vlmkit-core/plugin/contract.ts";
@@ -22,22 +28,75 @@ import {
   formatCopyCheckReport,
   runCopyCheck,
 } from "../inspect/copy-check.ts";
+import {
+  COPY_IMAGE_SKIPPED_RULES,
+  type CopyImageOptions,
+  runImageCopyCheck,
+} from "../inspect/copy-image.ts";
 import { TRANSCRIBE_PROMPT } from "../inspect/copy-target.ts";
-import { firstPositional, vlmFlag, withoutOptionalValue } from "./arg-helpers.ts";
+import {
+  firstPositional,
+  firstPositionalOrUndefined,
+  vlmFlag,
+  withoutOptionalValue,
+} from "./arg-helpers.ts";
 
 /** Options plus the unresolved `--vlm` request; `run` turns it into a reader. */
 export interface CopyGateOptions extends CopyCheckOptions {
   vlm?: string | true;
+  /** Set by `--elements`: check the renderer's text instead of a page's DOM. */
+  imageMode?: CopyImageOptions;
 }
 
 const COPY_VALUE_FLAGS = ["--manifest", "--target", "--out", "--allow-invisible"];
+
+/**
+ * Flags that promise a check element-rect mode does not perform.
+ *
+ * Rejected rather than ignored: `--target`'s whole output is crops of a reference screenshot
+ * reviewed by a VLM or an agent, and `--storage-state` only means anything to a browser
+ * navigation. Accepting either would let a caller believe a check ran that did not — the
+ * failure mode this feature's coverage reporting exists to prevent, so silently swallowing
+ * the flags would undo it at the front door.
+ */
+const NOT_IN_ELEMENTS_MODE: { flag: string; because: string }[] = [
+  {
+    flag: "--target",
+    because: "it crops a reference screenshot per rendered text block and reviews the crops"
+      + " (VLM or contact sheets); element-rect mode has no such comparison wired",
+  },
+  { flag: "--vlm", because: "it only drives --target's transcription" },
+  { flag: "--storage-state", because: "nothing is navigated, so there is no session to restore" },
+  { flag: "--out", because: "no sheets or worksheet are written" },
+];
+
+/**
+ * `--allow-invisible a,b` → validated reason classes, or `undefined` when absent.
+ *
+ * Shared by both modes: element-rect mode can produce `zero-size` and `unpainted` matches,
+ * and a project that has decided one of those is deliberate needs the same suppression the
+ * DOM path offers. Validating here keeps a typo a millisecond-fast usage error.
+ */
+function allowInvisibleFrom(argv: readonly string[]): InvisibleReason[] | undefined {
+  const raw = readFlag(argv, "allow-invisible");
+  if (raw === undefined) return undefined;
+  const classes = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  const bad = classes.filter((c) => !(INVISIBLE_REASONS as readonly string[]).includes(c));
+  if (classes.length === 0 || bad.length > 0) {
+    throw new UsageError(
+      `--allow-invisible: unknown class(es) ${bad.map((b) => `"${b}"`).join(", ") || "(none given)"}.`
+      + ` Valid: ${INVISIBLE_REASONS.join(", ")}`,
+    );
+  }
+  return classes as InvisibleReason[];
+}
 
 export const copyGate = defineGate<CopyCheckReport, CopyGateOptions>({
   id: "check.copy",
   command: ["check", "copy"],
   title: "Copy fidelity",
   summary:
-    "Copy fidelity: placeholder scan + --manifest verification + --target image check (VLM or agent-vision sheets)",
+    "Copy fidelity: placeholder scan + --manifest verification + --target image check (VLM or agent-vision sheets); --elements checks renderer text instead of a DOM (canvas/WebGPU)",
   category: "correctness",
   usage: `Copy fidelity gate: placeholder-text scan (always on), optional manifest
 verification, and optional target-image verification (crops every
@@ -60,9 +119,26 @@ is the user-visible copy spec — keep assistive-tech-only strings out
 of it. Markdown headings in the manifest ("# Section") are organizing
 comments, not required lines.
 
-Reason classes: ${INVISIBLE_REASONS.join(", ")}. When an invisibility is
-deliberate, accept that class with --allow-invisible; each accepted line is
-listed with its reason so the suppression stays auditable.`,
+Reason classes:
+  ${INVISIBLE_REASONS.join(", ")}
+When an invisibility is deliberate, accept that class with --allow-invisible;
+each accepted line is listed with its reason so the suppression stays
+auditable. (unpainted is --elements mode only, see below.)
+
+--elements <json> checks the RENDERER's text instead of a DOM, for canvas /
+WebGPU / native UIs where the DOM holds one <canvas> and every text rule
+finds nothing. Each row carries {path, tag, top, left, width, height, text}
+plus optional {textMeasured, clip} — the same schema as
+"check integrity --elements". No browser is started. Mutually exclusive with
+a page source. With --image <frame.png> each text bbox is also checked for
+ink, so a string the renderer reports but never painted (missing font,
+alpha 0, skipped draw call) reads as copy-invisible (reason: unpainted)
+instead of passing.
+
+${COPY_IMAGE_SKIPPED_RULES.length} rule(s) cannot run in element-rect mode and
+copy-invisible covers 2 of its 7 reason classes there; every gap is printed
+under "Coverage" next to the verdict, because a clean result is worth what it
+rules out.`,
   rules: [
     {
       id: "placeholder-text",
@@ -76,11 +152,39 @@ listed with its reason so the suppression stays auditable.`,
       severity: "suspect",
       docs: "Accept a specific reason class with --allow-invisible rather than disabling the rule.",
     },
+    {
+      id: "copy-truncated",
+      title: "Drawn text runs past its clip rect, so it renders cut off",
+      severity: "suspect",
+      docs: "--elements mode only: needs a text extent the renderer measured (`textMeasured`) and a"
+        + " `clip` rect. In the DOM, check integrity's text-clipped covers this.",
+    },
     { id: "copy-image-mismatch", title: "Rendered copy differs from the target image", severity: "suspect" },
     { id: "redirected", title: "Requested URL redirected elsewhere", severity: "suspect" },
   ],
   inputs: [
-    { name: "source", placeholder: "html-or-url", kind: "path-or-url", description: "Page to check", positional: 0, required: true },
+    {
+      name: "source",
+      placeholder: "html-or-url",
+      kind: "path-or-url",
+      description: "Page to check (omit when using --elements)",
+      positional: 0,
+      // No `required: true`, deliberately: --elements supplies the text instead. Keep it off
+      // or the MCP schema demands a page that the gate then rejects as mutually exclusive,
+      // which is how image-mode integrity ended up CLI-only (commit e9a1bec).
+    },
+    {
+      name: "elements",
+      placeholder: "elements.json",
+      kind: "path",
+      description: "Text + rects from the renderer instead of a DOM — canvas/WebGPU, native, Flutter",
+    },
+    {
+      name: "image",
+      placeholder: "frame.png",
+      kind: "path",
+      description: "Frame PNG for --elements mode; enables the ink check (text reported but never painted)",
+    },
     { name: "manifest", placeholder: "file", kind: "path", description: "Copy manifest (plain text / markdown; one required line per row)" },
     {
       name: "allow-invisible",
@@ -96,9 +200,42 @@ listed with its reason so the suppression stays auditable.`,
   parse: (argv) => {
     // `--vlm` is optionally-valued, so its model id cannot be excluded via
     // COPY_VALUE_FLAGS — see `withoutOptionalValue`.
+    const positionalArgv = withoutOptionalValue(argv, "vlm");
+    const elements = readFlag(argv, "elements");
+    const image = readFlag(argv, "image");
+    if (elements) {
+      if (firstPositionalOrUndefined(positionalArgv, COPY_VALUE_FLAGS)) {
+        throw new UsageError(
+          "check copy takes either a page source or --elements, not both. The two modes "
+          + "evaluate different rule sets, so a combined run's verdict would be ambiguous.",
+        );
+      }
+      for (const { flag, because } of NOT_IN_ELEMENTS_MODE) {
+        if (argv.includes(flag)) {
+          throw new UsageError(
+            `${flag} does not apply with --elements: ${because}.`
+            + " Drop it rather than have the run imply a check it did not perform.",
+          );
+        }
+      }
+      const elementsManifest = readFlag(argv, "manifest");
+      const elementsAllow = allowInvisibleFrom(argv);
+      return {
+        source: image ?? elements,
+        imageMode: {
+          elementsPath: elements,
+          ...(image ? { imagePath: image } : {}),
+          ...(elementsManifest ? { manifestPath: elementsManifest } : {}),
+          ...(elementsAllow ? { allowInvisible: elementsAllow } : {}),
+        },
+      };
+    }
+    if (image) {
+      throw new UsageError("--image needs --elements: a PNG alone carries no text to check.");
+    }
     const source = firstPositional(
-      withoutOptionalValue(argv, "vlm"),
-      "vlmkit check copy <html-or-url>",
+      positionalArgv,
+      "vlmkit check copy <html-or-url> | --elements <elements.json> [--image <frame.png>]",
       COPY_VALUE_FLAGS,
     );
     const manifestPath = readFlag(argv, "manifest");
@@ -107,19 +244,7 @@ listed with its reason so the suppression stays auditable.`,
     const storageState = readFlag(argv, "storage-state");
     const vlm = vlmFlag(argv);
     if (vlm !== undefined && !targetPath) throw new UsageError("--vlm requires --target <png>");
-    const rawAllow = readFlag(argv, "allow-invisible");
-    let allowInvisible: InvisibleReason[] | undefined;
-    if (rawAllow !== undefined) {
-      const classes = rawAllow.split(",").map((s) => s.trim()).filter(Boolean);
-      const bad = classes.filter((c) => !(INVISIBLE_REASONS as readonly string[]).includes(c));
-      if (classes.length === 0 || bad.length > 0) {
-        throw new UsageError(
-          `--allow-invisible: unknown class(es) ${bad.map((b) => `"${b}"`).join(", ") || "(none given)"}.`
-          + ` Valid: ${INVISIBLE_REASONS.join(", ")}`,
-        );
-      }
-      allowInvisible = classes as InvisibleReason[];
-    }
+    const allowInvisible = allowInvisibleFrom(argv);
     return {
       source,
       exploreStates: !argv.includes("--no-states"),
@@ -131,7 +256,10 @@ listed with its reason so the suppression stays auditable.`,
       ...(vlm !== undefined ? { vlm } : {}),
     };
   },
-  run: async ({ vlm, ...options }) => {
+  run: async ({ vlm, imageMode, ...options }) => {
+    // Element-rect mode never starts a browser, which is the point for a caller whose UI is
+    // a canvas: there is nothing for Playwright to read.
+    if (imageMode) return runImageCopyCheck(imageMode);
     if (vlm === undefined) return runCopyCheck(options);
     const { createVlmClient, resolveModel } = await import("@mizchi/vlmkit-ai/vlm-client.ts");
     const modelId = vlm === true ? (readEnv("VLM_MODEL") ?? "bytedance/ui-tars-1.5-7b") : vlm;

--- a/packages/vlmkit-markup/src/gates/gates.test.ts
+++ b/packages/vlmkit-markup/src/gates/gates.test.ts
@@ -156,6 +156,65 @@ describe("gate argument parsing", () => {
     assert.throws(() => gateFor("check integrity").parse(["page.html", "--allow", "no-such-kind;why"], ctx));
   });
 
+  /**
+   * `check copy --elements` (vlmkit#118). The parse-time rules are the ones that decide
+   * whether a caller can trust the verdict, so they are asserted without a browser:
+   *
+   *  - a page source AND `--elements` is refused, not silently resolved. The two modes
+   *    evaluate different rule sets; picking one quietly makes the verdict ambiguous.
+   *  - flags that only mean something to the browser path are refused too. Accepting
+   *    `--target` and reviewing nothing is the exact failure the coverage reporting exists to
+   *    prevent, and swallowing the flag would undo it before the run even starts.
+   */
+  it("check copy takes element rects instead of a page", () => {
+    const parsed = gateFor("check copy").parse(
+      ["--elements", "e.json", "--image", "f.png", "--manifest", "copy.txt"],
+      ctx,
+    ) as { source: string; imageMode: Record<string, unknown> };
+    assert.equal(parsed.source, "f.png");
+    assert.deepEqual(parsed.imageMode, {
+      elementsPath: "e.json",
+      imagePath: "f.png",
+      manifestPath: "copy.txt",
+    });
+  });
+
+  it("check copy refuses a page source alongside --elements", () => {
+    assert.throws(
+      () => gateFor("check copy").parse(["page.html", "--elements", "e.json"], ctx),
+      /either a page source or --elements, not both/,
+    );
+    assert.throws(
+      () => gateFor("check copy").parse(["--image", "f.png", "--manifest", "copy.txt"], ctx),
+      /--image needs --elements/,
+    );
+  });
+
+  it("check copy refuses browser-only flags in --elements mode", () => {
+    for (const [flag, value] of [["--target", "t.png"], ["--out", "sheets"], ["--storage-state", "s.json"]]) {
+      assert.throws(
+        () => gateFor("check copy").parse(["--elements", "e.json", flag!, value!], ctx),
+        new RegExp(`\\${flag} does not apply with --elements`),
+      );
+    }
+    assert.throws(
+      () => gateFor("check copy").parse(["--elements", "e.json", "--vlm"], ctx),
+      /--vlm does not apply with --elements/,
+    );
+  });
+
+  it("check copy validates --allow-invisible in element-rect mode too", () => {
+    const parsed = gateFor("check copy").parse(
+      ["--elements", "e.json", "--allow-invisible", "unpainted"],
+      ctx,
+    ) as { imageMode: { allowInvisible: string[] } };
+    assert.deepEqual(parsed.imageMode.allowInvisible, ["unpainted"]);
+    assert.throws(
+      () => gateFor("check copy").parse(["--elements", "e.json", "--allow-invisible", "nope"], ctx),
+      /unknown class\(es\) "nope"/,
+    );
+  });
+
   it("check layout requires a contract", () => {
     assert.throws(() => gateFor("check layout").parse(["page.html"], ctx), /--contract <contract\.json> is required/);
     const parsed = gateFor("check layout").parse(["page.html", "--contract", "c.json"], ctx) as Record<string, unknown>;

--- a/packages/vlmkit-markup/src/index.ts
+++ b/packages/vlmkit-markup/src/index.ts
@@ -18,9 +18,15 @@ export {
   extractComponentsFromRgba,
   extractComponentsFromFile,
   matchComponents,
+  DEFAULT_MIN_AREA,
+  DEFAULT_TOP_N,
+  EXTRACT_PRESETS,
+  EXTRACT_PRESET_NAMES,
+  isExtractPresetName,
   type ComponentBbox,
   type MatchedBbox,
   type ExtractComponentsOptions,
+  type ExtractPresetName,
   type MatchComponentsOptions,
 } from "./component/component-bbox.ts";
 export {

--- a/packages/vlmkit-markup/src/inspect/copy-check.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-check.ts
@@ -62,7 +62,19 @@ import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
 import { describeRedirect } from "@mizchi/vlmkit-core/navigation-redirect.ts";
 import { BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW } from "@mizchi/vlmkit-core/terminal-colors.ts";
 
-export type CopyIssueKind = "placeholder-text" | "copy-missing" | "copy-invisible" | "copy-image-mismatch" | "redirected";
+export type CopyIssueKind =
+  | "placeholder-text"
+  | "copy-missing"
+  | "copy-invisible"
+  /**
+   * Element-rect mode only (`copy-image.ts`): the renderer says the string is drawn but its
+   * measured extent runs past its own clip rect, so the user reads a cut-off version. Needs
+   * a text extent only the renderer can measure, which is why the DOM path has no equivalent
+   * — there, `check integrity`'s `text-clipped` covers it from `scrollWidth - clientWidth`.
+   */
+  | "copy-truncated"
+  | "copy-image-mismatch"
+  | "redirected";
 
 export interface CopyIssue {
   kind: CopyIssueKind;
@@ -239,6 +251,12 @@ export const INVISIBLE_REASONS = [
   "visually-hidden",
   "unreachable",
   "camouflage",
+  // Element-rect mode only (`copy-image.ts`): the renderer reports text at a bbox the frame
+  // PNG shows as a flat, ink-free region — a missing font, alpha 0, or a skipped draw call.
+  // Its own class rather than `transparent`, because the DOM path's `transparent` is a
+  // measured `color` alpha and this is a measured pixel spread; collapsing them would make
+  // `--allow-invisible transparent` silence two different pieces of evidence.
+  "unpainted",
   "unknown",
 ] as const;
 export type InvisibleReason = (typeof INVISIBLE_REASONS)[number];
@@ -772,11 +790,29 @@ export function formatCopyCheckReport(report: CopyCheckReport): string {
   const status = report.issues.some((i) => i.severity === "suspect") ? "suspect"
     : report.issues.length > 0 ? "warn"
     : "ok";
+  // Element-rect mode (`copy-image.ts`) attaches its coverage fields to the same report
+  // shape. Read structurally rather than through an import so this module keeps its one
+  // direction of dependency — copy-image imports copy-check, never the reverse.
+  const coverage = report as Partial<{
+    skippedRules: { rule: string; reason: string }[];
+    inertRules: { rule: string; reason: string }[];
+    coverageNotes: string[];
+    elements: number;
+    textElements: number;
+  }>;
+  const imageMode = coverage.skippedRules !== undefined;
   lines.push(`${BOLD}${CYAN}vlmkit check copy${RESET}`);
   lines.push(`${DIM}source: ${report.source}${RESET}`);
   lines.push("");
   lines.push(`status: ${status}`);
-  lines.push(`rendered text: ${report.textLength} chars`);
+  if (imageMode) {
+    lines.push(
+      `elements: ${coverage.elements ?? 0} (${coverage.textElements ?? 0} carrying text),`
+      + ` ${report.textLength} chars`,
+    );
+  } else {
+    lines.push(`rendered text: ${report.textLength} chars`);
+  }
   if (report.statesExplored > 0) {
     lines.push(`disclosure states: ${report.statesExplored} explored (details / tabs / aria-expanded)`);
     if (report.droppedStates > 0) {
@@ -794,6 +830,8 @@ export function formatCopyCheckReport(report: CopyCheckReport): string {
     for (const a of report.allowedInvisibleLines) {
       lines.push(`  ${DIM}invisible-allowed: "${a.line}" (${a.reason} — accepted via --allow-invisible)${RESET}`);
     }
+  } else if (imageMode) {
+    lines.push(`manifest: none (pass --manifest; --target is not available in --elements mode)`);
   } else {
     lines.push(`manifest: none (pass --manifest, or --target <png> to verify copy against the target pixels)`);
   }
@@ -822,6 +860,29 @@ export function formatCopyCheckReport(report: CopyCheckReport): string {
   } else {
     lines.push("");
     lines.push(`${GREEN}No copy issues detected.${RESET}`);
+  }
+  // Element-rect mode evaluates 3 of 5 rules, one of them partially. A bare "No copy issues
+  // detected." would let that read as full coverage, which is the one way this feature can do
+  // harm: what a clean result is worth is what it rules out. Printed next to the verdict, not
+  // in a footnote — the same call `formatIntegrityReport` makes for image-mode integrity.
+  if (coverage.skippedRules && coverage.skippedRules.length > 0) {
+    lines.push("");
+    lines.push(
+      `${YELLOW}Coverage: element-rect mode — ${coverage.skippedRules.length} rule(s) cannot be`
+      + ` evaluated without a DOM${RESET}`,
+    );
+    for (const skipped of coverage.skippedRules) {
+      lines.push(`${DIM}  - ${skipped.rule}: ${skipped.reason}${RESET}`);
+    }
+    if (coverage.inertRules && coverage.inertRules.length > 0) {
+      lines.push(`${DIM}  ${coverage.inertRules.length} rule(s) ran with no input to judge:${RESET}`);
+      for (const inert of coverage.inertRules) {
+        lines.push(`${DIM}  - ${inert.rule}: ${inert.reason}${RESET}`);
+      }
+    }
+    for (const note of coverage.coverageNotes ?? []) {
+      lines.push(`${DIM}  * ${note}${RESET}`);
+    }
   }
   return lines.join("\n");
 }

--- a/packages/vlmkit-markup/src/inspect/copy-image.test.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-image.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Element-rect `check copy` (vlmkit#118).
+ *
+ * `analyzeCopy` is reused unchanged, so what needs testing is the **adapter**: does element
+ * text reach it split into the right three pools (visible / raw / invisible-with-reason), and
+ * does the truncation pass fire where a canvas actually cuts a string off?
+ *
+ * Every fixture below is deliberately broken in one specific way — a manifest line the
+ * renderer never draws, an untranslated source string where the manifest wants the localized
+ * one, a `TODO` shipped, a number wider than its clip, a label the frame never painted — and
+ * each is paired with the inverse fixture that must report nothing. A gate that finds nothing
+ * on a clean frame has only proved that it is quiet; the failures are what give the passes
+ * their meaning.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { PNG } from "pngjs";
+import { COPY_IMAGE_SKIPPED_RULES, runImageCopyCheck } from "./copy-image.ts";
+import { formatCopyCheckReport } from "./copy-check.ts";
+
+async function dir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "vlmkit-copy-image-"));
+}
+
+async function fixture(
+  elements: unknown[],
+  manifest?: string,
+): Promise<{ elementsPath: string; manifestPath?: string; dir: string }> {
+  const base = await dir();
+  const elementsPath = join(base, "elements.json");
+  await writeFile(elementsPath, JSON.stringify({ elements }));
+  if (manifest === undefined) return { elementsPath, dir: base };
+  const manifestPath = join(base, "copy.txt");
+  await writeFile(manifestPath, manifest);
+  return { elementsPath, manifestPath, dir: base };
+}
+
+const ROOT = { path: "hud[0]", tag: "hud", classes: "hud-root", top: 0, left: 0, width: 640, height: 360 };
+
+const kinds = (report: { issues: { kind: string }[] }) => report.issues.map((i) => i.kind);
+
+/**
+ * A frame filled with one flat colour, with `painted` boxes given per-pixel noise.
+ *
+ * Noise rather than a second flat colour: `inkVerdict` asks whether the region varies at all,
+ * so a solid rectangle of a different colour is still "unpainted" — correctly, since a solid
+ * fill contains no glyphs.
+ */
+async function frame(
+  base: string,
+  painted: { top: number; left: number; width: number; height: number }[],
+): Promise<string> {
+  const png = new PNG({ width: 640, height: 360 });
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = 0x20;
+    png.data[i + 1] = 0x20;
+    png.data[i + 2] = 0x20;
+    png.data[i + 3] = 0xff;
+  }
+  for (const box of painted) {
+    for (let y = box.top; y < box.top + box.height; y++) {
+      for (let x = box.left; x < box.left + box.width; x++) {
+        const offset = (y * png.width + x) * 4;
+        const value = (x * 7 + y * 13) % 256;
+        png.data[offset] = value;
+        png.data[offset + 1] = value;
+        png.data[offset + 2] = value;
+      }
+    }
+  }
+  const path = join(base, "frame.png");
+  await writeFile(path, PNG.sync.write(png));
+  return path;
+}
+
+describe("manifest lines against renderer text", () => {
+  it("reports a manifest line the renderer never draws", async () => {
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20, text: "HP 120/120" },
+      { path: "hud[0]>a[1]", tag: "label", classes: "start", top: 200, left: 16, width: 200, height: 24, text: "Start Game" },
+    ], "HP 120/120\nStart Game\nOptions\n");
+    const report = await runImageCopyCheck({ elementsPath, manifestPath: manifestPath! });
+    assert.deepEqual(report.missingLines, ["Options"]);
+    assert.ok(kinds(report).includes("copy-missing"), kinds(report).join(", "));
+  });
+
+  it("reports nothing when every line is drawn", async () => {
+    // The inverse of the case above, same fixture minus the one absent line.
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20, text: "HP 120/120" },
+      { path: "hud[0]>a[1]", tag: "label", classes: "start", top: 200, left: 16, width: 200, height: 24, text: "Start Game" },
+    ], "HP 120/120\nStart Game\n");
+    const report = await runImageCopyCheck({ elementsPath, manifestPath: manifestPath! });
+    assert.deepEqual(report.issues, []);
+    assert.equal(report.manifestLines, 2);
+    assert.equal(report.textElements, 2);
+  });
+
+  it("catches an untranslated string shipped in place of the localized one", async () => {
+    // The engine drew the source-language fallback. Casing and spelling are spec in copy, so
+    // the manifest's localized line simply is not there.
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "start", top: 200, left: 16, width: 200, height: 24, text: "Start Game" },
+    ], "はじめる\n");
+    const report = await runImageCopyCheck({ elementsPath, manifestPath: manifestPath! });
+    assert.deepEqual(report.missingLines, ["はじめる"]);
+    assert.match(report.issues[0]!.message, /はじめる/);
+  });
+
+  it("matches a line spanning two adjacent strings in reading order", async () => {
+    // The DOM path lets one manifest line span several text nodes; element rects have no
+    // document order, so the adapter sorts by (top, left). Out of that order this fails.
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>b[0]", tag: "label", classes: "score-value", top: 16, left: 120, width: 80, height: 20, text: "1200" },
+      { path: "hud[0]>a[0]", tag: "label", classes: "score-label", top: 16, left: 16, width: 100, height: 20, text: "Score:" },
+    ], "Score: 1200\n");
+    const report = await runImageCopyCheck({ elementsPath, manifestPath: manifestPath! });
+    assert.deepEqual(report.missingLines, []);
+  });
+});
+
+describe("placeholder copy", () => {
+  it("reports a TODO shipped in a drawn string", async () => {
+    const { elementsPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "title", top: 40, left: 16, width: 300, height: 32, text: "TODO title" },
+    ]);
+    const report = await runImageCopyCheck({ elementsPath });
+    assert.deepEqual(report.placeholders, ["TODO"]);
+    assert.ok(kinds(report).includes("placeholder-text"));
+  });
+
+  it("stays quiet on real copy", async () => {
+    const { elementsPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "title", top: 40, left: 16, width: 300, height: 32, text: "Chapter 3: The Ashfall" },
+    ]);
+    const report = await runImageCopyCheck({ elementsPath });
+    assert.deepEqual(report.placeholders, []);
+    assert.deepEqual(report.issues, []);
+  });
+});
+
+describe("truncation", () => {
+  it("reports the px actually cut, and names the manifest line it only appears to satisfy", async () => {
+    // The reported pain in #118: a number outgrew its box. Matching the manifest against the
+    // renderer's `text` alone would call this satisfied — the user reads a cut-off string.
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      {
+        path: "hud[0]>a[0]", tag: "label", classes: "score", top: 16, left: 16, width: 200, height: 20,
+        text: "Score: 1234567890",
+        text_measured: { width: 320, height: 18 },
+        clip: { top: 16, left: 16, width: 200, height: 20 },
+      },
+    ], "Score: 1234567890\n");
+    const report = await runImageCopyCheck({ elementsPath, manifestPath: manifestPath! });
+    assert.deepEqual(report.missingLines, [], "the string IS drawn; it is only unreadable");
+    const issue = report.issues.find((i) => i.kind === "copy-truncated");
+    assert.ok(issue, kinds(report).join(", "));
+    // 320 measured - 200 clip = 120. Not 16 (the `left`), the mistake image-mode integrity made.
+    assert.match(issue!.message, /120px horizontally/);
+    assert.match(issue!.message, /"Score: 1234567890" on paper/);
+    assert.deepEqual(report.truncated.map((t) => t.selector), [".score"]);
+  });
+
+  it("does not report text that fits its clip", async () => {
+    const { elementsPath } = await fixture([
+      ROOT,
+      {
+        path: "hud[0]>a[0]", tag: "label", classes: "score", top: 16, left: 16, width: 200, height: 20,
+        text: "Score: 1200",
+        text_measured: { width: 90, height: 18 },
+        clip: { top: 16, left: 16, width: 200, height: 20 },
+      },
+    ]);
+    const report = await runImageCopyCheck({ elementsPath });
+    assert.deepEqual(report.truncated, []);
+    assert.deepEqual(kinds(report), []);
+  });
+
+  it("does not call oversized text without a clip rect truncated", async () => {
+    // On a canvas that overdraws its neighbours — a collision, not a cut-off string. Calling
+    // it "cut off" would send the reader after the wrong repair.
+    const { elementsPath } = await fixture([
+      ROOT,
+      {
+        path: "hud[0]>a[0]", tag: "label", classes: "score", top: 16, left: 16, width: 200, height: 20,
+        text: "Score: 1234567890",
+        text_measured: { width: 320, height: 18 },
+      },
+    ]);
+    const report = await runImageCopyCheck({ elementsPath });
+    assert.deepEqual(report.truncated, []);
+    assert.ok(
+      report.inertRules.some((r) => r.rule === "copy-truncated" && /overdraws/.test(r.reason)),
+      JSON.stringify(report.inertRules),
+    );
+  });
+});
+
+describe("text the renderer reports but the user cannot see", () => {
+  it("calls a manifest line in a zero-area box invisible, not missing", async () => {
+    // "Missing" would send the reader to write the string that is already there. The two
+    // repairs are different, which is the whole point of the reason classes.
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "toast", top: 100, left: 16, width: 0, height: 0, text: "Saved" },
+    ], "Saved\n");
+    const report = await runImageCopyCheck({ elementsPath, manifestPath: manifestPath! });
+    assert.deepEqual(report.missingLines, []);
+    assert.deepEqual(report.invisibleLines, [{ line: "Saved", reason: "zero-size" }]);
+    assert.ok(/--allow-invisible zero-size/.test(report.issues[0]!.message));
+  });
+
+  it("accepts a zero-size match when the caller allows that class", async () => {
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "toast", top: 100, left: 16, width: 0, height: 0, text: "Saved" },
+    ], "Saved\n");
+    const report = await runImageCopyCheck({
+      elementsPath,
+      manifestPath: manifestPath!,
+      allowInvisible: ["zero-size"],
+    });
+    assert.deepEqual(report.issues, []);
+    assert.deepEqual(report.allowedInvisibleLines, [{ line: "Saved", reason: "zero-size" }]);
+  });
+
+  it("reports a string the frame never painted", async () => {
+    // Missing font / alpha 0 / skipped draw call: the renderer is sure it drew "Start Game",
+    // and the frame's bbox is flat background. Without --image this passes silently, which is
+    // exactly what makes the ink check worth its pixels.
+    const base = await dir();
+    const elementsPath = join(base, "elements.json");
+    await writeFile(elementsPath, JSON.stringify({
+      elements: [
+        ROOT,
+        { path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20, text: "HP 120/120" },
+        { path: "hud[0]>a[1]", tag: "label", classes: "start", top: 200, left: 16, width: 200, height: 24, text: "Start Game" },
+      ],
+    }));
+    const manifestPath = join(base, "copy.txt");
+    await writeFile(manifestPath, "HP 120/120\nStart Game\n");
+    // Only the HP label's bbox got ink; ROOT carries no text, so it is not ink-checked.
+    const imagePath = await frame(base, [{ top: 16, left: 16, width: 200, height: 20 }]);
+
+    const withImage = await runImageCopyCheck({ elementsPath, imagePath, manifestPath });
+    assert.deepEqual(withImage.invisibleLines, [{ line: "Start Game", reason: "unpainted" }]);
+    assert.ok(kinds(withImage).includes("copy-invisible"), kinds(withImage).join(", "));
+
+    // And the same elements without the frame report nothing — the difference the flag buys.
+    const withoutImage = await runImageCopyCheck({ elementsPath, manifestPath });
+    assert.deepEqual(withoutImage.issues, []);
+    assert.ok(withoutImage.coverageNotes.some((n) => /No --image/.test(n)));
+  });
+
+  it("does not report a bbox that carries ink", async () => {
+    const base = await dir();
+    const elementsPath = join(base, "elements.json");
+    await writeFile(elementsPath, JSON.stringify({
+      elements: [
+        ROOT,
+        { path: "hud[0]>a[0]", tag: "label", classes: "start", top: 200, left: 16, width: 200, height: 24, text: "Start Game" },
+      ],
+    }));
+    const manifestPath = join(base, "copy.txt");
+    await writeFile(manifestPath, "Start Game\n");
+    const imagePath = await frame(base, [{ top: 200, left: 16, width: 200, height: 24 }]);
+    const report = await runImageCopyCheck({ elementsPath, imagePath, manifestPath });
+    assert.deepEqual(report.issues, []);
+    assert.ok(report.coverageNotes.some((n) => /Ink checked in 1 text bbox/.test(n)), report.coverageNotes.join(" | "));
+  });
+
+  it("counts off-frame elements instead of guessing why they are off-frame", async () => {
+    // Element rects carry no scroll or clip chain, so "never drawn" and "scrolled out of this
+    // frame" are indistinguishable. Reporting either would be a guess; the count is not.
+    const base = await dir();
+    const elementsPath = join(base, "elements.json");
+    await writeFile(elementsPath, JSON.stringify({
+      elements: [
+        ROOT,
+        { path: "hud[0]>a[0]", tag: "row", classes: "row-9", top: 900, left: 16, width: 200, height: 24, text: "Row 9" },
+      ],
+    }));
+    const imagePath = await frame(base, []);
+    const report = await runImageCopyCheck({ elementsPath, imagePath });
+    assert.deepEqual(kinds(report), []);
+    assert.ok(
+      report.coverageNotes.some((n) => /1 text element\(s\) lie outside the frame/.test(n)),
+      report.coverageNotes.join(" | "),
+    );
+  });
+});
+
+describe("coverage is reported, not implied", () => {
+  it("names every rule it cannot evaluate, with a reason", async () => {
+    const { elementsPath } = await fixture([ROOT]);
+    const report = await runImageCopyCheck({ elementsPath });
+    assert.equal(report.skippedRules.length, COPY_IMAGE_SKIPPED_RULES.length);
+    assert.ok(report.skippedRules.every((r) => r.reason.length > 10), JSON.stringify(report.skippedRules));
+    for (const needsPage of ["redirected", "copy-image-mismatch"]) {
+      assert.ok(report.skippedRules.some((r) => r.rule === needsPage), `${needsPage} must be listed`);
+    }
+    // The partial rule matters as much as the absent ones: copy-invisible running over 2 of
+    // its 7 reason classes is not the same gate as copy-invisible running over all 7.
+    assert.ok(report.coverageNotes.some((n) => /copy-invisible covers 2 of its 7/.test(n)));
+    assert.ok(report.inertRules.some((r) => r.rule === "copy-missing" && /no --manifest/.test(r.reason)));
+  });
+
+  it("prints the coverage block next to a clean verdict, not in a footnote", async () => {
+    // The one way this feature could do harm is a clean line reading as full coverage.
+    const { elementsPath, manifestPath } = await fixture([
+      ROOT,
+      { path: "hud[0]>a[0]", tag: "label", classes: "hp", top: 16, left: 16, width: 200, height: 20, text: "HP 120/120" },
+    ], "HP 120/120\n");
+    const text = formatCopyCheckReport(await runImageCopyCheck({ elementsPath, manifestPath: manifestPath! }));
+    assert.match(text, /No copy issues detected/);
+    assert.match(text, /Coverage: element-rect mode — 2 rule\(s\) cannot be evaluated without a DOM/);
+    assert.match(text, /- redirected: needs a navigation result/);
+    assert.match(text, /elements: 2 \(1 carrying text\)/);
+  });
+});
+
+describe("parsing is the shared one", () => {
+  it("throws on a row missing geometry rather than dropping it", async () => {
+    // Delegated to `parseIntegrityImageElements`. Asserted here because the consequence in
+    // this gate is specific: a dropped row makes its copy read as missing, so a typo in the
+    // elements file would look like a copy bug in the game.
+    const { elementsPath } = await fixture([{ path: "a[0]", tag: "a", top: 0, left: 0, text: "hi" }]);
+    await assert.rejects(
+      () => runImageCopyCheck({ elementsPath }),
+      /needs path\/top\/left\/width\/height/,
+    );
+  });
+});

--- a/packages/vlmkit-markup/src/inspect/copy-image.ts
+++ b/packages/vlmkit-markup/src/inspect/copy-image.ts
@@ -1,0 +1,348 @@
+/**
+ * `check copy` without a DOM: an element-rect JSON (text + bbox per element) and,
+ * optionally, the frame PNG those rects were drawn into.
+ *
+ * Requested in vlmkit#118 by the same canvas/WebGPU game engine that asked for image-only
+ * `check integrity` (#116). `runCopyCheck` reads text through Playwright — `COLLECT_RAW_TEXT`
+ * and `COLLECT_TEXT_VISIBILITY` walk text nodes — so a canvas UI presents one `<canvas>`
+ * element with no text nodes at all: the manifest check reports every line missing and the
+ * placeholder scan reports nothing. Both verdicts are about the DOM, not about the frame.
+ *
+ * The engine already knows what it drew and where, which is exactly the input the pure part
+ * of the gate wants. `analyzeCopy` in `copy-check.ts` is reused **unchanged**: it takes
+ * `{pageText, visibleText, invisibleChunks, manifestLines}` and owns the placeholder scan,
+ * the manifest matching and the invisible-reason attribution. This file's whole job is to
+ * turn element rects into those four strings honestly. Same shape as `integrity-image.ts`:
+ * the DOM becomes one adapter among several rather than the only way in.
+ *
+ * ## Element order matters, so it is defined
+ *
+ * The DOM path joins text-node values in document order and normalizes whitespace, which
+ * lets one manifest line span several nodes (`<p>Instagram · <a>RSS</a></p>` is one line).
+ * Element rects have no document order, so they are sorted by (top, left) — reading order,
+ * the same order `COLLECT_TEXT_BLOCKS` sorts its blocks into. A manifest line may therefore
+ * span two adjacent drawn strings, exactly as it may span two text nodes.
+ *
+ * ## What it will not do
+ *
+ * Two of the gate's five rules cannot run at all here, and `copy-invisible` runs over two of
+ * its seven reason classes. Those gaps are **named in the report** (`skippedRules`,
+ * `inertRules`, `coverageNotes`) rather than omitted, because a `no copy issues` result over
+ * two-and-a-bit rules is a much weaker claim than the same words over five, and the reader
+ * has to be able to see the difference. Same reasoning as `integrity-image.ts`.
+ *
+ * Deliberately NOT implemented, each because the input cannot support it honestly:
+ *
+ *   - **Off-frame text.** An element whose box lies outside the frame might not have been
+ *     drawn, or might be a scrolled-out row of a list the engine reports in full. Element
+ *     rects carry no scroll or clip-chain information, so the two are indistinguishable and
+ *     reporting either way would be a guess. Such elements are counted in `coverageNotes`
+ *     instead, so a caller can see their ink went unchecked.
+ *   - **`--target` image review.** The crop/contact-sheet path compares a *reference*
+ *     screenshot against a live render; wiring it here needs a second image and a different
+ *     question than "is my frame's copy right". The gate rejects `--target` in this mode
+ *     rather than accepting it and quietly reviewing nothing.
+ *   - **Disclosure-state sweep.** Opening `<details>` and clicking tabs needs a live page.
+ *     A collapsed panel's copy is simply absent from the frame the engine handed over.
+ */
+import { readFile } from "node:fs/promises";
+import { PNG } from "pngjs";
+import { appendRunLedger } from "@mizchi/vlmkit-core/run-ledger.ts";
+import {
+  type CopyCheckReport,
+  type InvisibleReason,
+  analyzeCopy,
+  normalizeWhitespace,
+  parseCopyManifest,
+} from "./copy-check.ts";
+// The element-rect parser is shared with image-mode `check integrity`, name and all: it
+// accepts `{elements:[…]}` or a bare array, snake_case and camelCase optional fields, and
+// throws on a row missing geometry. A second parser would be a second set of accepted
+// spellings, and callers write this JSON from a non-JS language.
+// `describe` comes from there too, so one element reads the same way (`.class`, then `#id`,
+// then the tag, then the path) whichever gate reports it.
+import {
+  type IntegrityImageElement,
+  describe as describeElement,
+  parseIntegrityImageElements,
+} from "./integrity-image.ts";
+
+export interface CopyImageOptions {
+  elementsPath: string;
+  /** Frame PNG. Optional: without it the ink check (unpainted text) cannot run. */
+  imagePath?: string;
+  manifestPath?: string;
+  /** Invisible-match reason classes to accept as satisfied (CLI `--allow-invisible`). */
+  allowInvisible?: InvisibleReason[];
+}
+
+/** Rules this input cannot support, each with the reason. Reported, not hidden. */
+export const COPY_IMAGE_SKIPPED_RULES: { rule: string; reason: string }[] = [
+  { rule: "redirected", reason: "needs a navigation result; element rects carry no URL" },
+  {
+    rule: "copy-image-mismatch",
+    reason: "needs a reference screenshot to crop and transcribe (--target), which this mode does not accept",
+  },
+];
+
+/** One element whose text is drawn but cut off by its own clip rect. */
+export interface CopyTruncation {
+  selector: string;
+  text: string;
+  /** Px of text beyond the clip rect, per axis. */
+  clippedX: number;
+  clippedY: number;
+  /** Manifest lines this element's text satisfies — satisfied on paper, unreadable in fact. */
+  manifestLines: string[];
+}
+
+export interface CopyImageReport extends CopyCheckReport {
+  /** Rules that cannot run in this mode, and why. */
+  skippedRules: { rule: string; reason: string }[];
+  /** Rules that ran but had no input — e.g. no element carried `text`. */
+  inertRules: { rule: string; reason: string }[];
+  /** Coverage caveats that are not per-rule (partial reason classes, unchecked elements). */
+  coverageNotes: string[];
+  truncated: CopyTruncation[];
+  elements: number;
+  textElements: number;
+}
+
+/**
+ * Px of text beyond the clip rect below which truncation is not worth reporting.
+ *
+ * 4, the same floor image-mode `check integrity` uses for `text-clipped`. Sub-pixel layout
+ * and glyph-metric rounding routinely produce 1-2px of overhang on text that reads fine.
+ */
+const TRUNCATION_FLOOR = 4;
+
+/**
+ * Max channel spread within a text bbox for the region to count as unpainted.
+ *
+ * Deliberately near-zero rather than an ink *ratio*: the claim being made is "no glyphs were
+ * painted here at all", and a flat region is the only pixel evidence that supports it
+ * without a font metric. Antialiased 8px text on a busy panel still spreads far more than 2
+ * channel steps, so legible-but-faint copy is not reported. The cost of the tight threshold
+ * is that same-color-on-same-color text (the DOM path's `camouflage` class) slips through —
+ * stated in `coverageNotes` rather than papered over with a looser number.
+ */
+const UNPAINTED_TOLERANCE = 2;
+
+export async function runImageCopyCheck(options: CopyImageOptions): Promise<CopyImageReport> {
+  const elements = parseIntegrityImageElements(await readFile(options.elementsPath, "utf-8"));
+
+  let image: PNG | undefined;
+  if (options.imagePath) image = PNG.sync.read(await readFile(options.imagePath));
+
+  const manifestLines = options.manifestPath
+    ? parseCopyManifest(await readFile(options.manifestPath, "utf8"))
+    : undefined;
+
+  // Reading order, so joining adjacent strings means what it means in the DOM path.
+  const withText = elements
+    .filter((element) => (element.text ?? "").trim().length > 0)
+    .sort((a, b) => a.top - b.top || a.left - b.left);
+
+  const inertRules: { rule: string; reason: string }[] = [];
+  const coverageNotes: string[] = [];
+
+  const visible: string[] = [];
+  const invisibleChunks: { reason: string; text: string }[] = [];
+  const truncated: CopyTruncation[] = [];
+  let offFrame = 0;
+  let inkChecked = 0;
+
+  for (const element of withText) {
+    const text = element.text!;
+    // Zero-area boxes first: an element with no box painted nothing regardless of pixels,
+    // and running the ink check on it would read whatever happens to sit at that point.
+    if (element.width <= 0 || element.height <= 0) {
+      invisibleChunks.push({ reason: "zero-size", text });
+      continue;
+    }
+    if (image) {
+      const verdict = inkVerdict(image, element);
+      if (verdict === "off-frame") {
+        offFrame++;
+      } else {
+        inkChecked++;
+        if (verdict === "unpainted") {
+          invisibleChunks.push({ reason: "unpainted", text });
+          continue;
+        }
+      }
+    }
+    visible.push(text);
+    const cut = truncationOf(element);
+    if (cut) {
+      truncated.push({
+        selector: describeElement(element),
+        text,
+        clippedX: cut.clippedX,
+        clippedY: cut.clippedY,
+        manifestLines: (manifestLines ?? []).filter((line) =>
+          normalizeWhitespace(text).includes(normalizeWhitespace(line))
+        ),
+      });
+    }
+  }
+
+  // Raw text carries every string the engine says it drew, visible or not — that is what
+  // `analyzeCopy` needs to tell copy-invisible (rendered but unseeable) from copy-missing
+  // (never rendered at all).
+  const rawParts = [...visible, ...invisibleChunks.map((chunk) => chunk.text)];
+
+  const report = analyzeCopy({
+    source: options.imagePath ?? options.elementsPath,
+    pageText: rawParts.join("\n"),
+    visibleText: visible.join("\n"),
+    invisibleChunks,
+    ...(options.allowInvisible ? { allowInvisible: options.allowInvisible } : {}),
+    ...(manifestLines ? { manifestLines } : {}),
+  }) as CopyImageReport;
+
+  // Truncation is reported for every clipped text element, not only manifest-carrying ones:
+  // the reported pain (vlmkit#118) is a dynamic number outgrowing its box, and no static
+  // manifest lists those. This overlaps image-mode `check integrity`'s `text-clipped` by
+  // design — integrity answers "is this frame broken", copy answers "can the user read the
+  // strings" — and one duplicated finding when both gates run is a better trade than copy
+  // passing a manifest line the user can only half read.
+  for (const cut of truncated) {
+    const axis = cut.clippedX >= cut.clippedY
+      ? `${cut.clippedX}px horizontally`
+      : `${cut.clippedY}px vertically`;
+    const satisfied = cut.manifestLines.length > 0
+      ? ` It satisfies manifest line(s) ${cut.manifestLines.map((l) => `"${l}"`).join(", ")} on paper,`
+        + ` but the user cannot read all of it.`
+      : "";
+    report.issues.push({
+      kind: "copy-truncated",
+      severity: "suspect",
+      message: `${cut.selector} draws "${cut.text}" but its measured text runs ${axis} past the clip rect,`
+        + ` so it renders cut off.${satisfied}`
+        + ` Shorten the string, widen the box, or shrink the type.`,
+    });
+  }
+
+  if (withText.length === 0) {
+    inertRules.push({
+      rule: "placeholder-text",
+      reason: "no element carried `text`; nothing to scan",
+    });
+  }
+  // Ordered so `copy-missing` gets exactly one reason: no manifest is the more fundamental
+  // absence, and reporting both would read as two independent gaps.
+  if (manifestLines === undefined) {
+    inertRules.push({ rule: "copy-missing", reason: "no --manifest given; there is nothing to require" });
+  } else if (withText.length === 0) {
+    inertRules.push({
+      rule: "copy-missing",
+      reason: "no element carried `text`, so every manifest line reports missing for want of input rather than for a real absence",
+    });
+  }
+  if (withText.every((element) => !element.textMeasured || !element.clip)) {
+    inertRules.push({
+      rule: "copy-truncated",
+      reason: withText.some((element) => element.textMeasured)
+        ? "no element declared both `textMeasured` and a `clip` rect; text wider than its box overdraws rather than truncating unless a clip says otherwise"
+        : "no element carried `textMeasured`; only the renderer knows the drawn extent",
+    });
+  }
+
+  coverageNotes.push(
+    "copy-invisible covers 2 of its 7 reason classes here: zero-size (empty box) and"
+    + " unpainted (--image only, a flat bbox). hidden, transparent, camouflage, unreachable and"
+    + " visually-hidden all need computed styles.",
+  );
+  if (!image) {
+    coverageNotes.push(
+      "No --image: text the engine reports but never actually painted (missing font, alpha 0,"
+      + " skipped draw call) cannot be detected. Pass the frame PNG to enable the ink check.",
+    );
+  } else {
+    coverageNotes.push(`Ink checked in ${inkChecked} text bbox(es) against ${options.imagePath}.`);
+    if (offFrame > 0) {
+      coverageNotes.push(
+        `${offFrame} text element(s) lie outside the frame, so their ink went unchecked. Element`
+        + " rects carry no scroll or clip-chain data, so \"never drawn\" and \"scrolled out of this"
+        + " frame\" are indistinguishable and neither is reported.",
+      );
+    }
+  }
+  coverageNotes.push(
+    "No disclosure-state sweep: opening <details> and clicking tabs needs a live page, so copy"
+    + " only reachable through an interaction is absent from this input, not hidden in it.",
+  );
+
+  report.skippedRules = COPY_IMAGE_SKIPPED_RULES;
+  report.inertRules = inertRules;
+  report.coverageNotes = coverageNotes;
+  report.truncated = truncated;
+  report.elements = elements.length;
+  report.textElements = withText.length;
+
+  appendRunLedger({
+    tool: "check-copy",
+    source: options.imagePath ?? options.elementsPath,
+    ...(options.manifestPath ? { target: options.manifestPath } : {}),
+    headline: {
+      mode: "elements",
+      elements: elements.length,
+      textElements: withText.length,
+      missing: report.missingLines.length,
+      placeholders: report.placeholders.length,
+      manifestLines: report.manifestLines,
+      truncated: truncated.length,
+      ...(report.invisibleLines.length > 0 ? { invisibleOnly: report.invisibleLines.length } : {}),
+      ...(report.allowedInvisibleLines.length > 0 ? { allowedInvisible: report.allowedInvisibleLines.length } : {}),
+      skippedRules: COPY_IMAGE_SKIPPED_RULES.length,
+    },
+  });
+  return report;
+}
+
+/** Px of text beyond the element's own clip rect, or `null` when it fits (or cannot be known). */
+function truncationOf(
+  element: IntegrityImageElement,
+): { clippedX: number; clippedY: number } | null {
+  // Both fields required, deliberately. `textMeasured` alone says the string is wider than
+  // its box, which on a canvas means it *overdraws* its neighbours — a collision, not a
+  // truncation, and naming it "cut off" would send the reader after the wrong repair. Image
+  // mode `check integrity` draws the same line for the same reason.
+  if (!element.textMeasured || !element.clip) return null;
+  const clippedX = Math.round(element.textMeasured.width - element.clip.width);
+  const clippedY = Math.round(element.textMeasured.height - element.clip.height);
+  if (clippedX < TRUNCATION_FLOOR && clippedY < TRUNCATION_FLOOR) return null;
+  return { clippedX: Math.max(0, clippedX), clippedY: Math.max(0, clippedY) };
+}
+
+/**
+ * Does the frame carry any ink inside this element's box?
+ *
+ * `off-frame` when the box does not intersect the image at all — an answer, not a finding
+ * (see the module header). Otherwise `unpainted` iff every pixel in the intersection is the
+ * same colour within `UNPAINTED_TOLERANCE`.
+ */
+function inkVerdict(image: PNG, element: IntegrityImageElement): "painted" | "unpainted" | "off-frame" {
+  const box = element.clip ?? element;
+  const x1 = Math.max(0, Math.floor(box.left));
+  const y1 = Math.max(0, Math.floor(box.top));
+  const x2 = Math.min(image.width, Math.ceil(box.left + box.width));
+  const y2 = Math.min(image.height, Math.ceil(box.top + box.height));
+  if (x2 - x1 < 1 || y2 - y1 < 1) return "off-frame";
+  const min = [255, 255, 255];
+  const max = [0, 0, 0];
+  for (let y = y1; y < y2; y++) {
+    for (let x = x1; x < x2; x++) {
+      const offset = (y * image.width + x) * 4;
+      for (let channel = 0; channel < 3; channel++) {
+        const value = image.data[offset + channel]!;
+        if (value < min[channel]!) min[channel] = value;
+        if (value > max[channel]!) max[channel] = value;
+      }
+    }
+  }
+  const spread = Math.max(max[0]! - min[0]!, max[1]! - min[1]!, max[2]! - min[2]!);
+  return spread > UNPAINTED_TOLERANCE ? "painted" : "unpainted";
+}
+

--- a/packages/vlmkit-markup/src/inspect/integrity-image.ts
+++ b/packages/vlmkit-markup/src/inspect/integrity-image.ts
@@ -416,7 +416,7 @@ function alignmentGroups(
  * through `diff png --elements-json` or here. Falls back to the path, which is always
  * present and always unique.
  */
-function describe(element: IntegrityImageElement): string {
+export function describe(element: IntegrityImageElement): string {
   const className = (element.classes ?? "").split(/\s+/).find((token) => /^-?[A-Za-z_][\w-]*$/.test(token));
   if (className) return `.${className}`;
   if (element.id && /^-?[A-Za-z_][\w-]*$/.test(element.id)) return `#${element.id}`;

--- a/packages/vlmkit-markup/src/png-diff.test.ts
+++ b/packages/vlmkit-markup/src/png-diff.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { parsePngDiffArgs, runPngDiff } from "./png-diff.ts";
+import { parsePngDiffArgs, runPngDiff, runPngDiffCli } from "./png-diff.ts";
 import { encodePng } from "@mizchi/vlmkit-core/png-utils.ts";
 
 const TMP = join(import.meta.dirname!, "..", "..", "..", "test-results", "png-diff-test");
@@ -41,6 +41,202 @@ function createPalettePng(
 
   return { width, height, data };
 }
+
+/**
+ * A flat frame with one rectangle painted a different colour — the shape of a
+ * game frame whose only variance is a particle burst or a timer readout
+ * (vlmkit#118). 160px short side puts `adaptiveRegionCellSize` on the 8px grid,
+ * and every rect used below is 8px-aligned so the detected region bbox is
+ * exactly the painted rect and the assertions are on real numbers, not on
+ * whatever the grid rounded to.
+ */
+function createFramePng(
+  width: number,
+  height: number,
+  background: [number, number, number],
+  rect?: { x: number; y: number; w: number; h: number; color: [number, number, number] },
+): { width: number; height: number; data: Uint8Array } {
+  const data = new Uint8Array(width * height * 4);
+  for (let i = 0; i < width * height; i++) {
+    data[i * 4] = background[0];
+    data[i * 4 + 1] = background[1];
+    data[i * 4 + 2] = background[2];
+    data[i * 4 + 3] = 255;
+  }
+  if (rect) {
+    for (let y = rect.y; y < rect.y + rect.h; y++) {
+      for (let x = rect.x; x < rect.x + rect.w; x++) {
+        const offset = (y * width + x) * 4;
+        data[offset] = rect.color[0];
+        data[offset + 1] = rect.color[1];
+        data[offset + 2] = rect.color[2];
+      }
+    }
+  }
+  return { width, height, data };
+}
+
+const NOISY = { x: 96, y: 112, w: 32, h: 32 } as const;
+const FRAME = 160;
+const FRAME_PIXELS = FRAME * FRAME;
+const NOISY_PIXELS = NOISY.w * NOISY.h;
+
+/** Two 160x160 frames differing only inside NOISY. */
+async function writeNoisyFramePair(dir: string): Promise<{ baselinePath: string; currentPath: string }> {
+  const baselinePath = join(dir, "frame-baseline.png");
+  const currentPath = join(dir, "frame-current.png");
+  await encodePng(baselinePath, createFramePng(FRAME, FRAME, [30, 30, 30], { ...NOISY, color: [30, 30, 30] }));
+  await encodePng(currentPath, createFramePng(FRAME, FRAME, [30, 30, 30], { ...NOISY, color: [220, 40, 40] }));
+  return { baselinePath, currentPath };
+}
+
+describe("png-diff --ignore-region", () => {
+  it("parses repeated --ignore-region into rects", () => {
+    const options = parsePngDiffArgs([
+      "a.png", "b.png",
+      "--ignore-region", "0,300,640x60",
+      "--ignore-region", " 12 , 4 , 8x8 ",
+    ]);
+    assert.deepEqual(options.ignoreRegions, [
+      { x: 0, y: 300, width: 640, height: 60 },
+      { x: 12, y: 4, width: 8, height: 8 },
+    ]);
+  });
+
+  it("rejects malformed --ignore-region values with exit code 2", () => {
+    for (const bad of ["0,300,640", "0,300,640x0", "abc", "0,300x640,60", ""]) {
+      assert.throws(
+        () => parsePngDiffArgs(["a.png", "b.png", "--ignore-region", bad]),
+        (error: Error & { exitCode?: number }) => {
+          assert.equal(error.exitCode, 2, `"${bad}" should be a usage error, not a silent no-mask`);
+          assert.match(error.message, /--ignore-region/);
+          return true;
+        },
+        `"${bad}" should be rejected`,
+      );
+    }
+  });
+
+  it("reports the diff without a mask, and drops it when the noisy rect is ignored", async () => {
+    await rm(TMP, { recursive: true, force: true });
+    await mkdir(TMP, { recursive: true });
+    try {
+      const { baselinePath, currentPath } = await writeNoisyFramePair(TMP);
+      const base = { baselinePath, currentPath, outputDir: TMP, threshold: 0.1, skipHeatmap: true, json: false };
+
+      const unmasked = await runPngDiff(base);
+      assert.equal(unmasked.diff.diffPixels, NOISY_PIXELS);
+      assert.equal(unmasked.diff.totalPixels, FRAME_PIXELS);
+      assert.equal(unmasked.diff.mask, undefined, "no mask key without --ignore-region");
+      assert.equal(unmasked.diff.regions.length, 1);
+      assert.deepEqual(
+        { x: unmasked.diff.regions[0]!.x, y: unmasked.diff.regions[0]!.y },
+        { x: NOISY.x, y: NOISY.y },
+      );
+
+      const masked = await runPngDiff({
+        ...base,
+        ignoreRegions: [{ x: NOISY.x, y: NOISY.y, width: NOISY.w, height: NOISY.h }],
+      });
+      // Both halves: no diff pixels left, and no region either. A region with
+      // diffPixelCount 0 would still be attributed to an element downstream.
+      assert.equal(masked.diff.diffPixels, 0);
+      assert.equal(masked.diff.regions.length, 0);
+      assert.equal(masked.diff.diffRatio, 0);
+      // Denominator excludes the ignored area: imagePixels - ignoredPixels.
+      assert.equal(masked.diff.totalPixels, FRAME_PIXELS - NOISY_PIXELS);
+      assert.equal(masked.diff.mask!.ignoredPixels, NOISY_PIXELS);
+      assert.equal(masked.diff.mask!.ignoredDiffPixels, NOISY_PIXELS);
+      assert.equal(masked.diff.mask!.imagePixels, FRAME_PIXELS);
+      assert.deepEqual(masked.diff.mask!.regions, [
+        { x: NOISY.x, y: NOISY.y, width: NOISY.w, height: NOISY.h, pixels: NOISY_PIXELS, diffPixels: NOISY_PIXELS },
+      ]);
+    } finally {
+      await rm(TMP, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the diff alone when an unrelated rect is ignored, and does not dilute the ratio", async () => {
+    await rm(TMP, { recursive: true, force: true });
+    await mkdir(TMP, { recursive: true });
+    try {
+      const { baselinePath, currentPath } = await writeNoisyFramePair(TMP);
+      const result = await runPngDiff({
+        baselinePath, currentPath, outputDir: TMP, threshold: 0.1, skipHeatmap: true, json: false,
+        ignoreRegions: [{ x: 0, y: 0, width: 32, height: 32 }],
+      });
+
+      assert.equal(result.diff.diffPixels, NOISY_PIXELS, "a mask elsewhere must not hide this change");
+      assert.equal(result.diff.regions.length, 1);
+      assert.equal(result.diff.mask!.ignoredDiffPixels, 0, "the mask swallowed nothing — say so");
+      assert.equal(result.diff.mask!.regions[0]!.diffPixels, 0);
+      // The point of shrinking the denominator: masking a quiet corner must not
+      // make an unrelated regression read as *less* severe than it did before.
+      assert.ok(
+        result.diff.diffRatio > NOISY_PIXELS / FRAME_PIXELS,
+        `ratio ${result.diff.diffRatio} should exceed the full-frame ratio ${NOISY_PIXELS / FRAME_PIXELS}`,
+      );
+      assert.equal(result.diff.totalPixels, FRAME_PIXELS - 32 * 32);
+    } finally {
+      await rm(TMP, { recursive: true, force: true });
+    }
+  });
+
+  it("counts overlapping rects once and reports an off-frame rect as masking nothing", async () => {
+    await rm(TMP, { recursive: true, force: true });
+    await mkdir(TMP, { recursive: true });
+    try {
+      const { baselinePath, currentPath } = await writeNoisyFramePair(TMP);
+      const result = await runPngDiff({
+        baselinePath, currentPath, outputDir: TMP, threshold: 0.1, skipHeatmap: true, json: false,
+        ignoreRegions: [
+          { x: NOISY.x, y: NOISY.y, width: NOISY.w, height: NOISY.h },
+          { x: NOISY.x + 16, y: NOISY.y, width: NOISY.w, height: NOISY.h }, // half overlaps the first
+          { x: 1000, y: 1000, width: 50, height: 50 }, // entirely off-frame
+        ],
+      });
+
+      const mask = result.diff.mask!;
+      // Union: all 1024 of the first rect plus the 512 px of the second that lie
+      // outside it. Per-rect diff counts sum to 1536 — the deduplicated total is
+      // 1024, which is what keeps imagePixels - ignoredPixels === totalPixels.
+      assert.equal(mask.ignoredPixels, NOISY_PIXELS + 16 * 32);
+      assert.equal(mask.ignoredDiffPixels, NOISY_PIXELS);
+      assert.equal(mask.regions[0]!.diffPixels + mask.regions[1]!.diffPixels, NOISY_PIXELS + 16 * 32);
+      assert.equal(result.diff.totalPixels, mask.imagePixels - mask.ignoredPixels);
+      assert.deepEqual(
+        { pixels: mask.regions[2]!.pixels, diffPixels: mask.regions[2]!.diffPixels },
+        { pixels: 0, diffPixels: 0 },
+        "an off-frame rect masks nothing and must report so rather than look applied",
+      );
+    } finally {
+      await rm(TMP, { recursive: true, force: true });
+    }
+  });
+
+  it("prints the masked-pixel accounting next to the verdict, not only in --json", async () => {
+    await rm(TMP, { recursive: true, force: true });
+    await mkdir(TMP, { recursive: true });
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => { lines.push(args.map(String).join(" ")); };
+    try {
+      const { baselinePath, currentPath } = await writeNoisyFramePair(TMP);
+      await runPngDiffCli([
+        baselinePath, currentPath, "--no-heatmap",
+        "--ignore-region", `${NOISY.x},${NOISY.y},${NOISY.w}x${NOISY.h}`,
+      ]);
+      const text = lines.join("\n");
+      assert.match(text, /diff:\s+0\.00% \(0 \/ 24576 px measured\)/);
+      assert.match(text, /ignored:\s+1 region\(s\), 1024 px \(4\.0% of the 25600 px compared area\) — never measured/);
+      assert.match(text, /\(96,112\) 32x32 — 1024 px, 1024 of them differed/);
+      assert.match(text, /1024 diff px discarded; denominator 25600 - 1024 = 24576/);
+    } finally {
+      console.log = original;
+      await rm(TMP, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("png-diff", () => {
   it("parses CLI flags for direct PNG comparison", () => {

--- a/packages/vlmkit-markup/src/png-diff.ts
+++ b/packages/vlmkit-markup/src/png-diff.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { compareScreenshots } from "@mizchi/vlmkit-core/heatmap.ts";
+import { compareScreenshots, parseIgnoreRegionSpec } from "@mizchi/vlmkit-core/heatmap.ts";
 import { readPngDimensions } from "@mizchi/vlmkit-core/image-resize.ts";
 import { classifyVisualDiff } from "./visual-semantic.ts";
 import {
@@ -11,7 +11,7 @@ import {
   type RegionElementRect,
   type RegionElementsViewport,
 } from "./region-selector-match.ts";
-import type { DiffRegion, VrtSnapshot } from "@mizchi/vlmkit-core/types.ts";
+import type { DiffIgnoreRegion, DiffRegion, VrtSnapshot } from "@mizchi/vlmkit-core/types.ts";
 
 export interface PngDiffCliOptions {
   baselinePath: string;
@@ -40,6 +40,19 @@ export interface PngDiffCliOptions {
    * computed, and one wrong winner otherwise hides every alternative.
    */
   elementsTop?: number;
+  /**
+   * Rectangles that change every frame by construction — particles, noise, a
+   * timer readout (vlmkit#118, a canvas/WebGPU engine).
+   *
+   * Deliberately not `baseline approve --region`: approval records a decision
+   * with a reason, an approver and an expiry, and shows up in the
+   * `gates suppressions` stocktake. A permanently non-deterministic area routed
+   * through approval re-pollutes that history on every run and turns the
+   * stocktake into noise. These rects are *never measured* instead: nothing is
+   * recorded, nothing expires, and nothing is forgiven — there is no finding to
+   * forgive.
+   */
+  ignoreRegions?: DiffIgnoreRegion[];
 }
 
 export interface PngDiffRegionCrop {
@@ -84,7 +97,16 @@ Options:
                         region coarser than the element that changed misattributes
                         the cause. Lower it for small frames with fine detail.
   --elements-top <N>    Report the top N attribution candidates per region
-                        (default 1) instead of only the winner`;
+                        (default 1) instead of only the winner
+  --ignore-region "<x>,<y>,<w>x<h>"
+                        Never measure this rectangle. Repeatable. For areas that
+                        are non-deterministic by construction (particles, noise,
+                        a timer readout) — unlike "baseline approve --region"
+                        nothing is recorded or forgiven, and it does not appear
+                        in the suppression stocktake. Ignored pixels leave BOTH
+                        the diff count and the diffRatio denominator, so the
+                        ratio stays "fraction of what was measured". The masked
+                        area and the diff pixels it swallowed are always printed`;
 }
 
 export function parsePngDiffArgs(args: string[]): PngDiffCliOptions {
@@ -99,10 +121,24 @@ export function parsePngDiffArgs(args: string[]): PngDiffCliOptions {
   let elementsHtml: string | undefined;
   let elementsViewport: RegionElementsViewport | undefined;
   let cropRegions: string | undefined;
+  const ignoreRegions: DiffIgnoreRegion[] = [];
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
     switch (arg) {
+      case "--ignore-region": {
+        const value = args[++i];
+        if (!value) throw new PngDiffCliError(`Missing value for ${arg}\n\n${formatPngDiffUsage()}`, 2);
+        try {
+          ignoreRegions.push(parseIgnoreRegionSpec(value));
+        } catch (error) {
+          // Exit 2 like --region-grid / --elements-top: a malformed rect is a
+          // usage error, and it must never degrade to "no mask applied" — that
+          // would report a diff the caller believes they excluded.
+          throw new PngDiffCliError(`--ignore-region: ${(error as Error).message}`, 2);
+        }
+        break;
+      }
       case "--crop-regions": {
         const value = args[++i];
         if (!value) throw new PngDiffCliError(`Missing value for ${arg}\n\n${formatPngDiffUsage()}`, 1);
@@ -197,6 +233,7 @@ export function parsePngDiffArgs(args: string[]): PngDiffCliOptions {
     ...(cropRegions ? { cropRegions } : {}),
     ...(regionGrid !== undefined ? { regionGrid } : {}),
     ...(elementsTop !== undefined ? { elementsTop } : {}),
+    ...(ignoreRegions.length > 0 ? { ignoreRegions } : {}),
   };
 }
 
@@ -273,6 +310,7 @@ export async function runPngDiff(options: PngDiffCliOptions) {
     skipHeatmap: options.skipHeatmap,
     threshold: options.threshold,
     ...(options.regionGrid !== undefined ? { regionCellSize: options.regionGrid } : {}),
+    ...(options.ignoreRegions ? { ignoreRegions: options.ignoreRegions } : {}),
   });
   if (!diff) {
     throw new Error("PNG diff requires both baseline and current screenshot paths");
@@ -367,6 +405,7 @@ export async function runPngDiffCli(cliArgs = process.argv.slice(2)) {
       diffPixels: result.diff.diffPixels,
       totalPixels: result.diff.totalPixels,
       diffRatio: result.diff.diffRatio,
+      ...(result.diff.mask ? { mask: result.diff.mask } : {}),
       regions: result.diff.regions,
       heatmapPath: result.diff.heatmapPath,
       summary: result.semantic.summary,
@@ -394,7 +433,39 @@ export async function runPngDiffCli(cliArgs = process.argv.slice(2)) {
         `  note:     height differs by ${formatSizeDelta(output.sizeDelta.height)}px — content reflow likely (an element gained or lost vertical space)`,
       );
     }
-    console.log(`  diff:     ${(output.diffRatio * 100).toFixed(2)}% (${output.diffPixels} / ${output.totalPixels} px)`);
+    console.log(
+      `  diff:     ${(output.diffRatio * 100).toFixed(2)}% (${output.diffPixels} / ${output.totalPixels} px`
+      + `${output.mask ? " measured" : ""})`,
+    );
+    // Printed immediately under the ratio, not in a footer and not only in
+    // --json, following `formatIntegrityReport`'s coverage block: the dangerous
+    // failure mode of this flag is a mask over half the frame and a verdict of
+    // "0.10%". A clean result has to be auditable from the same three lines a
+    // reader already looks at.
+    if (output.mask) {
+      const m = output.mask;
+      const share = m.imagePixels > 0 ? (m.ignoredPixels / m.imagePixels) * 100 : 0;
+      console.log(
+        `  ignored:  ${m.regions.length} region(s), ${m.ignoredPixels} px`
+        + ` (${share.toFixed(1)}% of the ${m.imagePixels} px compared area) — never measured`,
+      );
+      for (const region of m.regions) {
+        const covered = region.pixels === 0
+          ? "0 px — outside the compared area, masks nothing"
+          : `${region.pixels} px, ${region.diffPixels} of them differed`;
+        console.log(`    (${region.x},${region.y}) ${region.width}x${region.height} — ${covered}`);
+      }
+      // Spell out the denominator. `totalPixels` also carries size-mismatch
+      // overflow, which no rect inside the compared area can mask, so show that
+      // term rather than print arithmetic that does not add up.
+      const overflow = output.totalPixels - (m.imagePixels - m.ignoredPixels);
+      console.log(
+        `    ${m.ignoredDiffPixels} diff px discarded; denominator`
+        + ` ${m.imagePixels} - ${m.ignoredPixels}`
+        + (overflow !== 0 ? ` + ${overflow} unmaskable size-mismatch px` : "")
+        + ` = ${output.totalPixels}`,
+      );
+    }
     console.log(`  regions:  ${output.regions.length}`);
     if (output.regions.length > 0) {
       for (const region of output.regions.slice(0, 15)) {

--- a/packages/vlmkit-mcp/src/gate-tool.test.ts
+++ b/packages/vlmkit-mcp/src/gate-tool.test.ts
@@ -186,11 +186,12 @@ describe("required-ness follows `required`, not `positional`", () => {
         notRequired.push(`${gate.command.join(" ")} :: ${input.name}`);
       }
     }
-    // `check integrity` is the intended exception. Anything else appearing here means a
-    // gate is relying on the removed shortcut and its MCP schema just went optional.
+    // `check integrity` and `check copy` are the intended exceptions — both take element
+    // rects via `--elements` instead of a page. Anything else appearing here means a gate is
+    // relying on the removed shortcut and its MCP schema just went optional.
     assert.deepEqual(
-      notRequired,
-      ["check integrity :: source"],
+      notRequired.sort(),
+      ["check copy :: source", "check integrity :: source"],
       "a positional-0 input without `required: true` is now OPTIONAL in the MCP schema — "
       + "add `required: true` unless it is genuinely optional",
     );
@@ -206,6 +207,24 @@ describe("required-ness follows `required`, not `positional`", () => {
     assert.deepEqual(
       gateToolArgv(integrityGate, { elements: "e.json", image: "f.png" }, { description: "" }),
       ["--elements", "e.json", "--image", "f.png"],
+    );
+  });
+
+  it("leaves check copy's source optional so element-rect mode is callable", async () => {
+    // Same trap, same fix, one gate later: `check copy --elements` (vlmkit#118) would be
+    // CLI-only if its source declared itself required, because the gate rejects a page
+    // alongside `--elements` as mutually exclusive.
+    const { copyGate } = await import("@mizchi/vlmkit-markup/gates/copy.gate.ts");
+    const tool = gateTool(copyGate, { description: "x" });
+    assert.equal(tool.inputSchema.source!.isOptional(), true, "source must be optional");
+    assert.equal(tool.inputSchema.elements!.isOptional(), true);
+    assert.deepEqual(
+      gateToolArgv(
+        copyGate,
+        { elements: "e.json", image: "f.png", manifest: "copy.txt" },
+        { description: "" },
+      ),
+      ["--elements", "e.json", "--image", "f.png", "--manifest", "copy.txt"],
     );
   });
 });

--- a/src/baseline-cli.ts
+++ b/src/baseline-cli.ts
@@ -30,6 +30,12 @@
  *     Diff current rendering against pinned baselines + a11y +
  *     media-variants gates. Equivalent to `vlmkit diff-pr`.
  *
+ *   `pin` / `verify` / `update` also accept `--from-dir <dir>` and
+ *   `--from-png <file>`: the PNGs are taken as-is and no browser is
+ *   launched, for projects whose frames exist as files but have no
+ *   openable URL. See `baseline-from-png.ts` for the file→route rule and
+ *   for which gates that path cannot cover.
+ *
  *   vlmkit baseline post --pr <ref> [--summary <path>] [--marker <id>]
  *     Post a previously-generated summary.md as a PR comment.
  *     Equivalent to `vlmkit diff-pr post`.
@@ -222,8 +228,15 @@ async function cmdUpdate(args: string[]): Promise<number> {
   console.log();
 
   // Re-pin via the diff-pr pin path (the same capture machinery `pin` uses).
+  // Forward the file-source flags too, so `update --from-dir` refreshes from
+  // PNGs instead of falling back to a browser the caller may not have.
+  const forwarded: string[] = [];
+  for (const flag of ["config", "from-dir", "from-png", "route", "viewport"]) {
+    const value = getArg(args, flag);
+    if (value !== undefined) forwarded.push(`--${flag}`, value);
+  }
   const { main: diffPrMain } = await import("./diff-pr.ts");
-  await diffPrMain(["pin", ...targets, ...(getArg(args, "config") ? ["--config", getArg(args, "config")!] : [])]);
+  await diffPrMain(["pin", ...targets, ...forwarded]);
   return 0;
 }
 
@@ -328,14 +341,31 @@ Subcommands:
   pin     [route...] [--config vlmkit.config.json]
                               Capture / refresh baseline PNGs for
                               declared routes. Alias for \`vlmkit diff-pr pin\`.
+          [--from-dir <dir> | --from-png <file> [--route <r> --viewport <v>]]
+                              Pin already-rendered PNGs — no URL opened,
+                              no browser launched. For engines whose
+                              frames exist as files (canvas / WebGPU /
+                              native renderers). Names must match the
+                              baseline layout: <route>/<viewport>.png,
+                              <route>-<viewport>.png, or <route>.png when
+                              a single viewport is declared.
   verify  [--config vlmkit.config.json] [--output <dir>]
+          [--from-dir <dir> | --from-png <file> [--route <r> --viewport <v>]]
                               Diff current rendering against pinned
                               baselines. Alias for \`vlmkit diff-pr\`.
+                              --from-dir/--from-png reads the current
+                              side from PNGs; per-route thresholds,
+                              markdown summary and region approvals all
+                              still apply, but a11y / media-variants /
+                              cross-browser cannot run without a page and
+                              are reported as not evaluated.
   post    --pr <ref>          Post the most recent summary.md to a PR.
                               Alias for \`vlmkit diff-pr post\`.
   update  [route...] [--config vlmkit.config.json]
+          [--from-dir <dir> | --from-png <file> [--route <r> --viewport <v>]]
                               Archive current baselines to _history/<ts>/
                               and re-pin (reversible golden refresh).
+                              File-source flags are forwarded to \`pin\`.
   list    [--config vlmkit.config.json]
                               Show all pinned baselines.
   rm      <route...>          Remove one or more routes' baselines.

--- a/src/baseline-from-png.test.ts
+++ b/src/baseline-from-png.test.ts
@@ -335,6 +335,36 @@ describe("baseline pin --from-dir / --from-png", () => {
   });
 });
 
+describe("custom viewport labels in file mode", () => {
+  it("honors a declared label the browser path cannot resize to (a game frame)", async () => {
+    // The browser path maps a viewport label to pixel dimensions and drops
+    // anything that is not mobile/desktop/wide. A supplied PNG carries its own
+    // dimensions, so file mode takes the label as declared — which is what
+    // lets a 640x360 canvas frame be called `frame`.
+    const proj = await makeProject({
+      viewports: ["frame"],
+      thresholds: { frame: 0.01 },
+      routes: [{ name: "hud", path: "/hud" }],
+    });
+    try {
+      await writePng(join(proj, "captures", "hud", "frame.png"), { width: 640, height: 360 });
+      const pin = runBaseline(["pin", "--from-dir", "captures"], proj);
+      assert.equal(pin.status, 0, pin.stdout + pin.stderr);
+      assert.ok(existsSync(join(proj, "baselines", "hud", "frame.png")));
+
+      await writePng(join(proj, "current", "hud", "frame.png"), { width: 640, height: 360, blockSize: 100 });
+      const r = runBaseline(["verify", "--from-dir", "current", "--output", "run"], proj);
+      assert.equal(r.status, 1, r.stdout + r.stderr);
+      // 100x100 changed out of 640x360 = 4.34%.
+      assert.match(r.stdout, /hud\s+FAIL\s+frame=4\.34%/);
+      const md = await readFile(join(proj, "run", "summary.md"), "utf-8");
+      assert.match(md, /\| `hud` \| frame \| 4\.34% \| 1\.00% \| ❌ \|/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("baseline update --from-dir", () => {
   it("archives the old baselines to _history/ and re-pins from files", async () => {
     // Regression guard: pin used to `rm -r` the whole route dir, which deleted

--- a/src/baseline-from-png.test.ts
+++ b/src/baseline-from-png.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Tests for `baseline pin|verify --from-png / --from-dir`.
+ *
+ * Real temp dirs and real PNGs throughout (pngjs), because the whole point of
+ * the feature is that the bytes on disk are the input — a mocked filesystem
+ * would test the mapping table and skip the part that broke for the reporter.
+ * The CLI is driven end to end via `baseline-cli.ts` so the alias chain
+ * (`baseline pin` → `diff-pr pin`) is covered too.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { PNG } from "pngjs";
+import { parseDiffPrConfig } from "./diff-pr-config.ts";
+import { resolvePngSources } from "./baseline-from-png.ts";
+
+const BASELINE_CLI = resolve(fileURLToPath(import.meta.url), "..", "baseline-cli.ts");
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1B\[[0-9;]*m/g;
+
+function runBaseline(args: string[], cwd: string): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", BASELINE_CLI, ...args],
+    { encoding: "utf-8", cwd, env: { ...process.env, NO_COLOR: "1" } },
+  );
+  return {
+    stdout: (r.stdout ?? "").replace(ANSI, ""),
+    stderr: (r.stderr ?? "").replace(ANSI, ""),
+    status: r.status ?? 1,
+  };
+}
+
+/**
+ * Solid-colour PNG with an optional black rectangle, so a diff ratio can be
+ * computed by hand: a 20x20 block in a 100x100 frame is exactly 4%.
+ */
+async function writePng(
+  file: string,
+  opts: { width?: number; height?: number; blockSize?: number } = {},
+): Promise<void> {
+  const width = opts.width ?? 100;
+  const height = opts.height ?? 100;
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (width * y + x) << 2;
+      const inBlock = opts.blockSize !== undefined && x < opts.blockSize && y < opts.blockSize;
+      const v = inBlock ? 0 : 255;
+      png.data[i] = v;
+      png.data[i + 1] = v;
+      png.data[i + 2] = v;
+      png.data[i + 3] = 255;
+    }
+  }
+  await mkdir(resolve(file, ".."), { recursive: true });
+  await writeFile(file, PNG.sync.write(png));
+}
+
+interface ProjectOptions {
+  viewports?: string[];
+  thresholds?: Record<string, number>;
+  routes?: unknown[];
+  a11y?: unknown;
+}
+
+/** Temp project with a vlmkit.config.json; returns its dir. */
+async function makeProject(opts: ProjectOptions = {}): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "vlmkit-frompng-"));
+  const config: Record<string, unknown> = {
+    baseUrl: "http://localhost:9/",
+    baselineDir: "baselines",
+    viewports: opts.viewports ?? ["desktop"],
+    thresholds: opts.thresholds ?? { desktop: 0.01, mobile: 0.01, wide: 0.01 },
+    routes: opts.routes ?? [{ name: "hud", path: "/hud" }, { name: "menu", path: "/menu" }],
+  };
+  if (opts.a11y) config.a11y = opts.a11y;
+  await writeFile(join(dir, "vlmkit.config.json"), JSON.stringify(config, null, 2));
+  return dir;
+}
+
+describe("resolvePngSources", () => {
+  const config = parseDiffPrConfig(JSON.stringify({
+    baseUrl: "http://localhost:9/",
+    viewports: ["desktop"],
+    routes: [{ name: "hud", path: "/hud" }, { name: "form-app", path: "/form" }],
+  }), "/proj/vlmkit.config.json");
+
+  it("maps the nested <route>/<viewport>.png layout — the pinned layout round-trips", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-map-"));
+    try {
+      await writePng(join(dir, "hud", "desktop.png"));
+      await writePng(join(dir, "form-app", "desktop.png"));
+      const sources = await resolvePngSources({
+        routes: config.routes,
+        viewports: ["desktop"],
+        fromDir: dir,
+        cwd: dir,
+        requireFullCoverage: true,
+      });
+      assert.deepEqual(
+        sources.map((s) => `${s.route.name}/${s.viewport}:${s.matchedAs}`).sort(),
+        ["form-app/desktop:nested", "hud/desktop:nested"],
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches the flat form against declared names, so a route name containing `-` is not mis-split", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-map-"));
+    try {
+      // "form-app-mobile".split("-") would yield route "form" — matching against
+      // the declared cross-product instead is what makes this safe.
+      await writePng(join(dir, "hud-mobile.png"));
+      await writePng(join(dir, "form-app-mobile.png"));
+      const sources = await resolvePngSources({
+        routes: config.routes,
+        viewports: ["mobile"],
+        fromDir: dir,
+        cwd: dir,
+        requireFullCoverage: true,
+      });
+      assert.deepEqual(
+        sources.map((s) => `${s.route.name}/${s.viewport}:${s.matchedAs}`).sort(),
+        ["form-app/mobile:flat", "hud/mobile:flat"],
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts a bare <route>.png only when a single viewport is declared", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-map-"));
+    try {
+      await writePng(join(dir, "hud.png"));
+      const single = await resolvePngSources({
+        routes: [config.routes[0]],
+        viewports: ["desktop"],
+        fromDir: dir,
+        cwd: dir,
+        requireFullCoverage: true,
+      });
+      assert.equal(single.length, 1);
+      assert.equal(single[0].matchedAs, "bare");
+
+      await assert.rejects(
+        () => resolvePngSources({
+          routes: [config.routes[0]],
+          viewports: ["desktop", "mobile"],
+          fromDir: dir,
+          cwd: dir,
+          requireFullCoverage: true,
+        }),
+        /1 file\(s\) in .* map to no declared route\/viewport pair:\n {2}hud\.png/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects two files claiming the same route/viewport pair", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-map-"));
+    try {
+      await writePng(join(dir, "hud-desktop.png"));
+      await writePng(join(dir, "hud", "desktop.png"));
+      await assert.rejects(
+        () => resolvePngSources({
+          routes: [config.routes[0]],
+          viewports: ["desktop"],
+          fromDir: dir,
+          cwd: dir,
+          requireFullCoverage: true,
+        }),
+        /two files both map to route `hud` viewport `desktop`/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores _history/ so --from-dir <baselineDir> does not re-pin archived PNGs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-map-"));
+    try {
+      await writePng(join(dir, "hud", "desktop.png"));
+      await writePng(join(dir, "hud", "_history", "2026-01-01", "desktop.png"));
+      const sources = await resolvePngSources({
+        routes: [config.routes[0]],
+        viewports: ["desktop"],
+        fromDir: dir,
+        cwd: dir,
+        requireFullCoverage: true,
+      });
+      assert.equal(sources.length, 1);
+      assert.match(sources[0].file, /hud[\\/]desktop\.png$/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("requires --route and --viewport together for an arbitrarily-named single file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-map-"));
+    try {
+      const file = join(dir, "frame_0001.png");
+      await writePng(file);
+      await assert.rejects(
+        () => resolvePngSources({
+          routes: config.routes, viewports: ["desktop"], fromPng: file, cwd: dir,
+          requireFullCoverage: false,
+        }),
+        /maps to no declared route\/viewport pair/,
+      );
+      await assert.rejects(
+        () => resolvePngSources({
+          routes: config.routes, viewports: ["desktop"], fromPng: file, cwd: dir,
+          routeOverride: "hud", requireFullCoverage: false,
+        }),
+        /--route and --viewport must be given together/,
+      );
+      const ok = await resolvePngSources({
+        routes: config.routes, viewports: ["desktop"], fromPng: file, cwd: dir,
+        routeOverride: "hud", viewportOverride: "desktop", requireFullCoverage: false,
+      });
+      assert.deepEqual(ok.map((s) => [s.route.name, s.viewport, s.matchedAs]), [["hud", "desktop", "explicit"]]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a file that is not actually a PNG", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vlmkit-map-"));
+    try {
+      await writeFile(join(dir, "hud.png"), "this is a JPEG really");
+      await assert.rejects(
+        () => resolvePngSources({
+          routes: [config.routes[0]], viewports: ["desktop"], fromDir: dir, cwd: dir,
+          requireFullCoverage: true,
+        }),
+        /is not a PNG \(bad signature\)/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("baseline pin --from-dir / --from-png", () => {
+  it("copies a dir of PNGs into <baselineDir>/<route>/<viewport>.png", async () => {
+    const proj = await makeProject();
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"), { blockSize: 20 });
+      const r = runBaseline(["pin", "--from-dir", "captures"], proj);
+      assert.equal(r.status, 0, r.stdout + r.stderr);
+      assert.match(r.stdout, /no browser/);
+      assert.ok(existsSync(join(proj, "baselines", "hud", "desktop.png")), "hud baseline written");
+      assert.ok(existsSync(join(proj, "baselines", "menu", "desktop.png")), "menu baseline written");
+      // Copied byte-for-byte — the pinned baseline IS the supplied frame.
+      assert.deepEqual(
+        await readFile(join(proj, "baselines", "menu", "desktop.png")),
+        await readFile(join(proj, "captures", "menu", "desktop.png")),
+      );
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("errors, naming both sides, when a file maps to no declared route", async () => {
+    const proj = await makeProject();
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      await writePng(join(proj, "captures", "inventory-desktop.png"));
+      const r = runBaseline(["pin", "--from-dir", "captures"], proj);
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /inventory-desktop\.png/);
+      assert.match(r.stderr, /declared routes:\s+hud, menu/);
+      assert.match(r.stderr, /declared viewports:\s+desktop/);
+      // Nothing pinned: the run aborted rather than pinning the two good files.
+      assert.equal(existsSync(join(proj, "baselines")), false);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("errors when a declared route/viewport pair has no file", async () => {
+    const proj = await makeProject({ viewports: ["desktop", "mobile"] });
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "hud", "mobile.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      const r = runBaseline(["pin", "--from-dir", "captures"], proj);
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /no PNG supplied for 1 declared route\/viewport pair/);
+      assert.match(r.stderr, /menu\/mobile/);
+      assert.match(r.stderr, /supplied: .*hud\/desktop/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("errors when --from-png points at a missing file", async () => {
+    const proj = await makeProject();
+    try {
+      const r = runBaseline(["pin", "--from-png", "captures/nope.png", "--route", "hud", "--viewport", "desktop"], proj);
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /--from-png file not found:.*nope\.png/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("--from-png pins one pair and leaves sibling viewports alone", async () => {
+    const proj = await makeProject({ viewports: ["desktop", "mobile"] });
+    try {
+      // Pre-existing mobile baseline stands in for an earlier pin.
+      await writePng(join(proj, "baselines", "hud", "mobile.png"));
+      await writePng(join(proj, "frames", "frame_0001.png"), { blockSize: 10 });
+      const r = runBaseline(
+        ["pin", "--from-png", "frames/frame_0001.png", "--route", "hud", "--viewport", "desktop"],
+        proj,
+      );
+      assert.equal(r.status, 0, r.stdout + r.stderr);
+      assert.ok(existsSync(join(proj, "baselines", "hud", "desktop.png")));
+      assert.ok(existsSync(join(proj, "baselines", "hud", "mobile.png")), "sibling viewport survived");
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("baseline update --from-dir", () => {
+  it("archives the old baselines to _history/ and re-pins from files", async () => {
+    // Regression guard: pin used to `rm -r` the whole route dir, which deleted
+    // the `_history/<ts>/` archive `update` had just written one step earlier —
+    // making the golden refresh irreversible. Applies to the browser path too.
+    const proj = await makeProject();
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      assert.equal(runBaseline(["pin", "--from-dir", "captures"], proj).status, 0);
+
+      await writePng(join(proj, "next", "hud", "desktop.png"), { blockSize: 20 });
+      await writePng(join(proj, "next", "menu", "desktop.png"), { blockSize: 20 });
+      const r = runBaseline(["update", "--from-dir", "next"], proj);
+      assert.equal(r.status, 0, r.stdout + r.stderr);
+      assert.match(r.stdout, /archived 1 PNG\(s\) for hud/);
+
+      // New baseline is the supplied frame…
+      assert.deepEqual(
+        await readFile(join(proj, "baselines", "hud", "desktop.png")),
+        await readFile(join(proj, "next", "hud", "desktop.png")),
+      );
+      // …and the previous one is still recoverable.
+      const historyRoot = join(proj, "baselines", "hud", "_history");
+      assert.ok(existsSync(historyRoot), "_history survived the re-pin");
+      const stamps = await readdir(historyRoot);
+      assert.equal(stamps.length, 1);
+      assert.deepEqual(
+        await readFile(join(historyRoot, stamps[0], "desktop.png")),
+        await readFile(join(proj, "captures", "hud", "desktop.png")),
+      );
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("baseline verify --from-dir", () => {
+  it("diffs supplied PNGs against the pinned baselines and fails over threshold", async () => {
+    // Per-route thresholds: hud tolerates 10%, menu tolerates 1%. Both get the
+    // same 4% change (a 20x20 block in a 100x100 frame), so the run must pass
+    // hud and fail menu — that is the threshold actually being applied, not
+    // just carried in the report.
+    const proj = await makeProject({
+      thresholds: { desktop: 0.01 },
+      routes: [
+        { name: "hud", path: "/hud", thresholds: { desktop: 0.1 } },
+        { name: "menu", path: "/menu" },
+      ],
+    });
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      assert.equal(runBaseline(["pin", "--from-dir", "captures"], proj).status, 0);
+
+      // "Current" render: same frames with a 20x20 regression each.
+      await writePng(join(proj, "current", "hud", "desktop.png"), { blockSize: 20 });
+      await writePng(join(proj, "current", "menu", "desktop.png"), { blockSize: 20 });
+      const r = runBaseline(["verify", "--from-dir", "current", "--output", "run"], proj);
+      assert.equal(r.status, 1, r.stdout + r.stderr);
+      assert.match(r.stdout, /hud\s+pass\s+desktop=4\.00%/);
+      assert.match(r.stdout, /menu\s+FAIL\s+desktop=4\.00%/);
+
+      const md = await readFile(join(proj, "run", "summary.md"), "utf-8");
+      assert.match(md, /Status: \*\*FAIL\*\* \(1 of 2 route\(s\)\)/);
+      assert.match(md, /Current side: pre-rendered PNGs from `current` \(no browser\)/);
+      assert.match(md, /\| `hud` \| desktop \| 4\.00% \| 10\.00% \| ✅ \|/);
+      assert.match(md, /\| `menu` \| desktop \| 4\.00% \| 1\.00% \| ❌ \|/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when the supplied PNGs are identical to the baselines", async () => {
+    const proj = await makeProject();
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      assert.equal(runBaseline(["pin", "--from-dir", "captures"], proj).status, 0);
+      const r = runBaseline(["verify", "--from-dir", "captures", "--output", "run"], proj);
+      assert.equal(r.status, 0, r.stdout + r.stderr);
+      assert.match(r.stdout, /PASS/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("reports declared browser-only gates as not evaluated instead of passing them", async () => {
+    const proj = await makeProject({ a11y: { maxContrastFailures: 0 } });
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      assert.equal(runBaseline(["pin", "--from-dir", "captures"], proj).status, 0);
+      const r = runBaseline(["verify", "--from-dir", "captures", "--output", "run"], proj);
+      assert.equal(r.status, 0, r.stdout + r.stderr);
+      assert.match(r.stdout, /warn: skipped \(need a browser\): a11y/);
+      const md = await readFile(join(proj, "run", "summary.md"), "utf-8");
+      assert.match(md, /\*\*Not evaluated\*\* \(declared in config, needs a live page\): a11y/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("--from-png narrows the run to the named pair instead of passing unchecked routes", async () => {
+    const proj = await makeProject();
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      assert.equal(runBaseline(["pin", "--from-dir", "captures"], proj).status, 0);
+      await writePng(join(proj, "frames", "frame_0001.png"), { blockSize: 20 });
+      const r = runBaseline(
+        ["verify", "--from-png", "frames/frame_0001.png", "--route", "menu", "--viewport", "desktop", "--output", "run"],
+        proj,
+      );
+      assert.equal(r.status, 1, r.stdout + r.stderr);
+      assert.match(r.stdout, /warn: 1 of 2 declared route\(s\) checked \(no PNG supplied for: hud\)/);
+      // `hud` must not appear as a green row — it was never compared.
+      assert.doesNotMatch(r.stdout, /hud\s+pass/);
+      const md = await readFile(join(proj, "run", "summary.md"), "utf-8");
+      assert.match(md, /\*\*Partial run\*\*: 1 of 2 declared route\(s\) checked/);
+      assert.match(md, /\| `menu` \| desktop \| 4\.00% \| 1\.00% \| ❌ \|/);
+      assert.doesNotMatch(md, /\| `hud` \|/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+
+  it("errors when --from-dir omits a declared route", async () => {
+    const proj = await makeProject();
+    try {
+      await writePng(join(proj, "captures", "hud", "desktop.png"));
+      await writePng(join(proj, "captures", "menu", "desktop.png"));
+      assert.equal(runBaseline(["pin", "--from-dir", "captures"], proj).status, 0);
+      await rm(join(proj, "captures", "menu"), { recursive: true });
+      const r = runBaseline(["verify", "--from-dir", "captures", "--output", "run"], proj);
+      assert.equal(r.status, 1);
+      assert.match(r.stderr, /no PNG supplied for 1 declared route\/viewport pair/);
+      assert.match(r.stderr, /menu\/desktop/);
+    } finally {
+      await rm(proj, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/baseline-from-png.ts
+++ b/src/baseline-from-png.ts
@@ -1,0 +1,381 @@
+/**
+ * File → route/viewport resolution for `vlmkit baseline pin|verify
+ * --from-png / --from-dir` (issue #118 item 3).
+ *
+ * WHY this exists: `diff-pr` establishes route identity by rendering
+ * `route.url` in Playwright. A canvas/WebGPU engine reported that path is
+ * unusable for them — on Linux/Dawn `copyTextureToBuffer` + `mapAsync` never
+ * settle, so `page.screenshot()` returns a transparent canvas — while their
+ * native renderer already writes correct frames to PNG. They are in the state
+ * "the PNGs exist but there is no URL to open". `vlmkit diff png` compares two
+ * such files, but that is a one-shot: it has no per-route thresholds, no
+ * markdown summary, and no approval manifest. These flags let a PNG take the
+ * place the browser render would have taken, so the rest of the gate applies
+ * unchanged.
+ *
+ * ## The mapping rule (derived, not invented)
+ *
+ * Route identity in this codebase is `route.name` — either the explicit
+ * `name` field or `routeNameFromUrl()` of the URL — and a pinned baseline
+ * lives at `<baselineDir>/<route.name>/<viewport>.png` (see
+ * `baselineDirForRoute` in diff-pr.ts). Viewport identity is the label
+ * (`mobile` / `desktop` / `wide`). So a supplied file is mapped by matching
+ * its path against the *declared* route × viewport cross-product, in one of
+ * three spellings:
+ *
+ *   1. `<route>/<viewport>.png`  — canonical; byte-identical to the pinned
+ *      layout, so `--from-dir <baselineDir>` round-trips.
+ *   2. `<route>-<viewport>.png`  — flat; the separator `snapshot.ts` already
+ *      uses (`${label}-${vp.label}-baseline.png`).
+ *   3. `<route>.png`             — only when the config declares exactly ONE
+ *      viewport, because otherwise the viewport is unknowable.
+ *
+ * Matching is against the declared set rather than by splitting on the
+ * separator, which is what makes form 2 safe: route names may themselves
+ * contain `-` (`form-app`), so `"form-app-mobile".split("-")` is ambiguous
+ * while `"form-app-mobile" === \`${route.name}-${vp}\`` is not. A stem that
+ * two declared pairs both claim is reported as ambiguous rather than guessed.
+ *
+ * Anything the declared set does not claim is an **error naming both sides** —
+ * never a silent partial run. Same for a declared pair with no file. A
+ * renderer that emits `frame_0001.png` must either rename to one of the three
+ * forms or use the single-file `--from-png … --route … --viewport …` escape
+ * hatch; there is deliberately no sidecar manifest (one more format to
+ * document and version for a case renaming already covers).
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { copyFile, mkdir, open, readdir, rm } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
+import type { DiffPrRoute } from "./diff-pr-config.ts";
+
+export interface PngSource {
+  route: DiffPrRoute;
+  viewport: string;
+  /** Absolute path of the file the caller supplied. */
+  file: string;
+  /** How the file was matched — surfaced in CLI output so the rule is visible. */
+  matchedAs: "nested" | "flat" | "bare" | "explicit";
+}
+
+export interface ResolvePngSourcesOptions {
+  /** Target routes (already narrowed by any positional route names). */
+  routes: DiffPrRoute[];
+  /** Declared viewport labels, in declaration order. */
+  viewports: string[];
+  /** `--from-dir` (mutually exclusive with fromPng). */
+  fromDir?: string;
+  /** `--from-png` (mutually exclusive with fromDir). */
+  fromPng?: string;
+  /** `--route` — explicit route name, only meaningful with `--from-png`. */
+  routeOverride?: string;
+  /** `--viewport` — explicit viewport label, only meaningful with `--from-png`. */
+  viewportOverride?: string;
+  /** Resolve relative paths against this directory. */
+  cwd: string;
+  /**
+   * Require every target route × viewport pair to be supplied. True for
+   * `--from-dir` (a dir claims to be the whole capture set, so a hole in it
+   * is a mistake); false for `--from-png` (one file is one pair by
+   * construction).
+   */
+  requireFullCoverage: boolean;
+}
+
+/** Directory names skipped while walking `--from-dir`. */
+const IGNORED_DIRS = new Set([
+  // `baseline update` archives superseded PNGs here. Pointing --from-dir at a
+  // baselineDir must not re-pin the history.
+  "_history",
+  "node_modules",
+]);
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/**
+ * Throw unless `file` actually starts with the PNG signature. Checked before
+ * anything is copied: a `.png` that is really a JPEG (or a half-written frame)
+ * would otherwise surface much later as a pixelmatch decode error, with the
+ * baseline already overwritten. Reads 8 bytes, not the frame.
+ */
+export async function assertPng(file: string): Promise<void> {
+  const handle = await open(file, "r");
+  try {
+    const head = Buffer.alloc(8);
+    const { bytesRead } = await handle.read(head, 0, 8, 0);
+    if (bytesRead < 8 || !head.equals(PNG_MAGIC)) {
+      throw new Error(
+        `${file} is not a PNG (bad signature). ` +
+        `--from-png / --from-dir compare pixels, so the file must be a real PNG.`,
+      );
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+interface PairKeyEntry {
+  route: DiffPrRoute;
+  viewport: string;
+  matchedAs: PngSource["matchedAs"];
+}
+
+/**
+ * Build the lookup from a path key (extension-stripped, `/`-joined) to the
+ * declared route/viewport pair it names. Keys claimed by more than one pair
+ * are dropped from the map and remembered as ambiguous, so a file hitting one
+ * gets an explicit error instead of an arbitrary winner.
+ */
+function buildKeyIndex(
+  routes: DiffPrRoute[],
+  viewports: string[],
+): { index: Map<string, PairKeyEntry>; ambiguous: Set<string> } {
+  const index = new Map<string, PairKeyEntry>();
+  const ambiguous = new Set<string>();
+  const add = (key: string, entry: PairKeyEntry) => {
+    const prior = index.get(key);
+    if (prior && (prior.route.name !== entry.route.name || prior.viewport !== entry.viewport)) {
+      ambiguous.add(key);
+      return;
+    }
+    if (!prior) index.set(key, entry);
+  };
+  for (const route of routes) {
+    for (const viewport of viewports) {
+      add(`${route.name}/${viewport}`, { route, viewport, matchedAs: "nested" });
+      add(`${route.name}-${viewport}`, { route, viewport, matchedAs: "flat" });
+    }
+    // Bare `<route>.png` is only decidable with a single declared viewport.
+    if (viewports.length === 1) {
+      add(route.name, { route, viewport: viewports[0], matchedAs: "bare" });
+    }
+  }
+  for (const key of ambiguous) index.delete(key);
+  return { index, ambiguous };
+}
+
+function stripPngExt(p: string): string {
+  return extname(p).toLowerCase() === ".png" ? p.slice(0, -4) : p;
+}
+
+/** Collect PNGs under `dir`, keyed by their path relative to `dir`. */
+async function collectDirPngs(dir: string): Promise<Array<{ key: string; file: string; depth: number }>> {
+  const out: Array<{ key: string; file: string; depth: number }> = [];
+  const walk = async (current: string, prefix: string, depth: number): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (IGNORED_DIRS.has(e.name)) continue;
+        await walk(join(current, e.name), prefix ? `${prefix}/${e.name}` : e.name, depth + 1);
+        continue;
+      }
+      if (!e.isFile()) continue;
+      if (extname(e.name).toLowerCase() !== ".png") continue;
+      const rel = prefix ? `${prefix}/${e.name}` : e.name;
+      out.push({ key: stripPngExt(rel), file: join(current, e.name), depth });
+    }
+  };
+  await walk(dir, "", 0);
+  out.sort((a, b) => a.key.localeCompare(b.key));
+  return out;
+}
+
+function declaredSidesMessage(routes: DiffPrRoute[], viewports: string[]): string {
+  const forms = viewports.length === 1
+    ? `<route>/<viewport>.png, <route>-<viewport>.png, or <route>.png`
+    : `<route>/<viewport>.png or <route>-<viewport>.png`;
+  return [
+    `  declared routes:    ${routes.map((r) => r.name).join(", ")}`,
+    `  declared viewports: ${viewports.join(", ")}`,
+    `  accepted filenames: ${forms}`,
+  ].join("\n");
+}
+
+/**
+ * Map supplied PNG files onto declared route/viewport pairs.
+ *
+ * Throws (with both sides named) on: a file no declared pair claims, two files
+ * claiming the same pair, an ambiguous stem, an unknown `--route`/`--viewport`
+ * override, a missing file, or — under `requireFullCoverage` — a declared pair
+ * with no file.
+ */
+export async function resolvePngSources(opts: ResolvePngSourcesOptions): Promise<PngSource[]> {
+  const { routes, viewports } = opts;
+  if (routes.length === 0) throw new Error("no routes to pin");
+  if (viewports.length === 0) throw new Error("config declares no viewports");
+  if (opts.fromDir && opts.fromPng) {
+    throw new Error("--from-dir and --from-png are mutually exclusive");
+  }
+  if (!opts.fromDir && !opts.fromPng) throw new Error("neither --from-dir nor --from-png given");
+
+  const { index, ambiguous } = buildKeyIndex(routes, viewports);
+  const sources: PngSource[] = [];
+  const claimed = new Map<string, PngSource>();
+
+  const claim = (entry: PairKeyEntry, file: string, matchedAs: PngSource["matchedAs"]) => {
+    const pair = `${entry.route.name}/${entry.viewport}`;
+    const prior = claimed.get(pair);
+    if (prior) {
+      throw new Error(
+        `two files both map to route \`${entry.route.name}\` viewport \`${entry.viewport}\`:\n` +
+        `  ${prior.file}\n  ${file}\n` +
+        `Remove or rename one — a pair must have exactly one source.`,
+      );
+    }
+    const src: PngSource = { route: entry.route, viewport: entry.viewport, file, matchedAs };
+    claimed.set(pair, src);
+    sources.push(src);
+  };
+
+  if (opts.fromPng) {
+    const file = isAbsolute(opts.fromPng) ? opts.fromPng : resolve(opts.cwd, opts.fromPng);
+    if (!existsSync(file)) {
+      throw new Error(`--from-png file not found: ${file}`);
+    }
+    if (!statSync(file).isFile()) {
+      throw new Error(`--from-png expects a file, got a directory: ${file} (use --from-dir)`);
+    }
+    await assertPng(file);
+
+    if (opts.routeOverride || opts.viewportOverride) {
+      // Explicit form. Both halves are required: a renderer's `frame_0001.png`
+      // carries neither, and guessing one of the two is worse than asking.
+      if (!opts.routeOverride || !opts.viewportOverride) {
+        throw new Error(
+          `--route and --viewport must be given together with --from-png ` +
+          `(got ${opts.routeOverride ? "--route only" : "--viewport only"}).`,
+        );
+      }
+      const route = routes.find((r) => r.name === opts.routeOverride);
+      if (!route) {
+        throw new Error(
+          `--route ${opts.routeOverride} is not a declared route.\n` +
+          declaredSidesMessage(routes, viewports),
+        );
+      }
+      if (!viewports.includes(opts.viewportOverride)) {
+        throw new Error(
+          `--viewport ${opts.viewportOverride} is not a declared viewport.\n` +
+          declaredSidesMessage(routes, viewports),
+        );
+      }
+      claim({ route, viewport: opts.viewportOverride, matchedAs: "explicit" }, file, "explicit");
+    } else {
+      // Infer from the path: try `<parent>/<stem>` (nested form) before the
+      // bare stem, so `captures/home/desktop.png` resolves the same way it
+      // would inside a --from-dir walk.
+      const stem = stripPngExt(basename(file));
+      const parent = basename(dirname(file));
+      const nestedKey = `${parent}/${stem}`;
+      const hit = index.get(nestedKey) ?? index.get(stem);
+      if (!hit) {
+        const amb = ambiguous.has(nestedKey) || ambiguous.has(stem);
+        throw new Error(
+          `${file} maps to no declared route/viewport pair` +
+          (amb ? ` (its name is claimed by more than one pair)` : "") + `.\n` +
+          declaredSidesMessage(routes, viewports) +
+          `\nOr name the pair explicitly: --from-png ${opts.fromPng} --route <route> --viewport <viewport>`,
+        );
+      }
+      claim(hit, file, hit.matchedAs);
+    }
+  } else {
+    const dir = isAbsolute(opts.fromDir!) ? opts.fromDir! : resolve(opts.cwd, opts.fromDir!);
+    if (!existsSync(dir)) throw new Error(`--from-dir not found: ${dir}`);
+    if (!statSync(dir).isDirectory()) {
+      throw new Error(`--from-dir expects a directory, got a file: ${dir} (use --from-png)`);
+    }
+    const found = await collectDirPngs(dir);
+    if (found.length === 0) {
+      throw new Error(
+        `--from-dir ${dir} contains no .png files.\n` + declaredSidesMessage(routes, viewports),
+      );
+    }
+    const unmapped: string[] = [];
+    for (const f of found) {
+      const hit = index.get(f.key);
+      if (!hit) {
+        unmapped.push(f.key + ".png" + (ambiguous.has(f.key) ? " (ambiguous — claimed by 2+ pairs)" : ""));
+        continue;
+      }
+      await assertPng(f.file);
+      claim(hit, f.file, hit.matchedAs);
+    }
+    if (unmapped.length > 0) {
+      throw new Error(
+        `${unmapped.length} file(s) in ${dir} map to no declared route/viewport pair:\n` +
+        unmapped.map((u) => `  ${u}`).join("\n") + "\n" +
+        declaredSidesMessage(routes, viewports),
+      );
+    }
+  }
+
+  if (opts.requireFullCoverage) {
+    const missing: string[] = [];
+    for (const route of routes) {
+      for (const viewport of viewports) {
+        if (!claimed.has(`${route.name}/${viewport}`)) missing.push(`${route.name}/${viewport}`);
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `no PNG supplied for ${missing.length} declared route/viewport pair(s):\n` +
+        missing.map((m) => `  ${m}  (expected ${m}.png or ${m.replace("/", "-")}.png)`).join("\n") + "\n" +
+        `supplied: ${sources.map((s) => `${s.route.name}/${s.viewport}`).join(", ") || "(none)"}\n` +
+        `Supply every pair, or narrow the run with positional route name(s).`,
+      );
+    }
+  }
+
+  return sources;
+}
+
+/**
+ * Drop a route's pinned PNGs while leaving everything else in the dir alone.
+ *
+ * `pin` clears a route's baselines before writing so a viewport dropped from
+ * the config does not leave a stale PNG behind. It used to do that with
+ * `rm -r <routeDir>`, which also deleted `_history/` — the archive
+ * `baseline update` writes one step earlier to make a golden refresh
+ * reversible. Verified against the built CLI: `baseline update` archived
+ * 1 PNG per route to `_history/<ts>/` and the subsequent re-pin left
+ * `baselines/` with only the two new PNGs. Deleting just the top-level `.png`
+ * files keeps the stale-viewport guarantee and the archive.
+ */
+export async function clearRouteBaselinePngs(routeDir: string): Promise<void> {
+  if (!existsSync(routeDir)) return;
+  for (const entry of await readdir(routeDir, { withFileTypes: true })) {
+    if (entry.isFile() && extname(entry.name).toLowerCase() === ".png") {
+      await rm(join(routeDir, entry.name));
+    }
+  }
+}
+
+/**
+ * Copy resolved sources into `<baselineRoot>/<route>/<viewport>.png`.
+ *
+ * `wipeRouteDirs` mirrors `diff-pr pin`. It is on for `--from-dir` (full
+ * coverage was just enforced, so nothing is lost) and off for `--from-png`,
+ * where wiping would delete the sibling viewports the single file says
+ * nothing about.
+ */
+export async function pinPngSources(
+  baselineRoot: string,
+  sources: PngSource[],
+  opts: { wipeRouteDirs: boolean },
+): Promise<string[]> {
+  const written: string[] = [];
+  if (opts.wipeRouteDirs) {
+    for (const name of new Set(sources.map((s) => s.route.name))) {
+      await clearRouteBaselinePngs(join(baselineRoot, name));
+    }
+  }
+  for (const s of sources) {
+    const dir = join(baselineRoot, s.route.name);
+    await mkdir(dir, { recursive: true });
+    const dest = join(dir, `${s.viewport}.png`);
+    await copyFile(s.file, dest);
+    written.push(dest);
+  }
+  return written;
+}

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -18,7 +18,18 @@ function runVrt(args: string[]): { stdout: string; stderr: string; status: numbe
   const r = spawnSync(
     process.execPath,
     ["--experimental-strip-types", VLMKIT_TS, ...args],
-    { encoding: "utf-8", env: { ...process.env, NO_COLOR: "1" }, timeout: 5_000 },
+    // 30s, not 5s. Every case here spawns a real `node` that loads the CLI, and a help
+    // path measures ~900ms on an idle machine — a 5x margin, which sounds ample and is not.
+    // `node --test` runs this file alongside ~540 other suites, so the spawn competes with
+    // dozens of processes: adding 62 tests to the suite was enough to start breaching it,
+    // with a DIFFERENT subtest timing out each run and all 29 passing in isolation.
+    //
+    // The failure mode is what makes the low number wrong rather than merely tight: a
+    // timeout here reports as an ordinary assertion failure on a help command, which reads
+    // like a broken CLI verb. That sends the next person hunting a defect that is not there.
+    // These cases assert command *wiring*, so they have no business being sensitive to how
+    // busy the machine is.
+    { encoding: "utf-8", env: { ...process.env, NO_COLOR: "1" }, timeout: 30_000 },
   );
   return {
     stdout: r.stdout ?? "",

--- a/src/cli/gate-registry.test.ts
+++ b/src/cli/gate-registry.test.ts
@@ -79,11 +79,12 @@ describe("composed built-in registry", () => {
     }
   });
 
-  it("declares 119 tunable rules in total", async () => {
+  it("declares 120 tunable rules in total", async () => {
     // A canary, not a target: a gate losing its rule table to a bad merge is
     // otherwise invisible until someone tries to tune it.
+    // 119 → 120 when `check copy` gained `copy-truncated` (element-rect mode, vlmkit#118).
     const total = (await registry()).list().reduce((n, { gate }) => n + gate.rules.length, 0);
-    assert.equal(total, 119);
+    assert.equal(total, 120);
   });
 
   it("gives every built-in gate a category", async () => {

--- a/src/diff-pr.ts
+++ b/src/diff-pr.ts
@@ -182,6 +182,28 @@ function positionalRouteNames(args: string[]): string[] {
 }
 
 /**
+ * Viewport labels for file mode.
+ *
+ * `viewportSpecsFor` resolves a declared label to pixel dimensions and so
+ * silently drops anything that is not mobile/desktop/wide — measured with the
+ * built CLI: `"viewports": ["frame"]` produced `declared viewports: mobile,
+ * desktop, wide`. That fallback is correct for the browser path, which has to
+ * know what to resize the page to, and wrong here: a supplied PNG carries its
+ * own dimensions, and `thresholds` already accepts arbitrary keys. So a canvas
+ * engine can declare `"viewports": ["frame"]` and pin `hud/frame.png`.
+ *
+ * Limit worth stating: baselines pinned under a label the browser path does
+ * not know are reachable only from file mode. For a project whose renders
+ * cannot be produced by Playwright at all, that is the only mode anyway.
+ */
+function fileModeViewportSpecs(config: DiffPrConfig): Array<{ label: string; width: number; height: number }> {
+  if (!config.viewports || config.viewports.length === 0) return viewportSpecsFor(config);
+  return config.viewports.map((label) =>
+    DEFAULT_VIEWPORTS.find((v) => v.label === label) ?? { label, width: 0, height: 0 }
+  );
+}
+
+/**
  * Gates that need a live page and therefore cannot run in file mode. Reported
  * rather than silently skipped: a config that declares `a11y` and gets a PASS
  * must not read as "a11y passed".
@@ -254,7 +276,7 @@ async function pinFromFiles(
   routesToPin: DiffPrRoute[],
   files: FileSourceFlags,
 ): Promise<number> {
-  const viewports = viewportSpecsFor(config).map((v) => v.label);
+  const viewports = fileModeViewportSpecs(config).map((v) => v.label);
   let sources: PngSource[];
   try {
     sources = await resolvePngSources({
@@ -386,7 +408,7 @@ async function cmdRun(args: string[]): Promise<number> {
   // File mode: the "current" side comes from PNGs on disk rather than a
   // render. Resolved up front so a bad mapping fails before any work.
   const files = fileSourceFlags(args);
-  const viewports = viewportSpecsFor(config);
+  const viewports = files.active ? fileModeViewportSpecs(config) : viewportSpecsFor(config);
   let fileSources: Map<string, string> | null = null;
   let skippedGates: string[] = [];
   if (files.active) {

--- a/src/diff-pr.ts
+++ b/src/diff-pr.ts
@@ -17,6 +17,11 @@
  *     Emit a markdown summary suitable for pasting into a PR comment.
  *     Exit non-zero on any uncovered breach.
  *
+ * Both accept `--from-png <file>` / `--from-dir <dir>` in place of the
+ * browser render, for projects whose frames exist as PNGs but have no
+ * openable URL (canvas/WebGPU engines — see baseline-from-png.ts for the
+ * file→route rule and what the no-browser path cannot do).
+ *
  * Stays narrow: uses Playwright directly + the existing
  * `compareScreenshots` helper, NOT the full migration-compare
  * pipeline. The richer wireframe-suggestions / palette-diff signals
@@ -26,7 +31,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { chromium, type Browser } from "playwright";
 import {
@@ -38,6 +43,7 @@ import {
   type DiffPrConfig,
   type DiffPrRoute,
 } from "./diff-pr-config.ts";
+import { clearRouteBaselinePngs, pinPngSources, resolvePngSources, type PngSource } from "./baseline-from-png.ts";
 import { compareScreenshots } from "@mizchi/vlmkit-core/heatmap.ts";
 import { runA11yOnPage } from "./a11y-on-page.ts";
 import { runMediaVariants, type VariantResult, type MediaVariant } from "@mizchi/vlmkit-markup/stress/media-variants.ts";
@@ -134,6 +140,60 @@ function baselineDirForRoute(config: DiffPrConfig, route: DiffPrRoute): string {
   return resolve(configBaseDir(config), config.baselineDir, route.name);
 }
 
+function baselineRootFor(config: DiffPrConfig): string {
+  return resolve(configBaseDir(config), config.baselineDir);
+}
+
+/**
+ * The `--from-png` / `--from-dir` flag set, shared by `pin` and the diff run.
+ * `active` is what both commands branch on to skip Playwright entirely — the
+ * reporting project's browser cannot produce a usable canvas frame at all, so
+ * launching one would only cost time and then fail.
+ */
+interface FileSourceFlags {
+  active: boolean;
+  fromDir?: string;
+  fromPng?: string;
+  routeOverride?: string;
+  viewportOverride?: string;
+}
+
+function fileSourceFlags(args: string[]): FileSourceFlags {
+  const fromDir = getArg(args, "from-dir");
+  const fromPng = getArg(args, "from-png");
+  return {
+    active: Boolean(fromDir || fromPng),
+    fromDir,
+    fromPng,
+    routeOverride: getArg(args, "route"),
+    viewportOverride: getArg(args, "viewport"),
+  };
+}
+
+/** Positional route names, with `--flag value` pairs stripped out. */
+function positionalRouteNames(args: string[]): string[] {
+  const flaggedValues = new Set<string>();
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith("--") && i + 1 < args.length && !args[i + 1].startsWith("--")) {
+      flaggedValues.add(args[i + 1]);
+    }
+  }
+  return args.filter((a) => !a.startsWith("--")).filter((a) => !flaggedValues.has(a));
+}
+
+/**
+ * Gates that need a live page and therefore cannot run in file mode. Reported
+ * rather than silently skipped: a config that declares `a11y` and gets a PASS
+ * must not read as "a11y passed".
+ */
+function skippedGatesForFileMode(config: DiffPrConfig): string[] {
+  const skipped: string[] = [];
+  if (config.a11y || config.routes.some((r) => r.a11y)) skipped.push("a11y");
+  if (config.mediaVariants) skipped.push("media-variants");
+  if (config.crossBrowser) skipped.push("cross-browser");
+  return skipped;
+}
+
 function viewportSpecsFor(config: DiffPrConfig): Array<{ label: string; width: number; height: number }> {
   if (!config.viewports || config.viewports.length === 0) return DEFAULT_VIEWPORTS;
   const out: Array<{ label: string; width: number; height: number }> = [];
@@ -183,6 +243,52 @@ async function renderViewport(
   }
 }
 
+/**
+ * `pin --from-png/--from-dir`: copy already-rendered PNGs into the baseline
+ * layout instead of driving a browser. No Playwright is launched — that is the
+ * point of the flag, not an optimization.
+ */
+async function pinFromFiles(
+  config: DiffPrConfig,
+  configPath: string,
+  routesToPin: DiffPrRoute[],
+  files: FileSourceFlags,
+): Promise<number> {
+  const viewports = viewportSpecsFor(config).map((v) => v.label);
+  let sources: PngSource[];
+  try {
+    sources = await resolvePngSources({
+      routes: routesToPin,
+      viewports,
+      fromDir: files.fromDir,
+      fromPng: files.fromPng,
+      routeOverride: files.routeOverride,
+      viewportOverride: files.viewportOverride,
+      cwd: process.cwd(),
+      // A dir claims to be the whole capture set; a single file claims one pair.
+      requireFullCoverage: Boolean(files.fromDir),
+    });
+  } catch (err) {
+    console.error(`${RED}error:${RESET} ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  const origin = files.fromDir ?? files.fromPng!;
+  console.log(`${BOLD}${CYAN}vlmkit diff-pr pin${RESET}  ${DIM}${configPath}${RESET}`);
+  console.log(`${DIM}  from ${origin} (no browser) → ${config.baselineDir}/${RESET}`);
+  console.log();
+  const written = await pinPngSources(baselineRootFor(config), sources, {
+    wipeRouteDirs: Boolean(files.fromDir),
+  });
+  for (let i = 0; i < sources.length; i++) {
+    const s = sources[i];
+    console.log(`  ${s.route.name.padEnd(20)} ${s.viewport.padEnd(10)} ${GREEN}ok${RESET} ${DIM}${s.file} → ${written[i]} (${s.matchedAs})${RESET}`);
+  }
+  console.log();
+  console.log(`${DIM}Pinned ${written.length} PNG(s). Run \`vlmkit baseline verify --from-dir <dir>\` to gate against them.${RESET}`);
+  return 0;
+}
+
 async function cmdPin(args: string[]): Promise<void> {
   const cwd = process.cwd();
   const configPath = findConfigPath(cwd, getArg(args, "config"));
@@ -195,15 +301,7 @@ async function cmdPin(args: string[]): Promise<void> {
   // Filter to specific routes if any positional arguments were given.
   // Unknown route names are an error so a typo doesn't silently
   // refresh nothing.
-  const requested = args.filter((a) => !a.startsWith("--"));
-  // Strip --flag value pairs from `requested`.
-  const flaggedValues = new Set<string>();
-  for (let i = 0; i < args.length; i++) {
-    if (args[i].startsWith("--") && i + 1 < args.length && !args[i + 1].startsWith("--")) {
-      flaggedValues.add(args[i + 1]);
-    }
-  }
-  const requestedRouteNames = requested.filter((r) => !flaggedValues.has(r));
+  const requestedRouteNames = positionalRouteNames(args);
   let routesToPin = config.routes;
   if (requestedRouteNames.length > 0) {
     const unknown = requestedRouteNames.filter((n) => !config.routes.some((r) => r.name === n));
@@ -213,6 +311,13 @@ async function cmdPin(args: string[]): Promise<void> {
       process.exit(1);
     }
     routesToPin = config.routes.filter((r) => requestedRouteNames.includes(r.name));
+  }
+
+  const files = fileSourceFlags(args);
+  if (files.active) {
+    const code = await pinFromFiles(config, configPath, routesToPin, files);
+    if (code !== 0) process.exit(code);
+    return;
   }
 
   console.log(`${BOLD}${CYAN}vlmkit diff-pr pin${RESET}  ${DIM}${configPath}${RESET}`);
@@ -228,9 +333,10 @@ async function cmdPin(args: string[]): Promise<void> {
     for (const route of routesToPin) {
       process.stdout.write(`  ${route.name.padEnd(20)} ${DIM}${route.url}${RESET} ...`);
       const dir = baselineDirForRoute(config, route);
-      // Clean only this route's dir so other routes' baselines stay
-      // untouched (the partial-pin use case).
-      if (existsSync(dir)) await rm(dir, { recursive: true });
+      // Clean only this route's PNGs, so other routes' baselines stay
+      // untouched (the partial-pin use case) and `_history/` survives (the
+      // archive `baseline update` writes just before calling us).
+      await clearRouteBaselinePngs(dir);
       await mkdir(dir, { recursive: true });
       let success = 0;
       for (const vp of viewports) {
@@ -277,17 +383,69 @@ async function cmdRun(args: string[]): Promise<number> {
     }
   }
 
+  // File mode: the "current" side comes from PNGs on disk rather than a
+  // render. Resolved up front so a bad mapping fails before any work.
+  const files = fileSourceFlags(args);
+  const viewports = viewportSpecsFor(config);
+  let fileSources: Map<string, string> | null = null;
+  let skippedGates: string[] = [];
+  if (files.active) {
+    let sources: PngSource[];
+    try {
+      sources = await resolvePngSources({
+        routes: config.routes,
+        viewports: viewports.map((v) => v.label),
+        fromDir: files.fromDir,
+        fromPng: files.fromPng,
+        routeOverride: files.routeOverride,
+        viewportOverride: files.viewportOverride,
+        cwd,
+        requireFullCoverage: Boolean(files.fromDir),
+      });
+    } catch (err) {
+      console.error(`${RED}error:${RESET} ${err instanceof Error ? err.message : String(err)}`);
+      return 1;
+    }
+    fileSources = new Map(sources.map((s) => [`${s.route.name}/${s.viewport}`, s.file]));
+    skippedGates = skippedGatesForFileMode(config);
+  }
+
+  // `--from-png` names exactly one route/viewport, so the other declared
+  // routes are out of scope. Drop them from the run rather than letting them
+  // report an empty `pass` — a route with no viewport rows reads as green in
+  // both the terminal line and the markdown table, which is the silent
+  // partial run this feature is supposed to make impossible.
+  const routesToRun = fileSources
+    ? config.routes.filter((r) => viewports.some((vp) => fileSources!.has(`${r.name}/${vp.label}`)))
+    : config.routes;
+  const outOfScope = config.routes.filter((r) => !routesToRun.includes(r)).map((r) => r.name);
+  const scopeNote = outOfScope.length > 0
+    ? `${routesToRun.length} of ${config.routes.length} declared route(s) checked ` +
+      `(no PNG supplied for: ${outOfScope.join(", ")})`
+    : undefined;
+
   console.log(`${BOLD}${CYAN}vlmkit diff-pr${RESET}  ${DIM}${configPath}${RESET}`);
   console.log(`${DIM}  ${config.routes.length} route(s); thresholds ${JSON.stringify(config.thresholds)}${RESET}`);
   if (manifest) console.log(`${DIM}  approval manifest: ${manifest.rules.length} rule(s)${RESET}`);
+  if (fileSources) {
+    console.log(`${DIM}  current side from ${files.fromDir ?? files.fromPng} (no browser): ${fileSources.size} PNG(s)${RESET}`);
+    if (skippedGates.length > 0) {
+      // Loud, because these gates are declared in config and a PASS here does
+      // not cover them. They need a live page; a PNG cannot supply a DOM,
+      // media-emulation, or a second engine.
+      console.log(`${YELLOW}  warn: skipped (need a browser): ${skippedGates.join(", ")}${RESET}`);
+    }
+    if (scopeNote) console.log(`${YELLOW}  warn: ${scopeNote}${RESET}`);
+  }
   console.log();
 
-  const viewports = viewportSpecsFor(config);
   const results: PerRouteResult[] = [];
-  const browser = await chromium.launch();
+  // Do not launch chromium at all in file mode — the reporting project's
+  // headless canvas capture is exactly what does not work there.
+  const browser = fileSources ? null : await chromium.launch();
 
   try {
-    for (const route of config.routes) {
+    for (const route of routesToRun) {
       const baselineDir = baselineDirForRoute(config, route);
       if (!existsSync(baselineDir)) {
         console.log(`  ${route.name.padEnd(20)} ${RED}no baseline${RESET} ${DIM}(${baselineDir} — run \`vlmkit diff-pr pin\` first)${RESET}`);
@@ -304,18 +462,33 @@ async function cmdRun(args: string[]): Promise<number> {
       const routeOut = resolve(outputDir, route.name);
       await mkdir(routeOut, { recursive: true });
 
-      const a11yPolicy = resolveA11yPolicy(config, route);
+      // a11y needs a page; in file mode the policy is reported as skipped
+      // above and not evaluated here.
+      const a11yPolicy = fileSources ? undefined : resolveA11yPolicy(config, route);
       const perVp: PerViewportResult[] = [];
       for (const vp of viewports) {
         const baselinePath = join(baselineDir, `${vp.label}.png`);
         if (!existsSync(baselinePath)) continue;
+        const suppliedFile = fileSources?.get(`${route.name}/${vp.label}`);
+        // In file mode a viewport with no supplied PNG is out of scope
+        // (--from-png names exactly one pair); --from-dir already enforced
+        // full coverage, so this only skips what the caller narrowed away.
+        if (fileSources && !suppliedFile) continue;
         const variantPath = join(routeOut, `${vp.label}.png`);
         let renderRes: RenderResult;
         try {
-          renderRes = await renderViewport(
-            browser, route.url, vp.width, vp.height,
-            variantPath, route.waitFor, a11yPolicy,
-          );
+          if (suppliedFile) {
+            // Copy rather than diff in place, so the run dir stays
+            // self-contained (heatmap lands beside the variant) and the
+            // caller's capture dir is never written to.
+            await copyFile(suppliedFile, variantPath);
+            renderRes = { contrastFailures: [], touchFailures: [], focusOrderFailures: [], semanticFailures: [] };
+          } else {
+            renderRes = await renderViewport(
+              browser!, route.url, vp.width, vp.height,
+              variantPath, route.waitFor, a11yPolicy,
+            );
+          }
         } catch (err) {
           perVp.push({
             viewport: vp.label,
@@ -325,7 +498,8 @@ async function cmdRun(args: string[]): Promise<number> {
             threshold: resolveThreshold(config, route, vp.label),
             pass: false,
           });
-          console.log(`  ${route.name.padEnd(20)} ${vp.label} ${RED}render error: ${String(err)}${RESET}`);
+          const what = suppliedFile ? "copy" : "render";
+          console.log(`  ${route.name.padEnd(20)} ${vp.label} ${RED}${what} error: ${String(err)}${RESET}`);
           continue;
         }
         const snap: VrtSnapshot = {
@@ -408,7 +582,7 @@ async function cmdRun(args: string[]): Promise<number> {
       // viewport when `mediaVariants` is declared. Each variant
       // counts toward the route's pass/fail.
       let mediaVariantsResult: PerRouteResult["mediaVariants"];
-      if (config.mediaVariants) {
+      if (config.mediaVariants && !fileSources) {
         const mvDir = resolve(routeOut, "media-variants");
         const variants = config.mediaVariants.variants as MediaVariant[] | undefined;
         const maxSuspects = config.mediaVariants.maxSuspects ?? 0;
@@ -446,7 +620,7 @@ async function cmdRun(args: string[]): Promise<number> {
       // /webkit on minimal CI runners) auto-skip; allowSkipped=true
       // by default so missing engines don't fail the build.
       let crossBrowserResult: PerRouteResult["crossBrowser"];
-      if (config.crossBrowser) {
+      if (config.crossBrowser && !fileSources) {
         const xbDir = resolve(routeOut, "cross-browser");
         const threshold = config.crossBrowser.threshold ?? 0.03;
         const maxOver = config.crossBrowser.maxOver ?? 0;
@@ -507,10 +681,14 @@ async function cmdRun(args: string[]): Promise<number> {
       });
     }
   } finally {
-    await browser.close();
+    await browser?.close();
   }
 
-  const summary = buildMarkdownSummary(config, results);
+  const summary = buildMarkdownSummary(config, results, {
+    source: fileSources ? (files.fromDir ?? files.fromPng) : undefined,
+    skippedGates,
+    scopeNote,
+  });
   const summaryPath = resolve(outputDir, "summary.md");
   await writeFile(summaryPath, summary);
 
@@ -525,7 +703,20 @@ async function cmdRun(args: string[]): Promise<number> {
   return 0;
 }
 
-export function buildMarkdownSummary(config: DiffPrConfig, results: PerRouteResult[]): string {
+export interface MarkdownSummaryOptions {
+  /** `--from-dir`/`--from-png` origin, when the current side came from files. */
+  source?: string;
+  /** Declared gates that were not evaluated because there was no browser. */
+  skippedGates?: string[];
+  /** Set when the run covered fewer routes than the config declares. */
+  scopeNote?: string;
+}
+
+export function buildMarkdownSummary(
+  config: DiffPrConfig,
+  results: PerRouteResult[],
+  options: MarkdownSummaryOptions = {},
+): string {
   const lines: string[] = [];
   lines.push("# vlmkit diff-pr summary");
   lines.push("");
@@ -534,6 +725,13 @@ export function buildMarkdownSummary(config: DiffPrConfig, results: PerRouteResu
   const overall = failed === 0 ? "**PASS**" : `**FAIL** (${failed} of ${totalRoutes} route(s))`;
   lines.push(`Status: ${overall}`);
   if (config.configPath) lines.push(`Config: \`${config.configPath}\``);
+  if (options.source) lines.push(`Current side: pre-rendered PNGs from \`${options.source}\` (no browser)`);
+  if (options.scopeNote) lines.push(`**Partial run**: ${options.scopeNote}`);
+  if (options.skippedGates && options.skippedGates.length > 0) {
+    // The PASS above covers pixels only. Saying so in the artifact matters
+    // more than in the terminal — the markdown is what gets pasted into a PR.
+    lines.push(`**Not evaluated** (declared in config, needs a live page): ${options.skippedGates.join(", ")}`);
+  }
   lines.push("");
   const anyA11y = results.some((r) => r.viewports.some((v) => v.a11y));
   if (anyA11y) {
@@ -748,16 +946,31 @@ Subcommands:
                               No positional args → pin every route.
                               Positional names → pin only those, leave
                               the rest untouched (partial refresh).
+         [--from-dir <dir> | --from-png <file> [--route <r> --viewport <v>]]
+                              Take already-rendered PNGs instead of
+                              opening a URL (no browser launched). Files
+                              map to routes by name:
+                                <route>/<viewport>.png   (canonical)
+                                <route>-<viewport>.png   (flat)
+                                <route>.png              (1 viewport only)
+                              --from-dir must cover every declared
+                              route × viewport; unmapped or missing
+                              files are an error, never a partial pin.
   post   --pr <ref> [--summary <path>] [--marker <id>]
                               Post the most recent summary.md to a PR
                               via gh CLI. Falls back to printing the
                               markdown with copy-paste instructions
                               when gh is not on PATH.
   (none) [--config vlmkit.config.json] [--output <dir>]
+         [--from-dir <dir> | --from-png <file> [--route <r> --viewport <v>]]
                               Diff every route's current rendering
                               against its pinned baseline; apply
                               per-route thresholds; emit markdown.
                               Exit non-zero on any breach.
+                              With --from-dir/--from-png the current side
+                              is read from PNGs instead of rendered;
+                              a11y / media-variants / cross-browser are
+                              then skipped and reported as not evaluated.
 
 Config (vlmkit.config.json):
   {


### PR DESCRIPTION
Closes #118. Follows #121 (image-only `check integrity`, small-frame region attribution).

Four independent items, built in parallel and each verified independently before integration.
Two of them changed what the issue asked for, on measured grounds.

## 1. `check copy` without a DOM

```bash
vlmkit check copy --elements elements.json --manifest copy.txt   # + optional --image frame.png
```

Same input shape as image-only `check integrity`, reusing that parser and `analyzeCopy`
unchanged. Element order is treated as reading order (top, then left) so a manifest line can
span two adjacent drawn strings the way it spans two text nodes in the DOM.

Three of five copy rules run. `redirected` and `copy-image-mismatch` need a navigation result
and a reference screenshot; `copy-invisible` covers 2 of its 7 reason classes. All of it is
named in the report's coverage block rather than silently omitted.

**One new rule, `copy-truncated`** (119 → 120), because the reporter's third pain had no home:
the manifest matches the string the *renderer* reports, so `Score: 1234567890` reads as
satisfied while the user sees `Score: 12345…`. It requires `textMeasured` **and** a `clip`
rect — as in `check integrity`'s image mode, text wider than its box with no clip *overdraws*
on a canvas rather than truncating, so a clip is required rather than assumed.

`--target` / `--vlm` / `--out` / `--storage-state` are **rejected** in this mode, not ignored.

## 2. `diff png --ignore-region` — never measured, not forgiven

The reporter's distinction, which drove the design: `baseline approve --region` is an
*approval*, so a permanently-noisy area (particles, timers) pollutes the approval history
every run and shows up in the `gates suppressions` stocktake. `--ignore-region` writes no
state, so it is absent from that stocktake by construction.

**The diffRatio denominator shrinks with the mask**, and the justification is a measurement:
masking a 38400px particle band takes a real HUD recolor from 1.84% to **2.08%**; under a
full-frame denominator the same regression reads **1.74%** — adding a mask would have made an
unrelated regression look *better than before the mask existed*. That is precisely the
silent-shrink failure this flag risks.

Ignored pixels leave both the diff count **and** region detection: masking only the count
leaves a region with `diffPixelCount: 0` that `--elements-json` would then confidently
attribute to an element. `0/0` returns `0`, not `NaN` — `NaN` serialises to `null` and
compares false against every threshold, so a gate would silently pass.

Every masked run prints its own accounting:

```
  diff:     0.00% (0 / 226400 px measured)
  ignored:  1 region(s), 4000 px (1.7% of the 230400 px compared area) — never measured
    (16,16) 200x20 — 4000 px, 1800 of them differed
    1800 diff px discarded; denominator 230400 - 4000 = 226400
```

A mask that swallowed the entire finding still says how many diff pixels it swallowed, and the
denominator arithmetic is spelled out so `compared − ignored = measured` is checkable.

## 3. `baseline pin|verify|update --from-dir` / `--from-png`

For "the PNGs exist but there is no URL to open" — a native renderer, or a headless canvas
capture that never completes. `diff png` already compares two files, but that is a one-shot
with no per-route thresholds, no summary and no region approvals.

**The file→route mapping is derived, not invented.** Identity on disk was already
`(route.name, viewport)`, so a file matches only if its path equals `<route>/<viewport>.png`,
`<route>-<viewport>.png`, or `<route>.png` (that last only when exactly one viewport is
declared, since otherwise the viewport is unknowable). Matching is against the declared
cross-product rather than by splitting on `-`, which is what makes the flat form safe:
`"form-app-mobile".split("-")` gives route `form`; comparing against `` `${route.name}-${vp}` ``
does not. Ambiguity is reported, never guessed; any disagreement is an error naming both sides
and nothing is pinned.

`verify --from-dir` is **partial and says so**: pixel diff, per-route thresholds, summary,
worst offenders and region-bbox approvals all work; a11y, media-variants and cross-browser
print `**Not evaluated** (declared in config, needs a live page)` rather than an empty green
row.

### A pre-existing bug this uncovered

`baseline update` is documented as a reversible golden refresh: it archives to
`<routeDir>/_history/<ts>/`, then re-pins. But `pin` cleared the route with
`rm(routeDir, { recursive: true })`, and `_history` lives **inside** that dir — so the archive
was deleted one step after being written. Reproduced directly against `main`'s code: after the
`rm -r`, `find baselines/hud` returns nothing. "Reversible" was false for the feature's entire
life, on the browser path too, and undetectable until someone tried to roll back.

## 4. `scan component` on small frames — the issue's diagnosis was wrong

Reported as "the default `--min-area` makes elements hard to detect on a 320x240 HUD".
Measured on a 16-element HUD:

| setting | detected |
|---|--:|
| defaults (`minArea 200 / topN 8`) | 8 |
| `--min-area 24` alone | **8 — no change at all** |
| `--top-n 24` alone | 12 |
| both / `--preset game-ui` | 16 |

`topN: 8` was the binding limit, **`scan component` exposed no `--top-n` flag**, and the cap
binds identically at 1280x720. So `--top-n` is the first thing to try regardless of
resolution; `--min-area` only matters once the cap is lifted, and only below ~640x360.

**A size-adaptive default was built and rejected on its own evidence**: run against all 179
PNGs in the repo it changed 1, a real 480x240 card render, where it adds 4 glyph blobs of the
word "Dashboard" at areas 114/121/143/166px — **indistinguishable by area** from the 100–144px
icons the HUD case needs found. Frame size alone cannot separate "12x12 HUD icon = signal"
from "12x17 glyph = noise", so the caller has to say which they have. Defaults are unchanged;
`--preset game-ui` is opt-in, and a small frame that would gain ≥4 components prints a hint.

Also fixed: `--min-area abc` reached the extractor as `NaN` and silently filtered everything
out.

## Verification

Every agent report was reproduced independently on my own fixtures before integrating —
`--min-area 24` changing nothing, the masked-diff arithmetic, per-route thresholds actually
differing (`hud` passes at 10% and `menu` fails at 1% on the same 4.00% diff), the `_history`
deletion, and the two features composing (with a mask, zero regions survive so nothing is
attributed; without it, #117's attribution still names `.hp-bar` at 0.8333).

The doc's rule count was checked by **summing its own per-gate table against the live
registry** rather than by eye: both 120.

**2343 tests pass, 0 fail, two consecutive full runs.**

### One correction worth stating

I first called a `cli.test.ts` timeout a pre-existing flake. That was wrong, and checking
settled it: `origin/main` runs 2281/2281 green. This branch runs 2343 tests, and the extra
parallel load pushed a 5s subprocess budget — a 5x margin over a ~900ms help path — past the
edge, with a different subtest failing each run. The CLI did not get slower (870ms here vs
900ms on main, three runs each). Raised to 30s rather than explained away, because a timeout
there reports as an assertion failure on `check scroll --help`, which reads like a broken CLI
verb and sends the next person hunting a defect that does not exist.

## Not done

`#112` (data-driven map SPA feedback) is untouched. Within #118: no sidecar manifest for
arbitrary baseline filenames, no a11y/media emulation from a PNG, no masking of shift
detection (row-average luminance would be perturbed on unmasked rows too), and
`--ignore-region` is exposed only on `diff png` — `compareScreenshots` and
`generateDiffReport` accept it, so `snapshot` and `diff html` can adopt it in one line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a2DaLhFa2b1Switx8hEg3

---
_Generated by [Claude Code](https://claude.ai/code/session_011a2DaLhFa2b1Switx8hEg3)_