### PR TITLE
skills: `explanatory-animation` workflow for vlmkit-anim; anim-ir run in agent-validation-loop

### DIFF
--- a/.apm/skills/vlmkit/SKILL.md
+++ b/.apm/skills/vlmkit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vlmkit
-description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
+description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression — and whenever they ask to animate, illustrate or diagram how something works, or to draw a module, dependency or architecture map. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
 ---
 
 # vlmkit — Skill Router and CLI Guide
@@ -105,6 +105,7 @@ second only when the task genuinely crosses boundaries.
 | Evaluate a framework/CSS/build migration | `./workflows/vrt-migration-eval/SKILL.md` | Judge visual equivalence despite large intentional rewrites |
 | Benchmark known CSS repair challenges | `./workflows/vrt-css-fix-loop/SKILL.md` | Measure VLM+LLM recovery, not production healing |
 | Harden an agent-facing CLI, SDK, or harness | `./workflows/agent-validation-loop/SKILL.md` | Turn fresh-agent friction into fixes and tracked evidence |
+| Explain an algorithm, protocol or architecture as an animation or a still figure; draw a module / dependency map; import a mermaid diagram | `./workflows/explanatory-animation/SKILL.md` | Write one checked `vlmkit-anim` scene, hold it to its facts and layout, emit a page, GIF or cropped figure (separate binary: `@mizchi/vlmkit-anim`) |
 
 The human-facing catalog, direct install commands, and category rationale are
 in the [vlmkit skill catalog](https://github.com/mizchi/vlmkit/tree/main/.claude/skills).

--- a/.apm/skills/vlmkit/workflows/agent-validation-loop/SKILL.md
+++ b/.apm/skills/vlmkit/workflows/agent-validation-loop/SKILL.md
@@ -354,3 +354,52 @@ agent-g regressing on a class of bug (typographic cascade) that the
 existing signal hierarchy couldn't classify — the new REFLOW tag
 closed it, and post-REFLOW runs (h, i) converged within
 the budget.
+
+## Second reference run: an IR judged by its writers (anim-ir v1–v24)
+
+`vlmkit-anim` (the `explanatory-animation` skill) was built with this loop
+from its first day: 24 rounds over six days, 86 writer attempts (`a`…`qb`),
+reports `docs/reports/2026-09-0{4..9}-anim-ir-v*.md`, fixture
+`fixtures/anim-scenario/`. The tool under test is a **format** an agent
+writes, not a signal it reads, and that changed five things about the loop.
+They are worth copying whenever the deliverable is "an agent gets it right
+from the docs alone".
+
+- **The docs are the only input.** Each writer gets one brief and one guide
+  (`docs/anim-ir.md`) and is forbidden the package source, other attempts,
+  the reports and the CHANGELOG — by path, in the prompt. A writer who reads
+  the compiler is measuring their own reading, not the guide. Every JSON
+  block in the guide is compiled by a test, so the guide cannot drift from
+  the tool it describes.
+- **The success criterion is a fact sheet, not a green check.** Round 13 had
+  five green module maps and two of them were wrong (a true dependency
+  deleted, the wrong edge lit). From round 14 every brief ships
+  `facts/<brief>.expect.json` and success is `check --expect` exiting 0;
+  from round 18 the tool writes the sheet itself from the code
+  (`vlmkit-anim facts`). Whatever your tool draws or emits: find the ground
+  truth it can be held to and make the check read it, or a clean run proves
+  nothing.
+- **Two measurements, then compare them.** Geometry (`layout`) said the
+  frames were clean; vision readers on the same frames (round 12, and round
+  21 on stills) found lines through labels, containers crossing, a corner
+  label read as a caption. Each disagreement was a defect one side could not
+  see, and each became a rule in the cheaper measurement. A second, unlike
+  reader is how you learn what your first one is blind to.
+- **Ask for "what told you", per round.** From round 24 the log asks the
+  writer to quote the line — a `check` line, a `why` line, the picture, a
+  guess — that made them change what they changed. Two writers quoted the
+  same `why` line before their first edit; both then asked for it in the
+  warning itself, which is where it now is. The quote locates the fix in the
+  tool's output, not in the writer's head.
+- **Run two model sizes on the same brief.** A smaller model (haiku) beside
+  a larger one (sonnet) on the same brief, from round 14 on: the smaller one
+  hits the gaps in the guide the larger one reads past, and a fix that only
+  the larger model can use is not a fix. When the two converge on the same
+  lever from the same line, the tool said it.
+
+Two habits from this run that the ten steps above assume but do not say:
+a **corpus check** on every compiler change (`layout` over every fixture and
+attempt, diffed against the previous round's baseline — a fix for one
+writer's scene has regressed another's more than once), and a report that
+**names the next round** in its last paragraph, so the list the user gave
+and the list the evidence gives can be compared before either is started.

--- a/.apm/skills/vlmkit/workflows/explanatory-animation/SKILL.md
+++ b/.apm/skills/vlmkit/workflows/explanatory-animation/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: explanatory-animation
+description: Explain an algorithm, protocol, data structure, state machine, or architecture as a checked animation or still figure with `vlmkit-anim` — one JSON scene (a `kind` plus intent, never coordinates) compiled to SVG + Web Animations, a GIF, or a cropped figure, and checked against what it claims (semantic checks, `layout` geometry, a fact sheet with `--expect`, `why` for the layout's own reasons). Also draws a module map from a directory's import graph, a repository's architecture, the change map of a branch, the diff of two maps, and imports mermaid the repo already has. Use when asked to animate, illustrate, diagram, draw a dependency / module / architecture map, explain how something works step by step, or embed such a figure in docs. Not a VRT gate — `vlmkit-anim` is its own binary (`@mizchi/vlmkit-anim`).
+metadata:
+  internal: true
+---
+
+# explanatory-animation
+
+One file says **what is being explained**; the tool draws it, and then
+checks that the picture says what the file claims. The writer's job is the
+scene and the captions. The tool's job is layout, motion, and telling the
+writer where the picture lies.
+
+```json
+{ "format": "vlmkit-anim/scene@1", "kind": "sort", "algorithm": "bubble", "values": [5, 3, 8, 1] }
+```
+
+Two layers: a **Scene** (`kind` + intent — `"algorithm": "bubble"`,
+`"trace": ["connect", "SYN+ACK"]`, `"deps": [["web", "api"]]`, never x / y)
+compiles to a **Timeline** (nodes, keyframe tracks, captioned steps). Write
+the scene; read the timeline only through the verbs below.
+
+**The one page to read before writing is `docs/anim-ir.md`** (in this repo)
+— every kind, its ops, the annotation ops every kind shares, and one JSON
+example per kind that `check` passes. `vlmkit-anim schema --kind <k>` prints
+one kind's section. Do not learn the format from the compiler source.
+
+## Invocation
+
+`vlmkit-anim` is a **standalone binary**, not a `vlmkit` subcommand.
+
+```bash
+# this repository
+pnpm exec vlmkit-anim check scene.json                      # dist/ — run `pnpm --filter @mizchi/vlmkit-anim build` after editing src/
+node --experimental-strip-types packages/vlmkit-anim/src/cli.ts check scene.json   # no build
+
+# any other repository
+npx -p @mizchi/vlmkit-anim vlmkit-anim check scene.json     # or add @mizchi/vlmkit-anim as a dev dependency
+```
+
+Nothing below needs a browser or an API key except: `.png` output, `sheet`,
+`video`, `eval` (Playwright), and `review --model` (a vision model through
+`@mizchi/vlmkit-ai`). Writing and checking a scene is browser-free.
+
+## Route by task
+
+| Task shape | Do this |
+|---|---|
+| "Animate / show step by step how X works" (a sort, search, BST, heap, DP table, graph walk, state machine, message exchange, flowchart, gantt) | Pick the `kind` whose section in the guide names X; write the scene; run the loop below. Nineteen kinds: sort, array, stack, queue, list, tree, state-machine, heap, distributed, matrix, graph, chart, flowchart, gantt, sequence, diagram, modules, vector, compose. |
+| "Explain a concept" that no kind names | Choose the kind whose *things* the concept has (nodes exchanging messages → `distributed`; a table filling in → `matrix`); say the rest with annotation ops (`value`, `callout`, `snapshot`, `group`, `text`, `relate`) that name the kind's things. Two pictures at once → `kind: compose`. Coordinates are the last resort, and count against the scene. |
+| "Draw a module / dependency / architecture map" | `kind: modules` with `modules`, `deps` (`["a", "b"]` reads "a depends on b"), `groups`, optional `parent` on a group; `still` renders it. When the code exists, first `vlmkit-anim facts <dir> --depth 1 --out f.expect.json`, then `check --expect` the map against it. |
+| "Draw this repository" | `vlmkit-anim repo --out docs/diagrams --name <name>` — the workspace layer by layer, a GIF, a contact sheet, a Markdown page and its own fact sheet. |
+| "What does this branch change?" | `vlmkit-anim pr --base origin/main --out .vlmkit-anim/pr` — one beat per commit; `<name>.md` is paste-ready. |
+| "Show what changed between two maps" | `vlmkit-anim diff before.json after.json --out change.svg [--expect diff.json]` — added in accent, removed dashed grey, a legend; `--expect` checks the change against a diff sheet. |
+| "We already have a mermaid diagram" | `vlmkit-anim import mermaid page.md --out scene.json` (flowchart / graph, sequenceDiagram, stateDiagram-v2). Read its `dropped / changed:` and `notes:` lines; add what the import cannot know (a title, captions, a walk or trace). |
+| "Put it in the docs" | `html --out page.html` (runtime inline), `video --out demo.gif` for a README, or the remark plugin `@mizchi/vlmkit-anim/remark` so a ```` ```vlm-anim ```` fence in Markdown becomes the animation and ```` ```vlm-anim still ```` the figure. |
+
+## The loop
+
+```
+1. write scene.json                                  one kind; ids ASCII, language in `label`
+2. vlmkit-anim check scene.json [--expect facts.json] validate → compile → semantic checks → stats; exit 1 on ✗
+3. vlmkit-anim explain scene.json                    the narration as a numbered list — is this the story?
+4. vlmkit-anim layout scene.json                     texts on texts, under boxes, past the edge, lines through
+                                                     labels, containers crossing — per step; exit 1 when any
+5. vlmkit-anim why scene.json [--about id]           (modules / diagram) what set each canvas axis, rows vs bands
+                                                     and their share, what put each box on its layer, which box
+                                                     a bent edge went round — read this BEFORE relabelling
+6. vlmkit-anim still scene.json --out fig.svg        the figure  |  html --out page.html  |  video --out demo.gif
+7. vlmkit-anim review scene.json --out dir           optional: a contact sheet + brief for a vision reader;
+                                                     --answers scores its JSON against the geometry / the facts
+```
+
+Each ✗ line names a path, what is wrong, and a `→` hint with the fix. Fix
+the first ✗, re-run; ⚠ lines are advice you act on only when they touch
+what the picture is for. Budget five rounds; if the fifth is not green,
+stop and report the lines, not a guess.
+
+## Done condition
+
+- `check` exits 0 with no ✗ (and, when a fact sheet exists, `--expect` too).
+- `layout` reports no issue on any step.
+- `explain` reads as the explanation you meant — every beat has a caption
+  that says *why*, not only what moved.
+- For a still: both canvas sides under 2000px (the canvas ⚠ in `check`),
+  and you looked at the SVG once.
+
+## Reading the kickbacks
+
+- **The canvas warning names its cause.** "labels stop being legible — A
+  (206px, in G1) and B (53px, in G2) need 142px between their centres … and
+  the layout put them 10% of the width apart", then "N containers sit side by
+  side across the picture (a 40%, b 10%, …), each as wide as its fullest
+  layer's boxes". The lever is the named pair or the banding — flatten or
+  re-nest the containers, break the named label — not the longest label you
+  can see. `why` has every layer, band and detour; two writers who read it
+  before their first edit brought an 8882px graph under 2000px.
+- **A crossing names the edge by its ends** (`edge-24: diff → capture`) and
+  the box it runs through. Move one end to another layer (reorder the list,
+  regroup) or shorten *that* label.
+- **"no sequence" on a `diagram`** means the picture, not the motion, is the
+  point: switch to `kind: modules`. The switch changes layering (a diagram
+  layers one past what points into a box; a module map layers from its
+  leaves), so re-run `check` and read the new canvas line.
+- **`--expect` lines** are the facts the picture got wrong: a dependency
+  drawn that the sheet does not list, one listed and not drawn, the wrong
+  edge highlighted. A green `check` on a wrong picture is the failure this
+  exists for — the sheet wins over the picture.
+- **`import mermaid` `dropped / changed:`** names what the IR has no place
+  for (styles, classDefs, clicks, `direction` inside a subgraph, composite
+  states). Colour with `tone`; everything else you put back as captions.
+
+## Rules the checks enforce (do not fight them)
+
+- No coordinates in a scene that has a kind for its things. `kind: vector`
+  and hand-written positions are the fallback and are counted as such.
+- Every annotation names an anchor the kind owns (an index, a cell, a node,
+  an edge), and asks for a `side`; the compiler grows the canvas on that
+  side and routes the pointer round labelled boxes. Record asked vs landed
+  if it matters.
+- Labels may be any script; boxes are sized per glyph (CJK is one em). Ids
+  stay ASCII.
+- A dependency cycle in `modules` is a warning, drawn — name the cut in a
+  caption or mark one edge `"style": "forbidden"`.
+- A scene in a ```` ```vlm-anim ```` fence is checked the same way; a fence
+  that does not compile renders as a visible `<pre>` with the check's lines.
+
+## Outputs at a glance
+
+| File | Verb | Consumer |
+|---|---|---|
+| `scene.json` (or `scene.ts` exporting `scene.<kind>({…})`) | you | the repo — this is what is edited later |
+| `fig.svg` / `fig.png` | `still` | docs, a README, a slide |
+| `page.html` | `html` | a browser; `vlmkit check animation page.html` and `vlmkit-anim eval` measure it |
+| `demo.gif` / `.mp4` / `.webm` | `video` | a README or PR comment |
+| `*.expect.json` | `facts`, `repo`, by hand | `check --expect`; the truth the picture is held to |
+| `<name>.sheet.png`, `<name>.review-brief.md`, `<name>.review-score.md` | `review` | a vision model or a second agent, and its score |
+
+## Failure modes
+
+- `.png`, `sheet`, `video --out x.mp4`, `eval` fail with a browser error →
+  Playwright is missing; `.svg`, `.gif` and `sheet --out sheet.html` need no
+  browser.
+- In this repo the CLI shows old behaviour after editing `packages/vlmkit-anim/src/` →
+  `pnpm --filter @mizchi/vlmkit-anim build` (never piped to `head`), or run from source.
+- Every round shortens a label and the canvas does not move → the label was
+  not the binding one; read the canvas line and `why`.
+- A `modules` map has a dependency the code does not → the sheet from
+  `facts` catches it; a map drawn from memory is checked against the code,
+  not the other way round.
+- `check` is green, the figure is wrong → write the fact sheet. That is the
+  whole reason `--expect` exists.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -176,6 +176,11 @@ with `pnpm anim:samples` after changing a compiler. In this repo run it as
 `pnpm exec vlmkit-anim …` (resolves to `dist/`, so `pnpm --filter @mizchi/vlmkit-anim build`
 after editing `src/`) or, without a build, `node --experimental-strip-types packages/vlmkit-anim/src/cli.ts …`.
 
+The agent-facing playbook for writing a scene is the `explanatory-animation` skill
+(`.claude/skills/explanatory-animation/`; routed from `skills/vlmkit/SKILL.md` like the
+markup workflows). It points at `docs/anim-ir.md` as the one page to read and says how to
+read `check`'s canvas and crossing lines, `--expect`, `why` and `import mermaid`'s dropped list.
+
 The IR is judged on two things, measured by fresh subagents rather than by
 reading the code: **an agent gets it right from `docs/anim-ir.md` alone**, and
 **intent is readable when someone edits the file later**. Scenario fixture:

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,6 +1,6 @@
 # vlmkit agent skills
 
-vlmkit ships one automatic router backed by 11 specialized workflows.
+vlmkit ships one automatic router backed by 14 specialized workflows.
 Install once, then describe the outcome you want in ordinary language. The
 agent picks the workflow whose inputs and done condition match the task.
 
@@ -62,6 +62,7 @@ which skill the user wants.
 | Test generation | A natural-language story must become a reproducible browser test | [`spec-to-playwright`](./spec-to-playwright/) | Explore the app, generate Playwright tests, stabilize VRT, run CI gates, and heal drift |
 | Comparison and monitoring | Two renders or repeated runs must be compared | [`vrt-markup-synth`](./vrt-markup-synth/), [`vrt-visual-diff`](./vrt-visual-diff/), [`vrt-regression-watch`](./vrt-regression-watch/), [`vrt-migration-eval`](./vrt-migration-eval/) | Produce deterministic authoring signals, explain visual deltas, detect regressions over time, and evaluate framework/CSS migrations |
 | Evaluation and hardening | You are measuring the repair system or the agent-facing tool itself | [`vrt-css-fix-loop`](./vrt-css-fix-loop/), [`agent-validation-loop`](./agent-validation-loop/) | Benchmark VLM+LLM CSS recovery on known fixtures and improve tool ergonomics with fresh-agent validation loops |
+| Explanation and figures | Something has to be explained or drawn, not verified: an algorithm step by step, a protocol, a module or architecture map, a diagram the docs already carry as mermaid | [`explanatory-animation`](./explanatory-animation/) | Write one JSON scene (`kind` + intent, no coordinates) with `vlmkit-anim`; check it against its facts and its own layout; emit a `<vlm-anim>` page, a GIF, or a cropped still; import mermaid; draw a repository or a branch's change |
 
 ## Selection rules
 
@@ -77,3 +78,4 @@ which skill the user wants.
 - Component, token, theme, or i18n authoring signal → `vrt-markup-synth`.
 - Known CSS deletion benchmark → `vrt-css-fix-loop`.
 - Agent-facing CLI or harness usability study → `agent-validation-loop`.
+- Animate or illustrate how something works, draw a module / dependency / architecture map, turn a mermaid diagram into a checked figure → `explanatory-animation`.

--- a/.claude/skills/agent-validation-loop/SKILL.md
+++ b/.claude/skills/agent-validation-loop/SKILL.md
@@ -354,3 +354,52 @@ agent-g regressing on a class of bug (typographic cascade) that the
 existing signal hierarchy couldn't classify — the new REFLOW tag
 closed it, and post-REFLOW runs (h, i) converged within
 the budget.
+
+## Second reference run: an IR judged by its writers (anim-ir v1–v24)
+
+`vlmkit-anim` (the `explanatory-animation` skill) was built with this loop
+from its first day: 24 rounds over six days, 86 writer attempts (`a`…`qb`),
+reports `docs/reports/2026-09-0{4..9}-anim-ir-v*.md`, fixture
+`fixtures/anim-scenario/`. The tool under test is a **format** an agent
+writes, not a signal it reads, and that changed five things about the loop.
+They are worth copying whenever the deliverable is "an agent gets it right
+from the docs alone".
+
+- **The docs are the only input.** Each writer gets one brief and one guide
+  (`docs/anim-ir.md`) and is forbidden the package source, other attempts,
+  the reports and the CHANGELOG — by path, in the prompt. A writer who reads
+  the compiler is measuring their own reading, not the guide. Every JSON
+  block in the guide is compiled by a test, so the guide cannot drift from
+  the tool it describes.
+- **The success criterion is a fact sheet, not a green check.** Round 13 had
+  five green module maps and two of them were wrong (a true dependency
+  deleted, the wrong edge lit). From round 14 every brief ships
+  `facts/<brief>.expect.json` and success is `check --expect` exiting 0;
+  from round 18 the tool writes the sheet itself from the code
+  (`vlmkit-anim facts`). Whatever your tool draws or emits: find the ground
+  truth it can be held to and make the check read it, or a clean run proves
+  nothing.
+- **Two measurements, then compare them.** Geometry (`layout`) said the
+  frames were clean; vision readers on the same frames (round 12, and round
+  21 on stills) found lines through labels, containers crossing, a corner
+  label read as a caption. Each disagreement was a defect one side could not
+  see, and each became a rule in the cheaper measurement. A second, unlike
+  reader is how you learn what your first one is blind to.
+- **Ask for "what told you", per round.** From round 24 the log asks the
+  writer to quote the line — a `check` line, a `why` line, the picture, a
+  guess — that made them change what they changed. Two writers quoted the
+  same `why` line before their first edit; both then asked for it in the
+  warning itself, which is where it now is. The quote locates the fix in the
+  tool's output, not in the writer's head.
+- **Run two model sizes on the same brief.** A smaller model (haiku) beside
+  a larger one (sonnet) on the same brief, from round 14 on: the smaller one
+  hits the gaps in the guide the larger one reads past, and a fix that only
+  the larger model can use is not a fix. When the two converge on the same
+  lever from the same line, the tool said it.
+
+Two habits from this run that the ten steps above assume but do not say:
+a **corpus check** on every compiler change (`layout` over every fixture and
+attempt, diffed against the previous round's baseline — a fix for one
+writer's scene has regressed another's more than once), and a report that
+**names the next round** in its last paragraph, so the list the user gave
+and the list the evidence gives can be compared before either is started.

--- a/.claude/skills/explanatory-animation/SKILL.md
+++ b/.claude/skills/explanatory-animation/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: explanatory-animation
+description: Explain an algorithm, protocol, data structure, state machine, or architecture as a checked animation or still figure with `vlmkit-anim` — one JSON scene (a `kind` plus intent, never coordinates) compiled to SVG + Web Animations, a GIF, or a cropped figure, and checked against what it claims (semantic checks, `layout` geometry, a fact sheet with `--expect`, `why` for the layout's own reasons). Also draws a module map from a directory's import graph, a repository's architecture, the change map of a branch, the diff of two maps, and imports mermaid the repo already has. Use when asked to animate, illustrate, diagram, draw a dependency / module / architecture map, explain how something works step by step, or embed such a figure in docs. Not a VRT gate — `vlmkit-anim` is its own binary (`@mizchi/vlmkit-anim`).
+metadata:
+  internal: true
+---
+
+# explanatory-animation
+
+One file says **what is being explained**; the tool draws it, and then
+checks that the picture says what the file claims. The writer's job is the
+scene and the captions. The tool's job is layout, motion, and telling the
+writer where the picture lies.
+
+```json
+{ "format": "vlmkit-anim/scene@1", "kind": "sort", "algorithm": "bubble", "values": [5, 3, 8, 1] }
+```
+
+Two layers: a **Scene** (`kind` + intent — `"algorithm": "bubble"`,
+`"trace": ["connect", "SYN+ACK"]`, `"deps": [["web", "api"]]`, never x / y)
+compiles to a **Timeline** (nodes, keyframe tracks, captioned steps). Write
+the scene; read the timeline only through the verbs below.
+
+**The one page to read before writing is `docs/anim-ir.md`** (in this repo)
+— every kind, its ops, the annotation ops every kind shares, and one JSON
+example per kind that `check` passes. `vlmkit-anim schema --kind <k>` prints
+one kind's section. Do not learn the format from the compiler source.
+
+## Invocation
+
+`vlmkit-anim` is a **standalone binary**, not a `vlmkit` subcommand.
+
+```bash
+# this repository
+pnpm exec vlmkit-anim check scene.json                      # dist/ — run `pnpm --filter @mizchi/vlmkit-anim build` after editing src/
+node --experimental-strip-types packages/vlmkit-anim/src/cli.ts check scene.json   # no build
+
+# any other repository
+npx -p @mizchi/vlmkit-anim vlmkit-anim check scene.json     # or add @mizchi/vlmkit-anim as a dev dependency
+```
+
+Nothing below needs a browser or an API key except: `.png` output, `sheet`,
+`video`, `eval` (Playwright), and `review --model` (a vision model through
+`@mizchi/vlmkit-ai`). Writing and checking a scene is browser-free.
+
+## Route by task
+
+| Task shape | Do this |
+|---|---|
+| "Animate / show step by step how X works" (a sort, search, BST, heap, DP table, graph walk, state machine, message exchange, flowchart, gantt) | Pick the `kind` whose section in the guide names X; write the scene; run the loop below. Nineteen kinds: sort, array, stack, queue, list, tree, state-machine, heap, distributed, matrix, graph, chart, flowchart, gantt, sequence, diagram, modules, vector, compose. |
+| "Explain a concept" that no kind names | Choose the kind whose *things* the concept has (nodes exchanging messages → `distributed`; a table filling in → `matrix`); say the rest with annotation ops (`value`, `callout`, `snapshot`, `group`, `text`, `relate`) that name the kind's things. Two pictures at once → `kind: compose`. Coordinates are the last resort, and count against the scene. |
+| "Draw a module / dependency / architecture map" | `kind: modules` with `modules`, `deps` (`["a", "b"]` reads "a depends on b"), `groups`, optional `parent` on a group; `still` renders it. When the code exists, first `vlmkit-anim facts <dir> --depth 1 --out f.expect.json`, then `check --expect` the map against it. |
+| "Draw this repository" | `vlmkit-anim repo --out docs/diagrams --name <name>` — the workspace layer by layer, a GIF, a contact sheet, a Markdown page and its own fact sheet. |
+| "What does this branch change?" | `vlmkit-anim pr --base origin/main --out .vlmkit-anim/pr` — one beat per commit; `<name>.md` is paste-ready. |
+| "Show what changed between two maps" | `vlmkit-anim diff before.json after.json --out change.svg [--expect diff.json]` — added in accent, removed dashed grey, a legend; `--expect` checks the change against a diff sheet. |
+| "We already have a mermaid diagram" | `vlmkit-anim import mermaid page.md --out scene.json` (flowchart / graph, sequenceDiagram, stateDiagram-v2). Read its `dropped / changed:` and `notes:` lines; add what the import cannot know (a title, captions, a walk or trace). |
+| "Put it in the docs" | `html --out page.html` (runtime inline), `video --out demo.gif` for a README, or the remark plugin `@mizchi/vlmkit-anim/remark` so a ```` ```vlm-anim ```` fence in Markdown becomes the animation and ```` ```vlm-anim still ```` the figure. |
+
+## The loop
+
+```
+1. write scene.json                                  one kind; ids ASCII, language in `label`
+2. vlmkit-anim check scene.json [--expect facts.json] validate → compile → semantic checks → stats; exit 1 on ✗
+3. vlmkit-anim explain scene.json                    the narration as a numbered list — is this the story?
+4. vlmkit-anim layout scene.json                     texts on texts, under boxes, past the edge, lines through
+                                                     labels, containers crossing — per step; exit 1 when any
+5. vlmkit-anim why scene.json [--about id]           (modules / diagram) what set each canvas axis, rows vs bands
+                                                     and their share, what put each box on its layer, which box
+                                                     a bent edge went round — read this BEFORE relabelling
+6. vlmkit-anim still scene.json --out fig.svg        the figure  |  html --out page.html  |  video --out demo.gif
+7. vlmkit-anim review scene.json --out dir           optional: a contact sheet + brief for a vision reader;
+                                                     --answers scores its JSON against the geometry / the facts
+```
+
+Each ✗ line names a path, what is wrong, and a `→` hint with the fix. Fix
+the first ✗, re-run; ⚠ lines are advice you act on only when they touch
+what the picture is for. Budget five rounds; if the fifth is not green,
+stop and report the lines, not a guess.
+
+## Done condition
+
+- `check` exits 0 with no ✗ (and, when a fact sheet exists, `--expect` too).
+- `layout` reports no issue on any step.
+- `explain` reads as the explanation you meant — every beat has a caption
+  that says *why*, not only what moved.
+- For a still: both canvas sides under 2000px (the canvas ⚠ in `check`),
+  and you looked at the SVG once.
+
+## Reading the kickbacks
+
+- **The canvas warning names its cause.** "labels stop being legible — A
+  (206px, in G1) and B (53px, in G2) need 142px between their centres … and
+  the layout put them 10% of the width apart", then "N containers sit side by
+  side across the picture (a 40%, b 10%, …), each as wide as its fullest
+  layer's boxes". The lever is the named pair or the banding — flatten or
+  re-nest the containers, break the named label — not the longest label you
+  can see. `why` has every layer, band and detour; two writers who read it
+  before their first edit brought an 8882px graph under 2000px.
+- **A crossing names the edge by its ends** (`edge-24: diff → capture`) and
+  the box it runs through. Move one end to another layer (reorder the list,
+  regroup) or shorten *that* label.
+- **"no sequence" on a `diagram`** means the picture, not the motion, is the
+  point: switch to `kind: modules`. The switch changes layering (a diagram
+  layers one past what points into a box; a module map layers from its
+  leaves), so re-run `check` and read the new canvas line.
+- **`--expect` lines** are the facts the picture got wrong: a dependency
+  drawn that the sheet does not list, one listed and not drawn, the wrong
+  edge highlighted. A green `check` on a wrong picture is the failure this
+  exists for — the sheet wins over the picture.
+- **`import mermaid` `dropped / changed:`** names what the IR has no place
+  for (styles, classDefs, clicks, `direction` inside a subgraph, composite
+  states). Colour with `tone`; everything else you put back as captions.
+
+## Rules the checks enforce (do not fight them)
+
+- No coordinates in a scene that has a kind for its things. `kind: vector`
+  and hand-written positions are the fallback and are counted as such.
+- Every annotation names an anchor the kind owns (an index, a cell, a node,
+  an edge), and asks for a `side`; the compiler grows the canvas on that
+  side and routes the pointer round labelled boxes. Record asked vs landed
+  if it matters.
+- Labels may be any script; boxes are sized per glyph (CJK is one em). Ids
+  stay ASCII.
+- A dependency cycle in `modules` is a warning, drawn — name the cut in a
+  caption or mark one edge `"style": "forbidden"`.
+- A scene in a ```` ```vlm-anim ```` fence is checked the same way; a fence
+  that does not compile renders as a visible `<pre>` with the check's lines.
+
+## Outputs at a glance
+
+| File | Verb | Consumer |
+|---|---|---|
+| `scene.json` (or `scene.ts` exporting `scene.<kind>({…})`) | you | the repo — this is what is edited later |
+| `fig.svg` / `fig.png` | `still` | docs, a README, a slide |
+| `page.html` | `html` | a browser; `vlmkit check animation page.html` and `vlmkit-anim eval` measure it |
+| `demo.gif` / `.mp4` / `.webm` | `video` | a README or PR comment |
+| `*.expect.json` | `facts`, `repo`, by hand | `check --expect`; the truth the picture is held to |
+| `<name>.sheet.png`, `<name>.review-brief.md`, `<name>.review-score.md` | `review` | a vision model or a second agent, and its score |
+
+## Failure modes
+
+- `.png`, `sheet`, `video --out x.mp4`, `eval` fail with a browser error →
+  Playwright is missing; `.svg`, `.gif` and `sheet --out sheet.html` need no
+  browser.
+- In this repo the CLI shows old behaviour after editing `packages/vlmkit-anim/src/` →
+  `pnpm --filter @mizchi/vlmkit-anim build` (never piped to `head`), or run from source.
+- Every round shortens a label and the canvas does not move → the label was
+  not the binding one; read the canvas line and `why`.
+- A `modules` map has a dependency the code does not → the sheet from
+  `facts` catches it; a map drawn from memory is checked against the code,
+  not the other way round.
+- `check` is green, the figure is wrong → write the fact sheet. That is the
+  whole reason `--expect` exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ Dates are YYYY-MM-DD.
   `diagram` to `modules` changes the layering rule (forward from what points at a box vs backward from what it
   depends on) and can move the widest layer (qa, v24: 4615px → 7031px on the kind change alone).
 - Report: `docs/reports/2026-09-09-anim-ir-v24.md`.
+- **Skill `explanatory-animation`** (`.claude/skills/`, bundled into the `vlmkit` router as its fourteenth
+  workflow): the agent-facing playbook for `vlmkit-anim` — route by task (animate a kind, explain a concept
+  with annotations, draw a module map held to a fact sheet, draw the repository or a branch, diff two maps,
+  import mermaid, embed), the write → `check` → `explain` → `layout` → `why` → `still` / `html` / `video` loop,
+  the done condition, and how to read the canvas, crossing, `--expect` and `dropped / changed:` lines.
+  `agent-validation-loop` gains the anim-ir run (24 rounds, 86 attempts) as a second reference: the docs as
+  the only input, a fact sheet as the success criterion, two unlike measurements compared, "what told you"
+  per round, two model sizes per brief, a corpus check on every compiler change.
 
 ## 0.22.0 — 2026-09-09
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ the snapshot, workflow, and diff-pr sections.
 
 ## Agent Skills (APM)
 
-vlmkit ships thirteen coding-agent skills under `.claude/skills/`. They wrap
+vlmkit ships fourteen coding-agent skills under `.claude/skills/`. They wrap
 the most common workflows as standalone, agent-readable playbooks.
 Other repos can install them via [APM](https://agentskills.io):
 
@@ -168,6 +168,7 @@ apm install mizchi/vlmkit/.claude/skills/vrt-visual-diff
 | `markup-decompose` | routes `contract introspect` → `auto-markup` → `check story` | Whole screen: decide the component split, then freeze each part as a baseline |
 | `component-vrt` | `vlmkit check story --gallery <url>` | Repair one component with a component-sized diff; includes gallery templates (vanilla / React / Vue) |
 | `agent-validation-loop` | disposable subagent runs → friction → fix → re-run | Harden a CLI/library by measuring whether agents can drive it |
+| `explanatory-animation` | `vlmkit-anim check\|layout\|why\|still\|html\|video`, `import mermaid`, `facts`, `diff`, `repo`, `pr` | Explain an algorithm, protocol or architecture as a checked animation or still figure; draw a module map held to its facts (separate binary `@mizchi/vlmkit-anim`) |
 
 Each skill assumes the `vlmkit` CLI is on `$PATH` (this repo published as
 a Node package, or built from source) and Node 24+. VLM-using skills

--- a/examples/vlmkit-intro-page/content.js
+++ b/examples/vlmkit-intro-page/content.js
@@ -124,7 +124,7 @@ export const messages = Object.freeze({
     "skills.line2": "あとは自然に頼むだけ。",
     "skills.lead":
       "vlmkit をひとつ追加すれば、スキル名を覚える必要はありません。作りたい結果を伝えると、AI が依頼と素材を分類し、必要なワークフローを読み込んで、検証が通るまで実行します。",
-    "skills.note": "1 インストール · 自動ルーティング · 13 ワークフロー",
+    "skills.note": "1 インストール · 自動ルーティング · 14 ワークフロー",
     "skills.metaLabel": "メタエントリー",
     "skills.metaDescription":
       "フロントエンドの依頼で自動的に起動し、専門ワークフローを選択。利用者にスキル選択を求めず、CLI と Chromium も必要になった時だけ準備します。",
@@ -147,7 +147,10 @@ export const messages = Object.freeze({
     "skills.evaluateTitle": "評価と改善",
     "skills.evaluateDescription":
       "既知の CSS 回帰に対する修復性能と、エージェント向けツール自体の使いやすさを検証。",
-    "skills.catalogLink": "13スキルの詳しい選択ガイドを見る",
+    "skills.explainTitle": "説明と図",
+    "skills.explainDescription":
+      "アルゴリズムやプロトコルの動きをアニメーションにし、モジュール構成やアーキテクチャの図を描き、その絵を事実とレイアウトで検証。",
+    "skills.catalogLink": "14スキルの詳しい選択ガイドを見る",
     "skills.apmLabel": "APM でインストール",
     "skills.apmDescription":
       "公式 bootstrap で APM を導入または更新してから、自動ルーターをプロジェクトへひとつ追加します。",
@@ -286,7 +289,7 @@ export const messages = Object.freeze({
     "skills.line2": "Ask naturally.",
     "skills.lead":
       "Add vlmkit once—there are no skill names to learn. Describe the outcome, and the AI classifies the request and artifacts, loads the right workflow, and runs it until the checks pass.",
-    "skills.note": "1 install · automatic routing · 13 workflows",
+    "skills.note": "1 install · automatic routing · 14 workflows",
     "skills.metaLabel": "Meta entry",
     "skills.metaDescription":
       "Activates automatically for frontend work and selects the matching workflow. It never asks you to pick a skill, and prepares the CLI and Chromium only when needed.",
@@ -309,7 +312,10 @@ export const messages = Object.freeze({
     "skills.evaluateTitle": "Evaluation and hardening",
     "skills.evaluateDescription":
       "Measure repair performance on known CSS regressions and improve agent-facing tool usability.",
-    "skills.catalogLink": "Open the detailed guide to all 13 skills",
+    "skills.explainTitle": "Explanation and figures",
+    "skills.explainDescription":
+      "Animate how an algorithm or protocol works, draw a module or architecture map, and hold the picture to its facts and layout.",
+    "skills.catalogLink": "Open the detailed guide to all 14 skills",
     "skills.apmLabel": "Install with APM",
     "skills.apmDescription":
       "Install or update APM with its official bootstrap, then add the single automatic router.",

--- a/examples/vlmkit-intro-page/copy.txt
+++ b/examples/vlmkit-intro-page/copy.txt
@@ -75,6 +75,8 @@ vrt-migration-eval
 Evaluation and hardening
 vrt-css-fix-loop
 agent-validation-loop
+Explanation and figures
+explanatory-animation
 Install with APM
 curl -sSL https://aka.ms/apm-unix | sh
 apm install mizchi/vlmkit

--- a/examples/vlmkit-intro-page/index.html
+++ b/examples/vlmkit-intro-page/index.html
@@ -385,7 +385,7 @@
               <span data-i18n="skills.line2">Ask naturally.</span>
             </h2>
             <p data-i18n="skills.lead">Add vlmkit once—there are no skill names to learn. Describe the outcome, and the AI classifies the request and artifacts, loads the right workflow, and runs it until the checks pass.</p>
-            <p class="skills-note"><span>ROUTER</span> <span data-i18n="skills.note">1 install · automatic routing · 11 workflows</span></p>
+            <p class="skills-note"><span>ROUTER</span> <span data-i18n="skills.note">1 install · automatic routing · 14 workflows</span></p>
           </div>
 
           <div class="skills-directory">
@@ -445,9 +445,17 @@
                   </div>
                   <p class="skill-names"><code>vrt-css-fix-loop</code><code>agent-validation-loop</code></p>
                 </article>
+                <article class="skill-category">
+                  <div>
+                    <p class="skill-manager">06 / EXPLAIN</p>
+                    <h3 data-i18n="skills.explainTitle">Explanation and figures</h3>
+                    <p data-i18n="skills.explainDescription">Animate how an algorithm or protocol works, draw a module or architecture map, and hold the picture to its facts and layout.</p>
+                  </div>
+                  <p class="skill-names"><code>explanatory-animation</code></p>
+                </article>
               </div>
 
-              <a class="skill-catalog-link" href="https://github.com/mizchi/vlmkit/tree/main/.claude/skills"><span data-i18n="skills.catalogLink">Open the detailed guide to all 13 skills</span> <span aria-hidden="true">↗</span></a>
+              <a class="skill-catalog-link" href="https://github.com/mizchi/vlmkit/tree/main/.claude/skills"><span data-i18n="skills.catalogLink">Open the detailed guide to all 14 skills</span> <span aria-hidden="true">↗</span></a>
             </div>
 
             <div class="skill-installers" data-testid="skill-installers">

--- a/examples/vlmkit-intro-page/page.test.mjs
+++ b/examples/vlmkit-intro-page/page.test.mjs
@@ -15,6 +15,7 @@ const specializedSkills = [
   "auto-markup",
   "component-vrt",
   "dynamic-markup",
+  "explanatory-animation",
   "markup-assist",
   "markup-decompose",
   "mock-markup",

--- a/skills/vlmkit/SKILL.md
+++ b/skills/vlmkit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vlmkit
-description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
+description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression — and whenever they ask to animate, illustrate or diagram how something works, or to draw a module, dependency or architecture map. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
 ---
 
 # vlmkit — Skill Router and CLI Guide
@@ -105,6 +105,7 @@ second only when the task genuinely crosses boundaries.
 | Evaluate a framework/CSS/build migration | `./workflows/vrt-migration-eval/SKILL.md` | Judge visual equivalence despite large intentional rewrites |
 | Benchmark known CSS repair challenges | `./workflows/vrt-css-fix-loop/SKILL.md` | Measure VLM+LLM recovery, not production healing |
 | Harden an agent-facing CLI, SDK, or harness | `./workflows/agent-validation-loop/SKILL.md` | Turn fresh-agent friction into fixes and tracked evidence |
+| Explain an algorithm, protocol or architecture as an animation or a still figure; draw a module / dependency map; import a mermaid diagram | `./workflows/explanatory-animation/SKILL.md` | Write one checked `vlmkit-anim` scene, hold it to its facts and layout, emit a page, GIF or cropped figure (separate binary: `@mizchi/vlmkit-anim`) |
 
 The human-facing catalog, direct install commands, and category rationale are
 in the [vlmkit skill catalog](https://github.com/mizchi/vlmkit/tree/main/.claude/skills).

--- a/skills/vlmkit/workflows/agent-validation-loop/SKILL.md
+++ b/skills/vlmkit/workflows/agent-validation-loop/SKILL.md
@@ -354,3 +354,52 @@ agent-g regressing on a class of bug (typographic cascade) that the
 existing signal hierarchy couldn't classify — the new REFLOW tag
 closed it, and post-REFLOW runs (h, i) converged within
 the budget.
+
+## Second reference run: an IR judged by its writers (anim-ir v1–v24)
+
+`vlmkit-anim` (the `explanatory-animation` skill) was built with this loop
+from its first day: 24 rounds over six days, 86 writer attempts (`a`…`qb`),
+reports `docs/reports/2026-09-0{4..9}-anim-ir-v*.md`, fixture
+`fixtures/anim-scenario/`. The tool under test is a **format** an agent
+writes, not a signal it reads, and that changed five things about the loop.
+They are worth copying whenever the deliverable is "an agent gets it right
+from the docs alone".
+
+- **The docs are the only input.** Each writer gets one brief and one guide
+  (`docs/anim-ir.md`) and is forbidden the package source, other attempts,
+  the reports and the CHANGELOG — by path, in the prompt. A writer who reads
+  the compiler is measuring their own reading, not the guide. Every JSON
+  block in the guide is compiled by a test, so the guide cannot drift from
+  the tool it describes.
+- **The success criterion is a fact sheet, not a green check.** Round 13 had
+  five green module maps and two of them were wrong (a true dependency
+  deleted, the wrong edge lit). From round 14 every brief ships
+  `facts/<brief>.expect.json` and success is `check --expect` exiting 0;
+  from round 18 the tool writes the sheet itself from the code
+  (`vlmkit-anim facts`). Whatever your tool draws or emits: find the ground
+  truth it can be held to and make the check read it, or a clean run proves
+  nothing.
+- **Two measurements, then compare them.** Geometry (`layout`) said the
+  frames were clean; vision readers on the same frames (round 12, and round
+  21 on stills) found lines through labels, containers crossing, a corner
+  label read as a caption. Each disagreement was a defect one side could not
+  see, and each became a rule in the cheaper measurement. A second, unlike
+  reader is how you learn what your first one is blind to.
+- **Ask for "what told you", per round.** From round 24 the log asks the
+  writer to quote the line — a `check` line, a `why` line, the picture, a
+  guess — that made them change what they changed. Two writers quoted the
+  same `why` line before their first edit; both then asked for it in the
+  warning itself, which is where it now is. The quote locates the fix in the
+  tool's output, not in the writer's head.
+- **Run two model sizes on the same brief.** A smaller model (haiku) beside
+  a larger one (sonnet) on the same brief, from round 14 on: the smaller one
+  hits the gaps in the guide the larger one reads past, and a fix that only
+  the larger model can use is not a fix. When the two converge on the same
+  lever from the same line, the tool said it.
+
+Two habits from this run that the ten steps above assume but do not say:
+a **corpus check** on every compiler change (`layout` over every fixture and
+attempt, diffed against the previous round's baseline — a fix for one
+writer's scene has regressed another's more than once), and a report that
+**names the next round** in its last paragraph, so the list the user gave
+and the list the evidence gives can be compared before either is started.

--- a/skills/vlmkit/workflows/explanatory-animation/SKILL.md
+++ b/skills/vlmkit/workflows/explanatory-animation/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: explanatory-animation
+description: Explain an algorithm, protocol, data structure, state machine, or architecture as a checked animation or still figure with `vlmkit-anim` — one JSON scene (a `kind` plus intent, never coordinates) compiled to SVG + Web Animations, a GIF, or a cropped figure, and checked against what it claims (semantic checks, `layout` geometry, a fact sheet with `--expect`, `why` for the layout's own reasons). Also draws a module map from a directory's import graph, a repository's architecture, the change map of a branch, the diff of two maps, and imports mermaid the repo already has. Use when asked to animate, illustrate, diagram, draw a dependency / module / architecture map, explain how something works step by step, or embed such a figure in docs. Not a VRT gate — `vlmkit-anim` is its own binary (`@mizchi/vlmkit-anim`).
+metadata:
+  internal: true
+---
+
+# explanatory-animation
+
+One file says **what is being explained**; the tool draws it, and then
+checks that the picture says what the file claims. The writer's job is the
+scene and the captions. The tool's job is layout, motion, and telling the
+writer where the picture lies.
+
+```json
+{ "format": "vlmkit-anim/scene@1", "kind": "sort", "algorithm": "bubble", "values": [5, 3, 8, 1] }
+```
+
+Two layers: a **Scene** (`kind` + intent — `"algorithm": "bubble"`,
+`"trace": ["connect", "SYN+ACK"]`, `"deps": [["web", "api"]]`, never x / y)
+compiles to a **Timeline** (nodes, keyframe tracks, captioned steps). Write
+the scene; read the timeline only through the verbs below.
+
+**The one page to read before writing is `docs/anim-ir.md`** (in this repo)
+— every kind, its ops, the annotation ops every kind shares, and one JSON
+example per kind that `check` passes. `vlmkit-anim schema --kind <k>` prints
+one kind's section. Do not learn the format from the compiler source.
+
+## Invocation
+
+`vlmkit-anim` is a **standalone binary**, not a `vlmkit` subcommand.
+
+```bash
+# this repository
+pnpm exec vlmkit-anim check scene.json                      # dist/ — run `pnpm --filter @mizchi/vlmkit-anim build` after editing src/
+node --experimental-strip-types packages/vlmkit-anim/src/cli.ts check scene.json   # no build
+
+# any other repository
+npx -p @mizchi/vlmkit-anim vlmkit-anim check scene.json     # or add @mizchi/vlmkit-anim as a dev dependency
+```
+
+Nothing below needs a browser or an API key except: `.png` output, `sheet`,
+`video`, `eval` (Playwright), and `review --model` (a vision model through
+`@mizchi/vlmkit-ai`). Writing and checking a scene is browser-free.
+
+## Route by task
+
+| Task shape | Do this |
+|---|---|
+| "Animate / show step by step how X works" (a sort, search, BST, heap, DP table, graph walk, state machine, message exchange, flowchart, gantt) | Pick the `kind` whose section in the guide names X; write the scene; run the loop below. Nineteen kinds: sort, array, stack, queue, list, tree, state-machine, heap, distributed, matrix, graph, chart, flowchart, gantt, sequence, diagram, modules, vector, compose. |
+| "Explain a concept" that no kind names | Choose the kind whose *things* the concept has (nodes exchanging messages → `distributed`; a table filling in → `matrix`); say the rest with annotation ops (`value`, `callout`, `snapshot`, `group`, `text`, `relate`) that name the kind's things. Two pictures at once → `kind: compose`. Coordinates are the last resort, and count against the scene. |
+| "Draw a module / dependency / architecture map" | `kind: modules` with `modules`, `deps` (`["a", "b"]` reads "a depends on b"), `groups`, optional `parent` on a group; `still` renders it. When the code exists, first `vlmkit-anim facts <dir> --depth 1 --out f.expect.json`, then `check --expect` the map against it. |
+| "Draw this repository" | `vlmkit-anim repo --out docs/diagrams --name <name>` — the workspace layer by layer, a GIF, a contact sheet, a Markdown page and its own fact sheet. |
+| "What does this branch change?" | `vlmkit-anim pr --base origin/main --out .vlmkit-anim/pr` — one beat per commit; `<name>.md` is paste-ready. |
+| "Show what changed between two maps" | `vlmkit-anim diff before.json after.json --out change.svg [--expect diff.json]` — added in accent, removed dashed grey, a legend; `--expect` checks the change against a diff sheet. |
+| "We already have a mermaid diagram" | `vlmkit-anim import mermaid page.md --out scene.json` (flowchart / graph, sequenceDiagram, stateDiagram-v2). Read its `dropped / changed:` and `notes:` lines; add what the import cannot know (a title, captions, a walk or trace). |
+| "Put it in the docs" | `html --out page.html` (runtime inline), `video --out demo.gif` for a README, or the remark plugin `@mizchi/vlmkit-anim/remark` so a ```` ```vlm-anim ```` fence in Markdown becomes the animation and ```` ```vlm-anim still ```` the figure. |
+
+## The loop
+
+```
+1. write scene.json                                  one kind; ids ASCII, language in `label`
+2. vlmkit-anim check scene.json [--expect facts.json] validate → compile → semantic checks → stats; exit 1 on ✗
+3. vlmkit-anim explain scene.json                    the narration as a numbered list — is this the story?
+4. vlmkit-anim layout scene.json                     texts on texts, under boxes, past the edge, lines through
+                                                     labels, containers crossing — per step; exit 1 when any
+5. vlmkit-anim why scene.json [--about id]           (modules / diagram) what set each canvas axis, rows vs bands
+                                                     and their share, what put each box on its layer, which box
+                                                     a bent edge went round — read this BEFORE relabelling
+6. vlmkit-anim still scene.json --out fig.svg        the figure  |  html --out page.html  |  video --out demo.gif
+7. vlmkit-anim review scene.json --out dir           optional: a contact sheet + brief for a vision reader;
+                                                     --answers scores its JSON against the geometry / the facts
+```
+
+Each ✗ line names a path, what is wrong, and a `→` hint with the fix. Fix
+the first ✗, re-run; ⚠ lines are advice you act on only when they touch
+what the picture is for. Budget five rounds; if the fifth is not green,
+stop and report the lines, not a guess.
+
+## Done condition
+
+- `check` exits 0 with no ✗ (and, when a fact sheet exists, `--expect` too).
+- `layout` reports no issue on any step.
+- `explain` reads as the explanation you meant — every beat has a caption
+  that says *why*, not only what moved.
+- For a still: both canvas sides under 2000px (the canvas ⚠ in `check`),
+  and you looked at the SVG once.
+
+## Reading the kickbacks
+
+- **The canvas warning names its cause.** "labels stop being legible — A
+  (206px, in G1) and B (53px, in G2) need 142px between their centres … and
+  the layout put them 10% of the width apart", then "N containers sit side by
+  side across the picture (a 40%, b 10%, …), each as wide as its fullest
+  layer's boxes". The lever is the named pair or the banding — flatten or
+  re-nest the containers, break the named label — not the longest label you
+  can see. `why` has every layer, band and detour; two writers who read it
+  before their first edit brought an 8882px graph under 2000px.
+- **A crossing names the edge by its ends** (`edge-24: diff → capture`) and
+  the box it runs through. Move one end to another layer (reorder the list,
+  regroup) or shorten *that* label.
+- **"no sequence" on a `diagram`** means the picture, not the motion, is the
+  point: switch to `kind: modules`. The switch changes layering (a diagram
+  layers one past what points into a box; a module map layers from its
+  leaves), so re-run `check` and read the new canvas line.
+- **`--expect` lines** are the facts the picture got wrong: a dependency
+  drawn that the sheet does not list, one listed and not drawn, the wrong
+  edge highlighted. A green `check` on a wrong picture is the failure this
+  exists for — the sheet wins over the picture.
+- **`import mermaid` `dropped / changed:`** names what the IR has no place
+  for (styles, classDefs, clicks, `direction` inside a subgraph, composite
+  states). Colour with `tone`; everything else you put back as captions.
+
+## Rules the checks enforce (do not fight them)
+
+- No coordinates in a scene that has a kind for its things. `kind: vector`
+  and hand-written positions are the fallback and are counted as such.
+- Every annotation names an anchor the kind owns (an index, a cell, a node,
+  an edge), and asks for a `side`; the compiler grows the canvas on that
+  side and routes the pointer round labelled boxes. Record asked vs landed
+  if it matters.
+- Labels may be any script; boxes are sized per glyph (CJK is one em). Ids
+  stay ASCII.
+- A dependency cycle in `modules` is a warning, drawn — name the cut in a
+  caption or mark one edge `"style": "forbidden"`.
+- A scene in a ```` ```vlm-anim ```` fence is checked the same way; a fence
+  that does not compile renders as a visible `<pre>` with the check's lines.
+
+## Outputs at a glance
+
+| File | Verb | Consumer |
+|---|---|---|
+| `scene.json` (or `scene.ts` exporting `scene.<kind>({…})`) | you | the repo — this is what is edited later |
+| `fig.svg` / `fig.png` | `still` | docs, a README, a slide |
+| `page.html` | `html` | a browser; `vlmkit check animation page.html` and `vlmkit-anim eval` measure it |
+| `demo.gif` / `.mp4` / `.webm` | `video` | a README or PR comment |
+| `*.expect.json` | `facts`, `repo`, by hand | `check --expect`; the truth the picture is held to |
+| `<name>.sheet.png`, `<name>.review-brief.md`, `<name>.review-score.md` | `review` | a vision model or a second agent, and its score |
+
+## Failure modes
+
+- `.png`, `sheet`, `video --out x.mp4`, `eval` fail with a browser error →
+  Playwright is missing; `.svg`, `.gif` and `sheet --out sheet.html` need no
+  browser.
+- In this repo the CLI shows old behaviour after editing `packages/vlmkit-anim/src/` →
+  `pnpm --filter @mizchi/vlmkit-anim build` (never piped to `head`), or run from source.
+- Every round shortens a label and the canvas does not move → the label was
+  not the binding one; read the canvas line and `why`.
+- A `modules` map has a dependency the code does not → the sheet from
+  `facts` catches it; a map drawn from memory is checked against the code,
+  not the other way round.
+- `check` is green, the figure is wrong → write the fact sheet. That is the
+  whole reason `--expect` exists.

--- a/tests/skill-package.test.mjs
+++ b/tests/skill-package.test.mjs
@@ -22,6 +22,7 @@ const workflows = [
   "auto-markup",
   "component-vrt",
   "dynamic-markup",
+  "explanatory-animation",
   "markup-assist",
   "markup-decompose",
   "mock-markup",


### PR DESCRIPTION
## Summary

`vlmkit-anim` had no skill: 24 evaluation rounds and none of it reachable from the `vlmkit` router. This adds one and updates the loop skill it was built with.

- **New `.claude/skills/explanatory-animation/SKILL.md`** — the agent-facing playbook for writing a scene: route by task (animate a kind, explain a concept with annotation ops, draw a module map held to a fact sheet, draw the repository or a branch's change, diff two maps, import mermaid, embed), the write → `check` → `explain` → `layout` → `why` → `still` / `html` / `video` loop, the done condition, how to read `check`'s canvas and crossing lines, `--expect` and `import mermaid`'s `dropped / changed:` list, and the failure modes the v13–v24 writers hit. Points at `docs/anim-ir.md` as the one page to read.
- **`agent-validation-loop`** gains the anim-ir run (24 rounds, 86 attempts) as a second reference: the docs as the only input, a fact sheet as the success criterion, two unlike measurements compared, "what told you" per round, two model sizes on one brief, a corpus check on every compiler change.
- Router `skills/vlmkit/SKILL.md`: description covers animate / illustrate / diagram / architecture map; a fourteenth routing row. `.claude/skills/README.md` gets an "Explanation and figures" class and selection rule (its "11 workflows" was already stale at 13).
- Intro page: a sixth skill category in both locales, counts 11 / 13 → 14, copy manifest; `docs/configuration.md` table row; `CLAUDE.md` pointer; the two tests that pin the workflow list; `pnpm sync:skills` re-run; a CHANGELOG bullet under 0.23.0 (no version bump — docs and skills only).

## Test plan

- [x] `pnpm sync:skills` → 14 workflows
- [x] `vitest run tests/skill-package.test.mjs examples/vlmkit-intro-page/page.test.mjs examples/vlmkit-intro-page/site-links.test.mjs tests/workflow-commands.test.mjs src/cli/version.test.ts` green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpysLZjCrixyaunTWzmqHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpysLZjCrixyaunTWzmqHY)_