### PR TITLE
skills: `explain-with-anim` — answer a question with a figure drawn from the code

### DIFF
--- a/.apm/skills/vlmkit/SKILL.md
+++ b/.apm/skills/vlmkit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vlmkit
-description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression — and whenever they ask to animate, illustrate or diagram how something works, or to draw a module, dependency or architecture map. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
+description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression — and whenever they ask to explain, walk through, animate, illustrate or diagram how something works, or to draw a module, dependency or architecture map. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
 ---
 
 # vlmkit — Skill Router and CLI Guide
@@ -105,7 +105,8 @@ second only when the task genuinely crosses boundaries.
 | Evaluate a framework/CSS/build migration | `./workflows/vrt-migration-eval/SKILL.md` | Judge visual equivalence despite large intentional rewrites |
 | Benchmark known CSS repair challenges | `./workflows/vrt-css-fix-loop/SKILL.md` | Measure VLM+LLM recovery, not production healing |
 | Harden an agent-facing CLI, SDK, or harness | `./workflows/agent-validation-loop/SKILL.md` | Turn fresh-agent friction into fixes and tracked evidence |
-| Explain an algorithm, protocol or architecture as an animation or a still figure; draw a module / dependency map; import a mermaid diagram | `./workflows/explanatory-animation/SKILL.md` | Write one checked `vlmkit-anim` scene, hold it to its facts and layout, emit a page, GIF or cropped figure (separate binary: `@mizchi/vlmkit-anim`) |
+| Answer "how does this work / how is it structured / what does this change" with a figure drawn from the code and a narration that walks it | `./workflows/explain-with-anim/SKILL.md` | Choose the picture from the question, ground it in `facts` / `repo` / `pr`, check it, deliver SVG or GIF with beat-by-beat prose |
+| Write an animation or still figure as the deliverable: an algorithm, protocol or architecture; a module / dependency map; a mermaid import | `./workflows/explanatory-animation/SKILL.md` | Write one checked `vlmkit-anim` scene, hold it to its facts and layout, emit a page, GIF or cropped figure (separate binary: `@mizchi/vlmkit-anim`) |
 
 The human-facing catalog, direct install commands, and category rationale are
 in the [vlmkit skill catalog](https://github.com/mizchi/vlmkit/tree/main/.claude/skills).

--- a/.apm/skills/vlmkit/workflows/explain-with-anim/SKILL.md
+++ b/.apm/skills/vlmkit/workflows/explain-with-anim/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: explain-with-anim
+description: Answer "how does this work / how is this structured / what does this change" with a drawn figure and a narration that follows it — a module map from the code's own imports, a walked request, a state machine, an algorithm step by step, the change map of a branch — produced with `vlmkit-anim`, checked against the facts it draws, and delivered as an SVG / GIF next to the prose. Use whenever the user asks to explain, walk through, show the structure of, or illustrate code, a repository, a flow, a protocol, a PR, or a bug, and a picture with four or more things and their relations would carry the answer better than a paragraph. The explanation is the deliverable; the picture is its evidence. Scene mechanics are in `explanatory-animation`.
+metadata:
+  internal: true
+---
+
+# explain-with-anim
+
+The user asked a question. Answer it with a picture and the words that walk
+the picture — not a picture instead of an answer, and not a paragraph with
+a decorative diagram after it. The figure is drawn from the code (or the
+facts) by `vlmkit-anim`, checked, and delivered as a file; the prose follows
+the figure beat by beat and names the things in it by their ids.
+
+Read `explanatory-animation` for how to write and check a scene. This skill
+is about **what to draw, from what, and how to explain with it**.
+
+## First: does a picture help?
+
+Draw when the answer has **things and relations** — four or more modules,
+states, participants, steps — or an **order in time**, or a **before and
+after**. Do not draw for a one-line answer, a single function's body, or a
+question about a value. If in doubt, write the answer first; if it needs a
+list of more than four named things that point at each other, draw them.
+
+## Choose the picture from the question
+
+| The user asks… | Draw | From |
+|---|---|---|
+| "How is this repo / package / directory structured?" | `kind: modules` — a module map, containers per area | `vlmkit-anim facts <dir> --depth 1 --out f.expect.json` (the import graph), then the map, then `check --expect f.expect.json`; for the whole workspace `vlmkit-anim repo --out <dir>` draws it and writes its own sheet |
+| "How does a request / event / message flow through it?" | `modules` with a `sequence` that walks the path (`highlight`, `flow`), or `kind: sequence` when the participants and their calls are the point | the code path you read; the map from `facts`; each hop a beat with a caption saying why |
+| "How does this algorithm / data structure work?" | the kind that owns it: `sort`, `array`, `tree`, `heap`, `stack`, `queue`, `list`, `matrix`, `graph` | the function's own steps; small concrete values (five to eight) so every beat is readable |
+| "What states can this be in? What happens on X?" | `kind: state-machine` with a `trace` of the events that matter | the enum / reducer / status field and its transitions |
+| "How do these services talk? What if one is slow / lost?" | `kind: distributed` (nodes, messages, a lost one) or `kind: sequence` (frames for retry / alt) | the protocol as implemented; the failure the user asked about as the trace |
+| "Why does it go this way here?" (a decision) | `kind: flowchart` with the walked path | the branch conditions, as their labels |
+| "What does this branch / PR change?" | `vlmkit-anim pr --base origin/main --out .vlmkit-anim/pr` — one beat per commit; or `vlmkit-anim diff before.json after.json` for two maps | git; `<name>.md` is paste-ready |
+| "What is the schedule / what slipped?" | `kind: gantt` | the plan, the slips as `slip` ops |
+| "The docs already have a mermaid diagram" | `vlmkit-anim import mermaid page.md --out scene.json`, then finish it | the diagram; read its `dropped / changed:` list |
+
+One picture per question. Two aspects that both matter (structure and a
+walk) are one `modules` scene with a `sequence`, or `kind: compose` — not
+two files.
+
+## Ground it in the source, not in memory
+
+- A map of code is drawn from the code: `facts` for a directory, `repo` for
+  the workspace, the import list or `package.json` files by hand when
+  neither fits. Then `check --expect`. A map drawn from memory and not
+  checked is a guess with a border round it.
+- A walk is drawn from the path you read: cite the file and function each
+  beat corresponds to in the caption or in the prose ("`handle()` in
+  `router.ts` → `dispatch`").
+- Anything you could not verify goes in the prose as "not drawn: …", never
+  in the picture.
+
+## Produce
+
+```
+1. write <name>.scene.json            in the repo's docs/ or .vlmkit-anim/, or the scratch dir if it is not to be kept
+2. vlmkit-anim check <name>.scene.json [--expect <name>.expect.json]
+3. vlmkit-anim layout <name>.scene.json               must report no issue; `why` when the canvas warning names a pair
+4. vlmkit-anim still <name>.scene.json --out <name>.svg      a still (structure, a map, a state diagram)
+   vlmkit-anim video <name>.scene.json --out <name>.gif --width 640   a walk (a request, an algorithm, a trace)
+5. vlmkit-anim explain <name>.scene.json              the beats — this is the skeleton of your prose
+```
+
+Five rounds of edit → `check` at most. If it is not clean by then, deliver
+the explanation in words, say the figure did not converge and which line
+stopped it, and keep the scene file for the reader.
+
+## Write the explanation
+
+1. **One sentence of what the picture is** and what it was drawn from
+   ("the packages under `packages/`, from their imports, 12 modules, 19
+   dependencies").
+2. **The beats, in order**, one short paragraph or bullet each, reworded
+   from `explain` — say *why* at each step, not what moved. Name things by
+   the ids in the picture so the reader can find them.
+3. **What the picture leaves out** and where to read it (a file, a
+   function, a config).
+4. **The files**: the SVG / GIF path, the scene, the fact sheet.
+
+Do not describe the picture's geometry ("on the left", "the blue box") —
+layout is the compiler's and may move on the next edit. Say the id.
+
+## Deliver
+
+- In a chat: the prose, then the figure as a file the user can open
+  (`SendUserFile` when available; otherwise the path). A GIF for a walk,
+  an SVG for a structure.
+- In a PR or issue: paste the `<name>.md` that `pr` / `repo` write, or the
+  figure with the beats under it. `vlmkit-anim pr` already runs on every
+  same-repo PR through the `pr-visual` workflow; do not post a second one.
+- In docs: a ```` ```vlm-anim ```` fence (the animation) or ```` ```vlm-anim still ````
+  (the figure) with the scene inline, so the page stays checkable; or the
+  SVG committed next to the page.
+
+## Done condition
+
+- `check` green (and `--expect` green when a sheet exists), `layout` clean.
+- Every id named in the prose is in the picture, and every beat in the
+  prose is a step in `explain`.
+- The user can answer their own question from the figure alone; the prose
+  says why each step is there.
+
+## Anti-patterns
+
+- **A figure after the answer, unreferenced.** If the prose never names an
+  id from the picture, the picture is decoration; drop it or rewrite.
+- **Drawing what you believe the structure is.** Run `facts` first. Two of
+  five green module maps in one evaluation round were wrong about a real
+  dependency.
+- **Coordinates.** A scene with x / y is a drawing, not an explanation, and
+  cannot be re-edited by the next reader. Use the kind that owns the things.
+- **Twelve beats where four would do.** Pick the values and the trace that
+  show the one mechanism the question is about.
+- **Skipping `layout` because `check` was green.** Lines through labels are
+  what a reader sees first.

--- a/.apm/skills/vlmkit/workflows/explanatory-animation/SKILL.md
+++ b/.apm/skills/vlmkit/workflows/explanatory-animation/SKILL.md
@@ -21,6 +21,11 @@ Two layers: a **Scene** (`kind` + intent — `"algorithm": "bubble"`,
 compiles to a **Timeline** (nodes, keyframe tracks, captioned steps). Write
 the scene; read the timeline only through the verbs below.
 
+When the task is to *answer a question* with a figure — "how does this
+work", "how is this structured", "what does this PR change" — `explain-with-anim`
+decides what to draw, from what, and how the prose follows it; this skill is
+how the scene itself is written and checked.
+
 **The one page to read before writing is `docs/anim-ir.md`** (in this repo)
 — every kind, its ops, the annotation ops every kind shares, and one JSON
 example per kind that `check` passes. `vlmkit-anim schema --kind <k>` prints

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -176,10 +176,13 @@ with `pnpm anim:samples` after changing a compiler. In this repo run it as
 `pnpm exec vlmkit-anim …` (resolves to `dist/`, so `pnpm --filter @mizchi/vlmkit-anim build`
 after editing `src/`) or, without a build, `node --experimental-strip-types packages/vlmkit-anim/src/cli.ts …`.
 
-The agent-facing playbook for writing a scene is the `explanatory-animation` skill
-(`.claude/skills/explanatory-animation/`; routed from `skills/vlmkit/SKILL.md` like the
-markup workflows). It points at `docs/anim-ir.md` as the one page to read and says how to
-read `check`'s canvas and crossing lines, `--expect`, `why` and `import mermaid`'s dropped list.
+Two skills, routed from `skills/vlmkit/SKILL.md` like the markup workflows: `explain-with-anim`
+(`.claude/skills/explain-with-anim/`) is for answering a question — "how does this work", "how is
+this structured", "what does this PR change" — with a figure drawn from the code (`facts` / `repo` /
+`pr`), checked, and a narration that walks `explain`'s beats; `explanatory-animation`
+(`.claude/skills/explanatory-animation/`) is how a scene is written and checked. It points at
+`docs/anim-ir.md` as the one page to read and says how to read `check`'s canvas and crossing lines,
+`--expect`, `why` and `import mermaid`'s dropped list.
 
 The IR is judged on two things, measured by fresh subagents rather than by
 reading the code: **an agent gets it right from `docs/anim-ir.md` alone**, and

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,6 +1,6 @@
 # vlmkit agent skills
 
-vlmkit ships one automatic router backed by 14 specialized workflows.
+vlmkit ships one automatic router backed by 15 specialized workflows.
 Install once, then describe the outcome you want in ordinary language. The
 agent picks the workflow whose inputs and done condition match the task.
 
@@ -62,7 +62,7 @@ which skill the user wants.
 | Test generation | A natural-language story must become a reproducible browser test | [`spec-to-playwright`](./spec-to-playwright/) | Explore the app, generate Playwright tests, stabilize VRT, run CI gates, and heal drift |
 | Comparison and monitoring | Two renders or repeated runs must be compared | [`vrt-markup-synth`](./vrt-markup-synth/), [`vrt-visual-diff`](./vrt-visual-diff/), [`vrt-regression-watch`](./vrt-regression-watch/), [`vrt-migration-eval`](./vrt-migration-eval/) | Produce deterministic authoring signals, explain visual deltas, detect regressions over time, and evaluate framework/CSS migrations |
 | Evaluation and hardening | You are measuring the repair system or the agent-facing tool itself | [`vrt-css-fix-loop`](./vrt-css-fix-loop/), [`agent-validation-loop`](./agent-validation-loop/) | Benchmark VLM+LLM CSS recovery on known fixtures and improve tool ergonomics with fresh-agent validation loops |
-| Explanation and figures | Something has to be explained or drawn, not verified: an algorithm step by step, a protocol, a module or architecture map, a diagram the docs already carry as mermaid | [`explanatory-animation`](./explanatory-animation/) | Write one JSON scene (`kind` + intent, no coordinates) with `vlmkit-anim`; check it against its facts and its own layout; emit a `<vlm-anim>` page, a GIF, or a cropped still; import mermaid; draw a repository or a branch's change |
+| Explanation and figures | Something has to be explained or drawn, not verified: an algorithm step by step, a protocol, a module or architecture map, a diagram the docs already carry as mermaid | [`explain-with-anim`](./explain-with-anim/), [`explanatory-animation`](./explanatory-animation/) | Answer a "how does this work / what does this change" question with a figure drawn from the code and a narration that walks it (`explain-with-anim`); write one JSON scene (`kind` + intent, no coordinates) with `vlmkit-anim`, check it against its facts and its own layout, emit a `<vlm-anim>` page, a GIF, or a cropped still, import mermaid, draw a repository or a branch's change (`explanatory-animation`) |
 
 ## Selection rules
 
@@ -78,4 +78,5 @@ which skill the user wants.
 - Component, token, theme, or i18n authoring signal → `vrt-markup-synth`.
 - Known CSS deletion benchmark → `vrt-css-fix-loop`.
 - Agent-facing CLI or harness usability study → `agent-validation-loop`.
-- Animate or illustrate how something works, draw a module / dependency / architecture map, turn a mermaid diagram into a checked figure → `explanatory-animation`.
+- "Explain / walk me through / show me the structure of / what does this PR change" — an answer that needs a picture → `explain-with-anim` (decides what to draw from the code, explains beat by beat).
+- Animate or illustrate how something works, draw a module / dependency / architecture map, turn a mermaid diagram into a checked figure → `explanatory-animation` (how a scene is written and checked).

--- a/.claude/skills/explain-with-anim/SKILL.md
+++ b/.claude/skills/explain-with-anim/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: explain-with-anim
+description: Answer "how does this work / how is this structured / what does this change" with a drawn figure and a narration that follows it — a module map from the code's own imports, a walked request, a state machine, an algorithm step by step, the change map of a branch — produced with `vlmkit-anim`, checked against the facts it draws, and delivered as an SVG / GIF next to the prose. Use whenever the user asks to explain, walk through, show the structure of, or illustrate code, a repository, a flow, a protocol, a PR, or a bug, and a picture with four or more things and their relations would carry the answer better than a paragraph. The explanation is the deliverable; the picture is its evidence. Scene mechanics are in `explanatory-animation`.
+metadata:
+  internal: true
+---
+
+# explain-with-anim
+
+The user asked a question. Answer it with a picture and the words that walk
+the picture — not a picture instead of an answer, and not a paragraph with
+a decorative diagram after it. The figure is drawn from the code (or the
+facts) by `vlmkit-anim`, checked, and delivered as a file; the prose follows
+the figure beat by beat and names the things in it by their ids.
+
+Read `explanatory-animation` for how to write and check a scene. This skill
+is about **what to draw, from what, and how to explain with it**.
+
+## First: does a picture help?
+
+Draw when the answer has **things and relations** — four or more modules,
+states, participants, steps — or an **order in time**, or a **before and
+after**. Do not draw for a one-line answer, a single function's body, or a
+question about a value. If in doubt, write the answer first; if it needs a
+list of more than four named things that point at each other, draw them.
+
+## Choose the picture from the question
+
+| The user asks… | Draw | From |
+|---|---|---|
+| "How is this repo / package / directory structured?" | `kind: modules` — a module map, containers per area | `vlmkit-anim facts <dir> --depth 1 --out f.expect.json` (the import graph), then the map, then `check --expect f.expect.json`; for the whole workspace `vlmkit-anim repo --out <dir>` draws it and writes its own sheet |
+| "How does a request / event / message flow through it?" | `modules` with a `sequence` that walks the path (`highlight`, `flow`), or `kind: sequence` when the participants and their calls are the point | the code path you read; the map from `facts`; each hop a beat with a caption saying why |
+| "How does this algorithm / data structure work?" | the kind that owns it: `sort`, `array`, `tree`, `heap`, `stack`, `queue`, `list`, `matrix`, `graph` | the function's own steps; small concrete values (five to eight) so every beat is readable |
+| "What states can this be in? What happens on X?" | `kind: state-machine` with a `trace` of the events that matter | the enum / reducer / status field and its transitions |
+| "How do these services talk? What if one is slow / lost?" | `kind: distributed` (nodes, messages, a lost one) or `kind: sequence` (frames for retry / alt) | the protocol as implemented; the failure the user asked about as the trace |
+| "Why does it go this way here?" (a decision) | `kind: flowchart` with the walked path | the branch conditions, as their labels |
+| "What does this branch / PR change?" | `vlmkit-anim pr --base origin/main --out .vlmkit-anim/pr` — one beat per commit; or `vlmkit-anim diff before.json after.json` for two maps | git; `<name>.md` is paste-ready |
+| "What is the schedule / what slipped?" | `kind: gantt` | the plan, the slips as `slip` ops |
+| "The docs already have a mermaid diagram" | `vlmkit-anim import mermaid page.md --out scene.json`, then finish it | the diagram; read its `dropped / changed:` list |
+
+One picture per question. Two aspects that both matter (structure and a
+walk) are one `modules` scene with a `sequence`, or `kind: compose` — not
+two files.
+
+## Ground it in the source, not in memory
+
+- A map of code is drawn from the code: `facts` for a directory, `repo` for
+  the workspace, the import list or `package.json` files by hand when
+  neither fits. Then `check --expect`. A map drawn from memory and not
+  checked is a guess with a border round it.
+- A walk is drawn from the path you read: cite the file and function each
+  beat corresponds to in the caption or in the prose ("`handle()` in
+  `router.ts` → `dispatch`").
+- Anything you could not verify goes in the prose as "not drawn: …", never
+  in the picture.
+
+## Produce
+
+```
+1. write <name>.scene.json            in the repo's docs/ or .vlmkit-anim/, or the scratch dir if it is not to be kept
+2. vlmkit-anim check <name>.scene.json [--expect <name>.expect.json]
+3. vlmkit-anim layout <name>.scene.json               must report no issue; `why` when the canvas warning names a pair
+4. vlmkit-anim still <name>.scene.json --out <name>.svg      a still (structure, a map, a state diagram)
+   vlmkit-anim video <name>.scene.json --out <name>.gif --width 640   a walk (a request, an algorithm, a trace)
+5. vlmkit-anim explain <name>.scene.json              the beats — this is the skeleton of your prose
+```
+
+Five rounds of edit → `check` at most. If it is not clean by then, deliver
+the explanation in words, say the figure did not converge and which line
+stopped it, and keep the scene file for the reader.
+
+## Write the explanation
+
+1. **One sentence of what the picture is** and what it was drawn from
+   ("the packages under `packages/`, from their imports, 12 modules, 19
+   dependencies").
+2. **The beats, in order**, one short paragraph or bullet each, reworded
+   from `explain` — say *why* at each step, not what moved. Name things by
+   the ids in the picture so the reader can find them.
+3. **What the picture leaves out** and where to read it (a file, a
+   function, a config).
+4. **The files**: the SVG / GIF path, the scene, the fact sheet.
+
+Do not describe the picture's geometry ("on the left", "the blue box") —
+layout is the compiler's and may move on the next edit. Say the id.
+
+## Deliver
+
+- In a chat: the prose, then the figure as a file the user can open
+  (`SendUserFile` when available; otherwise the path). A GIF for a walk,
+  an SVG for a structure.
+- In a PR or issue: paste the `<name>.md` that `pr` / `repo` write, or the
+  figure with the beats under it. `vlmkit-anim pr` already runs on every
+  same-repo PR through the `pr-visual` workflow; do not post a second one.
+- In docs: a ```` ```vlm-anim ```` fence (the animation) or ```` ```vlm-anim still ````
+  (the figure) with the scene inline, so the page stays checkable; or the
+  SVG committed next to the page.
+
+## Done condition
+
+- `check` green (and `--expect` green when a sheet exists), `layout` clean.
+- Every id named in the prose is in the picture, and every beat in the
+  prose is a step in `explain`.
+- The user can answer their own question from the figure alone; the prose
+  says why each step is there.
+
+## Anti-patterns
+
+- **A figure after the answer, unreferenced.** If the prose never names an
+  id from the picture, the picture is decoration; drop it or rewrite.
+- **Drawing what you believe the structure is.** Run `facts` first. Two of
+  five green module maps in one evaluation round were wrong about a real
+  dependency.
+- **Coordinates.** A scene with x / y is a drawing, not an explanation, and
+  cannot be re-edited by the next reader. Use the kind that owns the things.
+- **Twelve beats where four would do.** Pick the values and the trace that
+  show the one mechanism the question is about.
+- **Skipping `layout` because `check` was green.** Lines through labels are
+  what a reader sees first.

--- a/.claude/skills/explanatory-animation/SKILL.md
+++ b/.claude/skills/explanatory-animation/SKILL.md
@@ -21,6 +21,11 @@ Two layers: a **Scene** (`kind` + intent — `"algorithm": "bubble"`,
 compiles to a **Timeline** (nodes, keyframe tracks, captioned steps). Write
 the scene; read the timeline only through the verbs below.
 
+When the task is to *answer a question* with a figure — "how does this
+work", "how is this structured", "what does this PR change" — `explain-with-anim`
+decides what to draw, from what, and how the prose follows it; this skill is
+how the scene itself is written and checked.
+
 **The one page to read before writing is `docs/anim-ir.md`** (in this repo)
 — every kind, its ops, the annotation ops every kind shares, and one JSON
 example per kind that `check` passes. `vlmkit-anim schema --kind <k>` prints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ Dates are YYYY-MM-DD.
   `agent-validation-loop` gains the anim-ir run (24 rounds, 86 attempts) as a second reference: the docs as
   the only input, a fact sheet as the success criterion, two unlike measurements compared, "what told you"
   per round, two model sizes per brief, a corpus check on every compiler change.
+- **Skill `explain-with-anim`** (the fifteenth workflow): answering a question — "how does this work", "how is
+  this structured", "what does this PR change" — with a figure and a narration that walks it. Decides whether a
+  picture helps (four or more things and their relations, an order, a before / after), chooses the picture from
+  the question (a module map from `facts`, a walked request, a state machine, an algorithm's kind, `pr` / `diff`
+  for a branch), grounds it in the code rather than memory, checks it (`check --expect`, `layout`), and writes
+  the prose from `explain`'s beats naming ids, never geometry. `explanatory-animation` stays the scene-writing
+  reference and points at it.
 
 ## 0.22.0 — 2026-09-09
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ the snapshot, workflow, and diff-pr sections.
 
 ## Agent Skills (APM)
 
-vlmkit ships fourteen coding-agent skills under `.claude/skills/`. They wrap
+vlmkit ships fifteen coding-agent skills under `.claude/skills/`. They wrap
 the most common workflows as standalone, agent-readable playbooks.
 Other repos can install them via [APM](https://agentskills.io):
 
@@ -168,6 +168,7 @@ apm install mizchi/vlmkit/.claude/skills/vrt-visual-diff
 | `markup-decompose` | routes `contract introspect` → `auto-markup` → `check story` | Whole screen: decide the component split, then freeze each part as a baseline |
 | `component-vrt` | `vlmkit check story --gallery <url>` | Repair one component with a component-sized diff; includes gallery templates (vanilla / React / Vue) |
 | `agent-validation-loop` | disposable subagent runs → friction → fix → re-run | Harden a CLI/library by measuring whether agents can drive it |
+| `explain-with-anim` | question → picture (`facts` / `repo` / `pr` / a kind) → `check --expect` → `still` / `video` → prose that walks `explain`'s beats | Answer "how does this work / how is it structured / what does this change" with a checked figure and a narration |
 | `explanatory-animation` | `vlmkit-anim check\|layout\|why\|still\|html\|video`, `import mermaid`, `facts`, `diff`, `repo`, `pr` | Explain an algorithm, protocol or architecture as a checked animation or still figure; draw a module map held to its facts (separate binary `@mizchi/vlmkit-anim`) |
 
 Each skill assumes the `vlmkit` CLI is on `$PATH` (this repo published as

--- a/examples/vlmkit-intro-page/content.js
+++ b/examples/vlmkit-intro-page/content.js
@@ -124,7 +124,7 @@ export const messages = Object.freeze({
     "skills.line2": "あとは自然に頼むだけ。",
     "skills.lead":
       "vlmkit をひとつ追加すれば、スキル名を覚える必要はありません。作りたい結果を伝えると、AI が依頼と素材を分類し、必要なワークフローを読み込んで、検証が通るまで実行します。",
-    "skills.note": "1 インストール · 自動ルーティング · 14 ワークフロー",
+    "skills.note": "1 インストール · 自動ルーティング · 15 ワークフロー",
     "skills.metaLabel": "メタエントリー",
     "skills.metaDescription":
       "フロントエンドの依頼で自動的に起動し、専門ワークフローを選択。利用者にスキル選択を求めず、CLI と Chromium も必要になった時だけ準備します。",
@@ -150,7 +150,7 @@ export const messages = Object.freeze({
     "skills.explainTitle": "説明と図",
     "skills.explainDescription":
       "アルゴリズムやプロトコルの動きをアニメーションにし、モジュール構成やアーキテクチャの図を描き、その絵を事実とレイアウトで検証。",
-    "skills.catalogLink": "14スキルの詳しい選択ガイドを見る",
+    "skills.catalogLink": "15スキルの詳しい選択ガイドを見る",
     "skills.apmLabel": "APM でインストール",
     "skills.apmDescription":
       "公式 bootstrap で APM を導入または更新してから、自動ルーターをプロジェクトへひとつ追加します。",
@@ -289,7 +289,7 @@ export const messages = Object.freeze({
     "skills.line2": "Ask naturally.",
     "skills.lead":
       "Add vlmkit once—there are no skill names to learn. Describe the outcome, and the AI classifies the request and artifacts, loads the right workflow, and runs it until the checks pass.",
-    "skills.note": "1 install · automatic routing · 14 workflows",
+    "skills.note": "1 install · automatic routing · 15 workflows",
     "skills.metaLabel": "Meta entry",
     "skills.metaDescription":
       "Activates automatically for frontend work and selects the matching workflow. It never asks you to pick a skill, and prepares the CLI and Chromium only when needed.",
@@ -315,7 +315,7 @@ export const messages = Object.freeze({
     "skills.explainTitle": "Explanation and figures",
     "skills.explainDescription":
       "Animate how an algorithm or protocol works, draw a module or architecture map, and hold the picture to its facts and layout.",
-    "skills.catalogLink": "Open the detailed guide to all 14 skills",
+    "skills.catalogLink": "Open the detailed guide to all 15 skills",
     "skills.apmLabel": "Install with APM",
     "skills.apmDescription":
       "Install or update APM with its official bootstrap, then add the single automatic router.",

--- a/examples/vlmkit-intro-page/copy.txt
+++ b/examples/vlmkit-intro-page/copy.txt
@@ -76,6 +76,7 @@ Evaluation and hardening
 vrt-css-fix-loop
 agent-validation-loop
 Explanation and figures
+explain-with-anim
 explanatory-animation
 Install with APM
 curl -sSL https://aka.ms/apm-unix | sh

--- a/examples/vlmkit-intro-page/index.html
+++ b/examples/vlmkit-intro-page/index.html
@@ -385,7 +385,7 @@
               <span data-i18n="skills.line2">Ask naturally.</span>
             </h2>
             <p data-i18n="skills.lead">Add vlmkit once—there are no skill names to learn. Describe the outcome, and the AI classifies the request and artifacts, loads the right workflow, and runs it until the checks pass.</p>
-            <p class="skills-note"><span>ROUTER</span> <span data-i18n="skills.note">1 install · automatic routing · 14 workflows</span></p>
+            <p class="skills-note"><span>ROUTER</span> <span data-i18n="skills.note">1 install · automatic routing · 15 workflows</span></p>
           </div>
 
           <div class="skills-directory">
@@ -451,11 +451,11 @@
                     <h3 data-i18n="skills.explainTitle">Explanation and figures</h3>
                     <p data-i18n="skills.explainDescription">Animate how an algorithm or protocol works, draw a module or architecture map, and hold the picture to its facts and layout.</p>
                   </div>
-                  <p class="skill-names"><code>explanatory-animation</code></p>
+                  <p class="skill-names"><code>explain-with-anim</code><code>explanatory-animation</code></p>
                 </article>
               </div>
 
-              <a class="skill-catalog-link" href="https://github.com/mizchi/vlmkit/tree/main/.claude/skills"><span data-i18n="skills.catalogLink">Open the detailed guide to all 14 skills</span> <span aria-hidden="true">↗</span></a>
+              <a class="skill-catalog-link" href="https://github.com/mizchi/vlmkit/tree/main/.claude/skills"><span data-i18n="skills.catalogLink">Open the detailed guide to all 15 skills</span> <span aria-hidden="true">↗</span></a>
             </div>
 
             <div class="skill-installers" data-testid="skill-installers">

--- a/examples/vlmkit-intro-page/page.test.mjs
+++ b/examples/vlmkit-intro-page/page.test.mjs
@@ -15,6 +15,7 @@ const specializedSkills = [
   "auto-markup",
   "component-vrt",
   "dynamic-markup",
+  "explain-with-anim",
   "explanatory-animation",
   "markup-assist",
   "markup-decompose",

--- a/skills/vlmkit/SKILL.md
+++ b/skills/vlmkit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vlmkit
-description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression — and whenever they ask to animate, illustrate or diagram how something works, or to draw a module, dependency or architecture map. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
+description: 'Automatic frontend quality router. Use automatically whenever the user asks to create, edit, debug, validate, test, compare, migrate, or repair a frontend UI, HTML/CSS, screenshot implementation, responsive or interactive behavior, Playwright/VRT, or a visual regression — and whenever they ask to explain, walk through, animate, illustrate or diagram how something works, or to draw a module, dependency or architecture map. The user does not need to mention vlmkit or choose a sub-skill. Classify the request, load the bundled workflow, run the smallest deterministic gates, fix failures, and rerun to green.'
 ---
 
 # vlmkit — Skill Router and CLI Guide
@@ -105,7 +105,8 @@ second only when the task genuinely crosses boundaries.
 | Evaluate a framework/CSS/build migration | `./workflows/vrt-migration-eval/SKILL.md` | Judge visual equivalence despite large intentional rewrites |
 | Benchmark known CSS repair challenges | `./workflows/vrt-css-fix-loop/SKILL.md` | Measure VLM+LLM recovery, not production healing |
 | Harden an agent-facing CLI, SDK, or harness | `./workflows/agent-validation-loop/SKILL.md` | Turn fresh-agent friction into fixes and tracked evidence |
-| Explain an algorithm, protocol or architecture as an animation or a still figure; draw a module / dependency map; import a mermaid diagram | `./workflows/explanatory-animation/SKILL.md` | Write one checked `vlmkit-anim` scene, hold it to its facts and layout, emit a page, GIF or cropped figure (separate binary: `@mizchi/vlmkit-anim`) |
+| Answer "how does this work / how is it structured / what does this change" with a figure drawn from the code and a narration that walks it | `./workflows/explain-with-anim/SKILL.md` | Choose the picture from the question, ground it in `facts` / `repo` / `pr`, check it, deliver SVG or GIF with beat-by-beat prose |
+| Write an animation or still figure as the deliverable: an algorithm, protocol or architecture; a module / dependency map; a mermaid import | `./workflows/explanatory-animation/SKILL.md` | Write one checked `vlmkit-anim` scene, hold it to its facts and layout, emit a page, GIF or cropped figure (separate binary: `@mizchi/vlmkit-anim`) |
 
 The human-facing catalog, direct install commands, and category rationale are
 in the [vlmkit skill catalog](https://github.com/mizchi/vlmkit/tree/main/.claude/skills).

--- a/skills/vlmkit/workflows/explain-with-anim/SKILL.md
+++ b/skills/vlmkit/workflows/explain-with-anim/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: explain-with-anim
+description: Answer "how does this work / how is this structured / what does this change" with a drawn figure and a narration that follows it — a module map from the code's own imports, a walked request, a state machine, an algorithm step by step, the change map of a branch — produced with `vlmkit-anim`, checked against the facts it draws, and delivered as an SVG / GIF next to the prose. Use whenever the user asks to explain, walk through, show the structure of, or illustrate code, a repository, a flow, a protocol, a PR, or a bug, and a picture with four or more things and their relations would carry the answer better than a paragraph. The explanation is the deliverable; the picture is its evidence. Scene mechanics are in `explanatory-animation`.
+metadata:
+  internal: true
+---
+
+# explain-with-anim
+
+The user asked a question. Answer it with a picture and the words that walk
+the picture — not a picture instead of an answer, and not a paragraph with
+a decorative diagram after it. The figure is drawn from the code (or the
+facts) by `vlmkit-anim`, checked, and delivered as a file; the prose follows
+the figure beat by beat and names the things in it by their ids.
+
+Read `explanatory-animation` for how to write and check a scene. This skill
+is about **what to draw, from what, and how to explain with it**.
+
+## First: does a picture help?
+
+Draw when the answer has **things and relations** — four or more modules,
+states, participants, steps — or an **order in time**, or a **before and
+after**. Do not draw for a one-line answer, a single function's body, or a
+question about a value. If in doubt, write the answer first; if it needs a
+list of more than four named things that point at each other, draw them.
+
+## Choose the picture from the question
+
+| The user asks… | Draw | From |
+|---|---|---|
+| "How is this repo / package / directory structured?" | `kind: modules` — a module map, containers per area | `vlmkit-anim facts <dir> --depth 1 --out f.expect.json` (the import graph), then the map, then `check --expect f.expect.json`; for the whole workspace `vlmkit-anim repo --out <dir>` draws it and writes its own sheet |
+| "How does a request / event / message flow through it?" | `modules` with a `sequence` that walks the path (`highlight`, `flow`), or `kind: sequence` when the participants and their calls are the point | the code path you read; the map from `facts`; each hop a beat with a caption saying why |
+| "How does this algorithm / data structure work?" | the kind that owns it: `sort`, `array`, `tree`, `heap`, `stack`, `queue`, `list`, `matrix`, `graph` | the function's own steps; small concrete values (five to eight) so every beat is readable |
+| "What states can this be in? What happens on X?" | `kind: state-machine` with a `trace` of the events that matter | the enum / reducer / status field and its transitions |
+| "How do these services talk? What if one is slow / lost?" | `kind: distributed` (nodes, messages, a lost one) or `kind: sequence` (frames for retry / alt) | the protocol as implemented; the failure the user asked about as the trace |
+| "Why does it go this way here?" (a decision) | `kind: flowchart` with the walked path | the branch conditions, as their labels |
+| "What does this branch / PR change?" | `vlmkit-anim pr --base origin/main --out .vlmkit-anim/pr` — one beat per commit; or `vlmkit-anim diff before.json after.json` for two maps | git; `<name>.md` is paste-ready |
+| "What is the schedule / what slipped?" | `kind: gantt` | the plan, the slips as `slip` ops |
+| "The docs already have a mermaid diagram" | `vlmkit-anim import mermaid page.md --out scene.json`, then finish it | the diagram; read its `dropped / changed:` list |
+
+One picture per question. Two aspects that both matter (structure and a
+walk) are one `modules` scene with a `sequence`, or `kind: compose` — not
+two files.
+
+## Ground it in the source, not in memory
+
+- A map of code is drawn from the code: `facts` for a directory, `repo` for
+  the workspace, the import list or `package.json` files by hand when
+  neither fits. Then `check --expect`. A map drawn from memory and not
+  checked is a guess with a border round it.
+- A walk is drawn from the path you read: cite the file and function each
+  beat corresponds to in the caption or in the prose ("`handle()` in
+  `router.ts` → `dispatch`").
+- Anything you could not verify goes in the prose as "not drawn: …", never
+  in the picture.
+
+## Produce
+
+```
+1. write <name>.scene.json            in the repo's docs/ or .vlmkit-anim/, or the scratch dir if it is not to be kept
+2. vlmkit-anim check <name>.scene.json [--expect <name>.expect.json]
+3. vlmkit-anim layout <name>.scene.json               must report no issue; `why` when the canvas warning names a pair
+4. vlmkit-anim still <name>.scene.json --out <name>.svg      a still (structure, a map, a state diagram)
+   vlmkit-anim video <name>.scene.json --out <name>.gif --width 640   a walk (a request, an algorithm, a trace)
+5. vlmkit-anim explain <name>.scene.json              the beats — this is the skeleton of your prose
+```
+
+Five rounds of edit → `check` at most. If it is not clean by then, deliver
+the explanation in words, say the figure did not converge and which line
+stopped it, and keep the scene file for the reader.
+
+## Write the explanation
+
+1. **One sentence of what the picture is** and what it was drawn from
+   ("the packages under `packages/`, from their imports, 12 modules, 19
+   dependencies").
+2. **The beats, in order**, one short paragraph or bullet each, reworded
+   from `explain` — say *why* at each step, not what moved. Name things by
+   the ids in the picture so the reader can find them.
+3. **What the picture leaves out** and where to read it (a file, a
+   function, a config).
+4. **The files**: the SVG / GIF path, the scene, the fact sheet.
+
+Do not describe the picture's geometry ("on the left", "the blue box") —
+layout is the compiler's and may move on the next edit. Say the id.
+
+## Deliver
+
+- In a chat: the prose, then the figure as a file the user can open
+  (`SendUserFile` when available; otherwise the path). A GIF for a walk,
+  an SVG for a structure.
+- In a PR or issue: paste the `<name>.md` that `pr` / `repo` write, or the
+  figure with the beats under it. `vlmkit-anim pr` already runs on every
+  same-repo PR through the `pr-visual` workflow; do not post a second one.
+- In docs: a ```` ```vlm-anim ```` fence (the animation) or ```` ```vlm-anim still ````
+  (the figure) with the scene inline, so the page stays checkable; or the
+  SVG committed next to the page.
+
+## Done condition
+
+- `check` green (and `--expect` green when a sheet exists), `layout` clean.
+- Every id named in the prose is in the picture, and every beat in the
+  prose is a step in `explain`.
+- The user can answer their own question from the figure alone; the prose
+  says why each step is there.
+
+## Anti-patterns
+
+- **A figure after the answer, unreferenced.** If the prose never names an
+  id from the picture, the picture is decoration; drop it or rewrite.
+- **Drawing what you believe the structure is.** Run `facts` first. Two of
+  five green module maps in one evaluation round were wrong about a real
+  dependency.
+- **Coordinates.** A scene with x / y is a drawing, not an explanation, and
+  cannot be re-edited by the next reader. Use the kind that owns the things.
+- **Twelve beats where four would do.** Pick the values and the trace that
+  show the one mechanism the question is about.
+- **Skipping `layout` because `check` was green.** Lines through labels are
+  what a reader sees first.

--- a/skills/vlmkit/workflows/explanatory-animation/SKILL.md
+++ b/skills/vlmkit/workflows/explanatory-animation/SKILL.md
@@ -21,6 +21,11 @@ Two layers: a **Scene** (`kind` + intent — `"algorithm": "bubble"`,
 compiles to a **Timeline** (nodes, keyframe tracks, captioned steps). Write
 the scene; read the timeline only through the verbs below.
 
+When the task is to *answer a question* with a figure — "how does this
+work", "how is this structured", "what does this PR change" — `explain-with-anim`
+decides what to draw, from what, and how the prose follows it; this skill is
+how the scene itself is written and checked.
+
 **The one page to read before writing is `docs/anim-ir.md`** (in this repo)
 — every kind, its ops, the annotation ops every kind shares, and one JSON
 example per kind that `check` passes. `vlmkit-anim schema --kind <k>` prints

--- a/tests/skill-package.test.mjs
+++ b/tests/skill-package.test.mjs
@@ -22,6 +22,7 @@ const workflows = [
   "auto-markup",
   "component-vrt",
   "dynamic-markup",
+  "explain-with-anim",
   "explanatory-animation",
   "markup-assist",
   "markup-decompose",


### PR DESCRIPTION
## Summary

The fifteenth workflow, `.claude/skills/explain-with-anim/SKILL.md`. `explanatory-animation` (#146) is how a scene is written and checked; this one is **what to draw, from what, and how the prose follows it** when the user asks "how does this work / how is it structured / what does this PR change".

- **Does a picture help at all** — four or more things and their relations, an order in time, a before / after; otherwise answer in words.
- **The picture from the question** — a module map from `vlmkit-anim facts` (then `check --expect`), a walked request (`modules` + `sequence`, or `kind: sequence`), an algorithm's own kind, a state machine with a trace, `distributed` for a lost message, `flowchart` for a decision, `pr` / `diff` for a branch, `repo` for the workspace, `import mermaid` when the docs already have one.
- **Grounded in the code, not memory** — `facts` first, `--expect` after; anything unverified goes in the prose as "not drawn", never in the picture.
- **Produce → explain → deliver** — `check`, `layout`, `still` or `video`, then prose built from `explain`'s beats that names ids and never geometry; five rounds, then the answer in words with the line that stopped the figure; delivery rules for chat, PR (the `pr-visual` workflow already posts one), and docs (```` ```vlm-anim ```` fence).
- Router row and description ("explain, walk through"), catalog class and selection rules, `explanatory-animation` cross-reference, intro page (both locales, counts 14 → 15, copy manifest), `docs/configuration.md`, `CLAUDE.md`, the two tests pinning the workflow list, bundled copies re-synced, CHANGELOG bullet under 0.23.0 (no version bump).

## Test plan

- [x] `pnpm sync:skills` → 15 workflows
- [x] `vitest run tests/skill-package.test.mjs examples/vlmkit-intro-page/page.test.mjs examples/vlmkit-intro-page/site-links.test.mjs tests/workflow-commands.test.mjs src/cli/version.test.ts` — 72 passed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpysLZjCrixyaunTWzmqHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpysLZjCrixyaunTWzmqHY)_