### PR TITLE
Await a painted frame before every mid-gesture screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,19 @@ said anything.
   changed; the date arrived. The expiry is computed relative to the run now, which is what a test
   asking a question about the future needs, and the assertion prints the output it got.
 
+- **A mid-gesture screenshot was racing the compositor, so the pixel probes under-reported.**
+  `page.mouse.move` resolves when the input has been DISPATCHED, not when the result has been
+  painted, and both drag probes screenshot straight after it. Idle machines win that race and hide
+  it. Found by the diagnostics added below: the canvas assertion printed
+  `feedback=0.250% committed=0.500% handlerCalls=11` — the page had received the whole gesture and
+  the shot showed one stroke segment of nine, on a fixture that measured 2.181% on every quiet run.
+
+  A wrong number, not only a flaky test: `feedbackRatio` and the `drag-ghost-illegible` pair are
+  evidence a reader acts on, and a stale frame under-reports both — in the legibility rule's case
+  toward a false negative, since the ghost has not been painted yet. Both probes await a painted
+  frame (double `requestAnimationFrame`) before every mid-flight shot. Idle values are unchanged to
+  three decimals; four consecutive full runs green.
+
 - **The canvas pointer-drag assertion had a 1.4x margin and no diagnostics.** The probe drags across
   ~40% of the pad, and a 3px stroke changed 0.709% of the element's pixels against a 0.5% floor —
   which passed every run in isolation and failed twice in six full runs, where browsers run in

--- a/fixtures/handlers/pointer-drag.html
+++ b/fixtures/handlers/pointer-drag.html
@@ -110,13 +110,13 @@
     /*
      * 12, not 3. The probe drags across ~40% of the pad, so a 3px stroke changed 0.709% of the
      * element's pixels against the test's 0.5% floor — a 1.4x margin on a pixel measurement, which
-     * is no margin at all in a suite that runs browsers in parallel. That assertion failed in full
-     * runs while passing every time in isolation.
+     * is no margin at all in a suite that runs browsers in parallel.
      *
-     * The fixture's job is to prove that pixels move where the DOM does not, and a thicker line
-     * proves exactly the same thing with room to spare. It does NOT explain the failures — those
-     * are still unexplained, which is why the assertion now prints the ratios and the handler-call
-     * count when it trips.
+     * Widening it did NOT stop the failures, and that is what identified the real cause: the
+     * assertion printed `feedback=0.250% handlerCalls=11`, so the page had received the whole
+     * gesture and the SHOT was behind — one stroke segment of nine. `probePointerDrags` awaits a
+     * painted frame before the mid-drag screenshot now. The thicker line stays as margin; it was
+     * never the fix.
      */
     ctx.lineWidth = 12;
     c.addEventListener("pointerdown", (e) => {

--- a/packages/vlmkit-markup/src/inspect/handler-map.test.ts
+++ b/packages/vlmkit-markup/src/inspect/handler-map.test.ts
@@ -656,11 +656,12 @@ test("E2E: the pointer-drag gesture separates a working drag from a dead one, ca
   /*
    * The canvas: pixels move, the DOM does not.
    *
-   * The numbers are in the message because this is the one assertion here with a thin margin — the
-   * stroke covers 0.709% of the pad against a 0.5% floor — and it has failed in a full parallel run
-   * while passing every time in isolation. `handlerCalls` separates the two explanations that a bare
-   * "it did not register" cannot: a gesture that never reached the canvas (0 calls) is a different
-   * defect from one that ran the handlers and drew too little to count.
+   * The numbers are in the message, and they are what found the cause. This assertion failed in full
+   * parallel runs while passing every time in isolation, and printing them said why:
+   * `feedback=0.250% committed=0.500% handlerCalls=11` — the page had received the whole gesture and
+   * drawn a ninth of the stroke, which is a screenshot racing the compositor rather than a drag that
+   * did not happen. `probePointerDrags` awaits a painted frame now. `handlerCalls` is what made it
+   * legible: 0 would have meant the gesture never arrived, which is a different defect entirely.
    */
   const canvas = row("canvas-works")!;
   assert.ok(

--- a/packages/vlmkit-markup/src/inspect/handler-map.ts
+++ b/packages/vlmkit-markup/src/inspect/handler-map.ts
@@ -841,6 +841,26 @@ async function handleForPath(page: Page, path: string): Promise<JSHandle> {
   })()`);
 }
 
+/**
+ * One rendered frame, awaited in the page.
+ *
+ * `page.mouse.move` resolves when the input has been DISPATCHED, not when the result has been
+ * painted, so a screenshot taken straight after it races the compositor. Idle machines win that race
+ * and hide it; a loaded one does not. Measured on the pointer-drag fixture, whose canvas draws nine
+ * stroke segments across the gesture: the mid-drag shot reported 2.181% of the element's pixels
+ * changed on every quiet run and 0.250% in a full parallel suite — one segment of nine — with the
+ * page's own listeners invoked the normal eleven times, so the gesture had arrived and only the
+ * PICTURE was behind.
+ *
+ * Double `requestAnimationFrame` is the "after the next paint" idiom: the first callback runs before
+ * the frame is composited, the second after it.
+ */
+async function nextPaintedFrame(page: Page): Promise<void> {
+  await page.evaluate(
+    "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
+  ).catch(() => {});
+}
+
 async function probePointerDrags(
   page: Page,
   elements: readonly HandlerSurfaceEntry[],
@@ -868,6 +888,10 @@ async function probePointerDrags(
       await page.mouse.move(...at(0.3, 0.3));
       await page.mouse.down();
       await page.mouse.move(...at(0.5, 0.5), { steps: 4 });
+      // The picture has to be current or the ratio under-reports what the drag did — see
+      // `nextPaintedFrame`. This is the number a reader acts on, so a stale frame is a wrong answer
+      // and not merely a flaky test.
+      await nextPaintedFrame(page);
       const during = await el.screenshot();
       await page.mouse.move(...at(0.7, 0.7), { steps: 4 });
       await page.mouse.up();
@@ -1575,6 +1599,7 @@ async function probeRealDrags(
     // Mid-drag, with the mouse still down. Measured as workable: ~60-80ms per shot, and it
     // separates a zone that highlights on dragenter (99% of its own box changed) from one that
     // does not (0.00%, byte-identical).
+    if (before || source) await nextPaintedFrame(page);
     const during = before ? await target!.screenshot().catch(() => null) : null;
     /*
      * The dragged element, in the air. Its own opacity is read here rather than inferred from the


### PR DESCRIPTION
`page.mouse.move` resolves when the input has been **dispatched**, not when the result has been
**painted**, and both drag probes screenshot straight after it. An idle machine wins that race,
which is why this hid.

Found by the diagnostics added to the canvas assertion — and by the fact that widening the stroke
did *not* stop the failures, which ruled the margin out as the cause:

```
feedback=0.250% committed=0.500% handlerCalls=11
```

Eleven invocations is the normal count for this gesture, so the page received all of it. 0.250%
against the 2.181% every quiet run measures is one stroke segment of nine. The gesture happened;
the picture was behind.

**A wrong number, not only a flaky test.** `feedbackRatio` is printed as evidence a reader acts on,
and `drag-ghost-illegible` grades the pair of ratios it measures the same way — there a stale frame
shows the card *before* its ghost opacity applies, which under-reports toward a false negative.

Both probes await a painted frame now (double `requestAnimationFrame`, so the callback runs after
the frame is composited rather than before it).

- Idle measurements unchanged to three decimals: canvas 2.181% / 4.331%, solitaire legibility
  7.59:1 → 7.52:1.
- Four consecutive full runs green, 3403 tests. The prior failure rate was ~1 in 3.
- The 12px stroke stays as margin, with its comment corrected — it was never the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)