### PR TITLE
Pages: refresh the demo section's numbers, and say what playing it produced

### DIFF
--- a/examples/vlmkit-intro-page/content.js
+++ b/examples/vlmkit-intro-page/content.js
@@ -79,7 +79,9 @@ export const messages = Object.freeze({
     "demo.metricWin": "CI で勝ちまで指した seed 2つ",
     "demo.metricPlies": "手。毎手ごとに DOM を監査",
     "demo.metricTests": "テスト。ルールはブラウザなし、表示は Chromium",
-    "demo.metricFamilies": "0.11 の probe が打つ操作系統",
+    "demo.metricFamilies": "probe が打つ操作系統",
+    "demo.produced":
+      "このページを手で遊んで、どのゲートも報告しなかった不具合が3件見つかりました。いずれも今はルールです:",
     "demo.gatesLabel": "どれかが赤ければデプロイは止まる",
     "demo.play": "デモを遊ぶ",
     "demo.changelog": "0.11 の変更点を読む",
@@ -238,7 +240,9 @@ export const messages = Object.freeze({
     "demo.metricWin": "two seeds played to a win in CI",
     "demo.metricPlies": "plies, with the DOM audited after each one",
     "demo.metricTests": "tests: the rules headless, the view in Chromium",
-    "demo.metricFamilies": "interaction families the 0.11 probes drive",
+    "demo.metricFamilies": "interaction families the probes drive",
+    "demo.produced":
+      "Playing this page by hand found three defects no gate reported. Each is a rule now:",
     "demo.gatesLabel": "Red on any of these blocks the deploy",
     "demo.play": "Play the demo",
     "demo.changelog": "Read what 0.11 changed",

--- a/examples/vlmkit-intro-page/copy.txt
+++ b/examples/vlmkit-intro-page/copy.txt
@@ -29,7 +29,8 @@ while you are dragging.
 52/52 two seeds played to a win in CI
 144 plies, with the DOM audited after each one
 57 tests: the rules headless, the view in Chromium
-6 interaction families the 0.11 probes drive
+7 interaction families the probes drive
+Playing this page by hand found three defects no gate reported. Each is a rule now:
 vlmkit check integrity
 vlmkit check a11y focus
 vlmkit check a11y touch --level AAA

--- a/examples/vlmkit-intro-page/index.html
+++ b/examples/vlmkit-intro-page/index.html
@@ -243,7 +243,7 @@
               <li><strong>52/52</strong><span data-i18n="demo.metricWin">two seeds played to a win in CI</span></li>
               <li><strong>144</strong><span data-i18n="demo.metricPlies">plies, with the DOM audited after each one</span></li>
               <li><strong>57</strong><span data-i18n="demo.metricTests">tests: the rules headless, the view in Chromium</span></li>
-              <li><strong>6</strong><span data-i18n="demo.metricFamilies">interaction families the 0.11 probes drive</span></li>
+              <li><strong>7</strong><span data-i18n="demo.metricFamilies">interaction families the probes drive</span></li>
             </ul>
             <div class="demo-gates">
               <p class="demo-gate-label" data-i18n="demo.gatesLabel">Red on any of these blocks the deploy</p>
@@ -251,6 +251,16 @@
               <code>vlmkit check a11y focus</code>
               <code>vlmkit check a11y touch --level AAA</code>
             </div>
+            <!--
+              What playing it produced. The page is a dogfood site, so the demo's strongest claim is
+              not that it exists but that using it found defects the gates could not — and that each
+              one became a rule the toolkit now ships. `page.test.mjs` reads these three names out of
+              the rule table, so a renamed rule fails a test instead of leaving a stale claim here.
+            -->
+            <p class="demo-produced">
+              <span data-i18n="demo.produced">Playing this page by hand found three defects no gate reported. Each is a rule now:</span>
+              <code>drag-selects-text</code><code>dblclick-selects-text</code><code>drag-ghost-illegible</code>
+            </p>
             <div class="demo-actions">
               <a class="button button-dark" href="./solitaire/"><span data-i18n="demo.play">Play the demo</span> <span aria-hidden="true">→</span></a>
               <a class="demo-changelog" href="https://github.com/mizchi/vlmkit/blob/main/CHANGELOG.md"><span data-i18n="demo.changelog">Read what 0.11 changed</span> <span aria-hidden="true">↗</span></a>

--- a/examples/vlmkit-intro-page/page.test.mjs
+++ b/examples/vlmkit-intro-page/page.test.mjs
@@ -139,6 +139,31 @@ test("the playable-demo section routes to the game and states what proves it", a
       `${gate} is advertised but the deploy workflow does not run it against the demo`,
     );
   }
+
+  /*
+   * The two claims in this section that go stale on their own, pinned to the code that decides them.
+   *
+   * The family count was written as 6 and the seventh (`dblclick`) landed a release later, which is
+   * the shape of every number on a marketing page: true when typed, silently wrong afterwards. Read
+   * out of the source as TEXT rather than imported — this file has to stay dependency-free, because
+   * `skill-package.yml` runs it with no pnpm install and no Playwright.
+   */
+  const handlerMap = await readFile(
+    join(exampleDir, "../../packages/vlmkit-markup/src/inspect/handler-map.ts"),
+    "utf8",
+  );
+  const families = handlerMap.match(/export const PROBE_FAMILIES = \[(.*?)\]/)[1].split(",").length;
+  assert.match(
+    section,
+    new RegExp(`<strong>${families}</strong><span data-i18n="demo\\.metricFamilies"`),
+    `the page advertises a different number of probe families than the ${families} that exist`,
+  );
+  // The rules this demo produced. A renamed rule has to fail here rather than leave the page
+  // naming something the toolkit no longer ships.
+  for (const rule of ["drag-selects-text", "dblclick-selects-text", "drag-ghost-illegible"]) {
+    assert.ok(section.includes(`<code>${rule}</code>`), `${rule} is missing from the demo section`);
+    assert.ok(handlerMap.includes(`id: "${rule}"`), `${rule} is not a rule this project declares`);
+  }
 });
 
 /**

--- a/examples/vlmkit-intro-page/styles.css
+++ b/examples/vlmkit-intro-page/styles.css
@@ -1049,6 +1049,30 @@ dd {
   overflow-wrap: anywhere;
 }
 
+/*
+ * The rules this demo produced. Chips rather than prose: they are identifiers a reader copies into
+ * `--rule <id>=off` or greps the docs for, and running them into a sentence makes them unselectable
+ * by eye. Wraps as a unit with its lead-in so a narrow screen does not orphan one name.
+ */
+.demo-produced {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 8px;
+  color: var(--surface-muted-strong);
+  font-size: 12px;
+}
+
+.demo-produced code {
+  padding: 3px 7px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--green-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
 .demo-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Two claims on the published site had gone stale in a week.

- **`6 interaction families` is 7.** `dblclick` landed a release after the line was written. The
  label drops the version with it — "the 0.11 probes" would age the same way the count did.
- **The section now says what the demo is for, with evidence.** Playing this page by hand found
  three defects no gate reported, and each is a rule the toolkit ships:
  `drag-selects-text`, `dblclick-selects-text`, `drag-ghost-illegible`. Rendered as chips rather
  than prose because they are identifiers a reader copies into `--rule <id>=off`.

Both pinned rather than trusted: `page.test.mjs` counts `PROBE_FAMILIES` out of the source as text
(the file stays dependency-free — `skill-package.yml` runs it with no pnpm install) and asserts the
page matches, and checks each rule id is one this project declares. Ablating the count to 6 fails
with "the page advertises a different number of probe families than the 7 that exist".

The still did not need re-shooting — verified byte-identical by re-running `capture-demo-still.mjs`,
since `user-select` is invisible, `.card.dragging` only applies mid-drag, and the stock is
`dealable` at ply 60.

Gates: the four locale/theme states pass, `check copy` reads 72 manifest lines with 0 missing,
`check design` is COHERENT, no overflow at 1280 / 1280-dark / 375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)